### PR TITLE
fix: fix missing `cb` query params when clearing cache

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -13,7 +13,8 @@ router.get(`/clear/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
   try {
     const { address, network, w, h, fallback } = await parseQuery(id, type, {
       s: constants.max,
-      fb: req.query.fb
+      fb: req.query.fb,
+      cb: req.query.cb
     });
     const key = getCacheKey({ type, network, address, w, h, fallback });
     await clear(key);


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When clearing the cache, the `cb` query params is ignored

## 💊 Fixes / Solution

- Add the `cb` query params when computing the cache key

## 🛠️ Tests

