### PR TITLE
chore: send input to error logging

### DIFF
--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -34,7 +34,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
         .filter((_, index) => !!validNames[index])
     );
   } catch (e) {
-    capture(e);
+    capture(e, { addresses });
     return {};
   }
 }

--- a/src/addressResolvers/lens.ts
+++ b/src/addressResolvers/lens.ts
@@ -31,7 +31,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
     return Object.fromEntries(items.map(i => [i.ownedBy, i.handle])) || {};
   } catch (e) {
-    capture(e);
+    capture(e, { addresses });
     return {};
   }
 }

--- a/src/addressResolvers/unstoppableDomains.ts
+++ b/src/addressResolvers/unstoppableDomains.ts
@@ -17,7 +17,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
     return Object.fromEntries(Object.entries(names).filter(([, name]) => !!name));
   } catch (e) {
-    capture(e);
+    capture(e, { addresses });
     return {};
   }
 }


### PR DESCRIPTION
There's an unusual high number of errors, since the introduction of addressResolver.

https://snapshot-labs.sentry.io/issues/4651451195/?project=4505506866593792&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0

All errors are coming from Lens, returning a 400 error. 

This PR log the addresses input, so we have a little insight of why the addresses we're sending to Lens api are errored