### PR TITLE
fix: Clear cache doesn't work with `cb` param

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -29,14 +29,14 @@ router.post('/', async (req, res) => {
 router.get(`/clear/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
   const { type, id } = req.params;
   try {
-    const { address, network, w, h, fallback } = await parseQuery(id, type, {
+    const { address, network, w, h, fallback, cb } = await parseQuery(id, type, {
       s: constants.max,
       fb: req.query.fb,
       cb: req.query.cb
     });
-    const key = getCacheKey({ type, network, address, w, h, fallback });
-    await clear(key);
-    res.status(200).json({ status: 'ok' });
+    const key = getCacheKey({ type, network, address, w, h, fallback, cb });
+    const result = await clear(key);
+    res.status(result ? 200 : 404).json({ status: result ? 'ok' : 'not found' });
   } catch (e) {
     capture(e);
     res.status(500).json({ status: 'error', error: 'failed to clear cache' });

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -39,7 +39,7 @@ export async function clear(path) {
       Bucket: bucket,
       Prefix: `public/${dir}/${path}`
     });
-    if (!listedObjects.Contents || listedObjects.Contents.length === 0) return;
+    if (!listedObjects.Contents || listedObjects.Contents.length === 0) return false;
     const objs = listedObjects.Contents.map(obj => ({ Key: obj.Key }));
     await client.deleteObjects({
       Bucket: bucket,
@@ -47,7 +47,7 @@ export async function clear(path) {
     });
     if (listedObjects.IsTruncated) await clear(path);
     console.log('Cleared cache', path);
-    return;
+    return path;
   } catch (e) {
     console.log('Clear cache failed', e);
     throw e;


### PR DESCRIPTION
## Issues
- Not able to clear cache for images with `cb` param, for example https://cdn.stamp.fyi/space/wen%F0%9F%8C%95.eth?s=96&cb=c178562f8f12066b
- If there is nothing to clear, It returns `ok` in response 


How to test:
- Try going to http://localhost:3008/space/thanku.eth?s=160&cb=ce8ed162479340899ca4cae882bd0a0e
- Clear cache by going to http://localhost:3008/clear/space/thanku.eth?s=160&cb=ce8ed162479340899ca4cae882bd0a0e