### PR TITLE
fix: return false when ENS avatar is not an URL

### DIFF
--- a/src/resolvers/ens.ts
+++ b/src/resolvers/ens.ts
@@ -11,7 +11,7 @@ export default async function resolve(name: string) {
     }
 
     const url = await ensResolver.getText('avatar');
-    if (!url) {
+    if (!url || !url.startsWith('http')) {
       return false;
     }
 


### PR DESCRIPTION
The current ENS resolver is returning the raw value from ENS, and it's working great when the value is an http url.

But when it's an NFT address, such as `eip155:1/erc1155:0x495f947276749Ce646f68AC8c248420045cb7b5e/61751686310106735452369515624497384717106902022558848289817630643456812515329` we should return `false`, and not continue with trying to fetch the image.

See https://github.com/snapshot-labs/stamp/issues/76