### PR TITLE
chore: improve test config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Build and run lint
 on: [push]
 jobs:
   build-test:
@@ -10,8 +10,6 @@ jobs:
           node-version: '16'
           cache: 'yarn'
       - run: yarn
-      - run: yarn test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - run: yarn build
+      - run: yarn lint:nofix
+      - run: yarn typecheck

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Stamp
+# Stamp [![codecov](https://codecov.io/gh/snapshot-labs/stamp/branch/master/graph/badge.svg?token=N9IMKE41RA)](https://codecov.io/gh/snapshot-labs/stamp)
+
 Resolve and resize web3 avatar and token images.
 
 ### Usage
+
 Simply use a valid Stamp URL to display an avatar:
 
 https://cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7
@@ -11,29 +13,36 @@ https://cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7
 ```
 
 ### URL structure
+
 cdn.stamp.fyi/**{type}**/**{identifier}**?**{params}**  
 cdn.stamp.fyi/**avatar**/**0xeF8305E140ac520225DAf050e2f71d5fBcC543e7**?**s=140**
 
 ### Type
+
 The type is either avatar or token.
 
 #### Examples
+
 cdn.stamp.fyi/**avatar**/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7  
 cdn.stamp.fyi/**token**/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e
 
 ### Identifier
+
 The identifier can be an address (case insensitive), ENS name, CAIP-10, EIP-3770 or DID.
 
 #### Examples
+
 cdn.stamp.fyi/avatar/**0xeF8305E140ac520225DAf050e2f71d5fBcC543e7**  
 cdn.stamp.fyi/avatar/**fabien.eth**  
 cdn.stamp.fyi/token/**eth:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**  
 cdn.stamp.fyi/token/**eip155:1:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**
 
 ### Params
+
 With the params you can define the size of the image returned. You can also refresh the image cache using **cb** param.
 
 #### Examples
+
 cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?**s=160**
 cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?**w=160&h=240**
 cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?**cb=1**
@@ -41,21 +50,33 @@ cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?**cb=1**
 ### Resolvers
 
 #### [ENS avatar](/src/resolvers/ens.ts)
+
 #### [Lens](/src/resolvers/lens.ts)
+
 #### [Self.ID](/src/resolvers/selfid.ts)
+
 #### [Snapshot](/src/resolvers/snapshot.ts)
+
 #### [TrustWallet Assets Info](/src/resolvers/trustwallet.ts)
+
 #### [Blockie](/src/resolvers/blockie.ts)
+
 #### [Jazzicon](/src/resolvers/jazzicon.ts)
 
 ### Integrations
 
 #### [Snapshot](http://snapshot.org)
+
 #### [Parcel](https://parcel.money)
+
 #### [Lenster](https://lenster.xyz)
+
 #### [RSS3](https://rss3.io)
+
 #### [Cirip](https://cirip.io)
+
 #### [Lenstube](https://lenstube.xyz)
+
 #### [You?](https://github.com/snapshot-labs/stamp/edit/master/README.md)
 
 ### License

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,11 +8,12 @@ export default {
   collectCoverage: true,
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
+  collectCoverageFrom: ['./src/**'],
   coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/dist/', '<rootDir>/test/fixtures/'],
 
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFiles: ['dotenv/config'],
   testPathIgnorePatterns: ['/node_modules/', '<rootDir>/dist/', '<rootDir>/test/fixtures/'],
-  moduleFileExtensions: ['js', 'ts']
+  moduleFileExtensions: ['js', 'ts'],
 };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,5 +15,5 @@ export default {
   testEnvironment: 'node',
   setupFiles: ['dotenv/config'],
   testPathIgnorePatterns: ['/node_modules/', '<rootDir>/dist/', '<rootDir>/test/fixtures/'],
-  moduleFileExtensions: ['js', 'ts'],
+  moduleFileExtensions: ['js', 'ts']
 };

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint . --ext .ts --fix",
+    "lint": "yarn lint:nofix --fix",
+    "lint:nofix": "eslint . --ext .ts",
     "build": "tsc",
     "dev": "nodemon src/index.ts",
     "start": "node dist/src/index.js",
-    "test": "yarn jest"
+    "test": "yarn jest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.352.0",

--- a/test/e2e/api.test.ts
+++ b/test/e2e/api.test.ts
@@ -1,0 +1,20 @@
+describe('E2E api', () => {
+  it.todo('returns a 500 status on invalid query');
+
+  describe('when the image is not cached', () => {
+    it.todo('returns the image');
+    it.todo('caches the base image');
+    it.todo('caches the resized image');
+  });
+
+  describe('when the base image is cached, but not the requested size', () => {
+    it.todo('resize the image from the cached base image');
+    it.todo('caches the resized image');
+  });
+
+  describe('when the resized image is cached', () => {
+    it.todo('returns the cached resize image');
+  });
+
+  it.todo('clears the cache');
+});


### PR DESCRIPTION
This PR improve the test config:

- Collect coverage from all files, instead of only tested files
- Add test coverage badge to readme
- Separate lint and test task on github actions