### PR TITLE
fix: lift cache on fallback images

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -63,7 +63,7 @@ router.get('/:type/:id', async (req, res) => {
       const fallbackImage = await resolvers[fallback](address, network);
       const resizedImage = await resize(fallbackImage, w, h);
 
-      setHeader(res, 'SHORT');
+      setHeader(res, 'SHORT_CACHE');
       return res.send(resizedImage);
     }
   }

--- a/src/constants.json
+++ b/src/constants.json
@@ -1,6 +1,7 @@
 {
   "max": 500,
   "ttl": 86400,
+  "shortTtl": 3600,
   "resolvers": {
     "avatar": ["selfid", "lens", "ens", "snapshot"],
     "token": ["trustwallet", "zapper"],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,8 +98,8 @@ export function getCacheKey({
   return sha256(JSON.stringify({ type, network, address, w, h, fallback }));
 }
 
-export function setHeader(res: Response, cacheType: 'SHORT' | 'LONG' = 'LONG') {
-  const ttl = cacheType === 'SHORT' ? constants.shortTtl : constants.ttl;
+export function setHeader(res: Response, cacheType: 'SHORT_CACHE' | 'LONG_CACHE' = 'LONG_CACHE') {
+  const ttl = cacheType === 'SHORT_CACHE' ? constants.shortTtl : constants.ttl;
 
   res.set({
     'Content-Type': 'image/webp',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import sharp from 'sharp';
+import { Response } from 'express';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import snapshot from '@snapshot-labs/snapshot.js';
 import constants from './constants.json';
@@ -97,10 +98,12 @@ export function getCacheKey({
   return sha256(JSON.stringify({ type, network, address, w, h, fallback }));
 }
 
-export function setHeader(res) {
+export function setHeader(res: Response, cacheType: 'SHORT' | 'LONG' = 'LONG') {
+  const ttl = cacheType === 'SHORT' ? constants.shortTtl : constants.ttl;
+
   res.set({
     'Content-Type': 'image/webp',
-    'Cache-Control': `public, max-age=${constants.ttl}`,
-    Expires: new Date(Date.now() + constants.ttl * 1e3).toUTCString()
+    'Cache-Control': `public, max-age=${ttl}`,
+    Expires: new Date(Date.now() + ttl * 1e3).toUTCString()
   });
 }

--- a/test/unit/resolvers/ens.test.ts
+++ b/test/unit/resolvers/ens.test.ts
@@ -13,6 +13,6 @@ describe('resolvers', () => {
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);
-    });
+    }, 30000);
   });
 });


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/stamp/issues/40

Currently we have couple of issues with how cache works:
- If fallback image is served it is still written to S3 so it will be stuck to fallback image forever (or as long as our S3 expiry policy is configured for) as cache takes priority. I don't think we should cache fallback images in S3 at all, instead just cache it at edge and just lower TTL for cache.
- Fallback gets TTL of 1 day which seems overly pessimistic, we can lower it to 1h, so if avatar is set (or some issue that caused it to fail to load no longer exists) it can update itself quicker.

## Test plan

- Setup local repo with AWS S3.
- Return false in space.ts
- Visit: http://localhost:3000/space/0xbattleground.eth?s=160 -> you get fallback image, Cache-Control is set to 3600
- Remove false in space.ts
- Visit that URL again -> you get proper image, Cache-Control is set to 86400