### PR TITLE
fix: write resized images to correct location

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -73,7 +73,7 @@ router.get('/:type/:id', async (req, res) => {
       await set(`${key1}/${key1}`, file1);
       console.log('Stored base cache', key1);
     }
-    await set(`${key2}/${key1}`, file2);
+    await set(`${key1}/${key2}`, file2);
     console.log('Stored cache', address);
   } catch (e) {
     console.log('Store cache failed', address, e);

--- a/test/unit/resolvers/selfid.test.ts
+++ b/test/unit/resolvers/selfid.test.ts
@@ -19,6 +19,6 @@ describe('resolvers', () => {
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);
-    });
+    }, 30000);
   });
 });


### PR DESCRIPTION
We read it from `key1/key2` and we wrote it to `key2/key1`.