### PR TITLE
feat: add Lens resolver

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -2,7 +2,7 @@
   "max": 500,
   "ttl": 86400,
   "resolvers": {
-    "avatar": ["blockie", "ens", "snapshot", "selfid"],
+    "avatar": ["blockie", "ens", "snapshot", "selfid", "lens"],
     "token": ["blockie", "trustwallet"],
     "space": ["blockie", "space"]
   }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -4,6 +4,7 @@ import trustwallet from './trustwallet';
 import snapshot from './snapshot';
 import space from './space';
 import selfid from './selfid';
+import lens from './lens';
 
 export default {
   blockie,
@@ -11,5 +12,6 @@ export default {
   trustwallet,
   snapshot,
   space,
-  selfid
+  selfid,
+  lens
 };

--- a/src/resolvers/lens.ts
+++ b/src/resolvers/lens.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import { getAddress } from '@ethersproject/address';
+import { getUrl, resize } from '../utils';
+import { max } from '../constants.json';
+
+const API_URL = 'https://api.lens.dev';
+
+export default async function resolve(address) {
+  try {
+    const { data } = await axios({
+      url: `${API_URL}/graphql`,
+      method: 'post',
+      data: {
+        query: `
+            query DefaultProfile {
+              defaultProfile(request: { ethereumAddress: "${getAddress(address)}"}) {
+                picture {
+                  ... on NftImage {
+                    contractAddress
+                    tokenId
+                    uri
+                    chainId
+                    verified
+                  }
+                }
+              }
+            }
+          `
+      }
+    });
+
+    const { uri } = data.data.defaultProfile?.picture || {};
+    if (!uri) return false;
+
+    const url = getUrl(uri);
+    const input = (await axios({ url, responseType: 'arraybuffer' })).data as Buffer;
+    return await resize(input, max, max);
+  } catch (e) {
+    return false;
+  }
+}

--- a/test/unit/resolvers/lens.test.ts
+++ b/test/unit/resolvers/lens.test.ts
@@ -1,0 +1,18 @@
+import resolvers from '../../../src/resolvers';
+
+describe('resolvers', () => {
+  describe('lens', () => {
+    it('should return false if missing', async () => {
+      const result = await resolvers.lens('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
+
+      expect(result).toBe(false);
+    });
+
+    it('should resolve', async () => {
+      const result = await resolvers.lens('0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3');
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(1000);
+    });
+  });
+});

--- a/test/unit/resolvers/lens.test.ts
+++ b/test/unit/resolvers/lens.test.ts
@@ -15,8 +15,8 @@ describe('resolvers', () => {
       expect(result.length).toBeGreaterThan(1000);
     });
 
-    it('should resolve with address (default profile)', async () => {
-      const result = await resolvers.lens('0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3');
+    it('should resolve with address', async () => {
+      const result = await resolvers.lens('0xeF8305E140ac520225DAf050e2f71d5fBcC543e7');
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);

--- a/test/unit/resolvers/lens.test.ts
+++ b/test/unit/resolvers/lens.test.ts
@@ -8,7 +8,14 @@ describe('resolvers', () => {
       expect(result).toBe(false);
     });
 
-    it('should resolve', async () => {
+    it('should resolve with handle', async () => {
+      const result = await resolvers.lens('fabien.lens');
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(1000);
+    });
+
+    it('should resolve with address (default profile)', async () => {
       const result = await resolvers.lens('0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3');
 
       expect(result).toBeInstanceOf(Buffer);


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/stamp/issues/14

Adds [Lens.xyz](https://lens.xyz/) resolver. Couldn't test with my own account as it looks like it's not open yet for everyone.

## Test plan
- Disable `ens` resolver if you are testing with addresses that have the same image on `ens` as on `lens` so you can tell if it works or not.
- Try going to http://localhost:3000/avatar/fabien.lens
- It should return an image.
- Try going to http://localhost:3000/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7
- It should return an image.