### PR TITLE
chore: rename lenstube to tape

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?**cb=1**
 
 #### [Cirip](https://cirip.io)
 
-#### [Lenstube](https://lenstube.xyz)
+#### [Tape](https://tape.xyz)
 
 #### [You?](https://github.com/snapshot-labs/stamp/edit/master/README.md)
 


### PR DESCRIPTION
We just rebranded lenstube.xyz to tape.xyz 📼

https://twitter.com/tapexyz/status/1710259320418615518

cc @bonustrack 