### PR TITLE
chore: update test coverage to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,3 +13,7 @@ jobs:
       - run: yarn
       - run: yarn lint
       - run: yarn test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Code coverage is not tracked by codecov

## 💊 Fixes / Solution

Upload the test coverage to codecov

## 🚧 Changes

- Add a new task in Github actions test workflow, to upload the coverage report after the test

## 🛠️ Tests

- N/A