### PR TITLE
fix: ignore invalid addresses

### DIFF
--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -34,7 +34,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
         .filter((_, index) => !!validNames[index])
     );
   } catch (e) {
-    capture(e);
+    capture(e, { addresses });
     return {};
   }
 }

--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -1,8 +1,7 @@
-import { getAddress } from '@ethersproject/address';
 import * as ensResolver from './ens';
 import * as lensResolver from './lens';
 import * as unstoppableDomainResolver from './unstoppableDomains';
-import { Address } from './utils';
+import { Address, normalizeAddresses } from './utils';
 import cache from './cache';
 
 const RESOLVERS = [ensResolver, unstoppableDomainResolver, lensResolver];
@@ -16,16 +15,9 @@ export async function lookupAddresses(addresses: Address[]) {
     });
   }
 
-  let normalizedAddresses: Address[];
-  try {
-    normalizedAddresses = addresses.map(getAddress);
-  } catch (e) {
-    return Promise.reject({ error: 'params contains invalid address', code: 400 });
-  }
-
   return Object.fromEntries(
     Object.entries(
-      await cache(normalizedAddresses, async (addresses: Address[]) => {
+      await cache(normalizeAddresses(addresses), async (addresses: Address[]) => {
         const results = await Promise.all(RESOLVERS.map(r => r.lookupAddresses(addresses)));
 
         return Object.fromEntries(

--- a/src/addressResolvers/lens.ts
+++ b/src/addressResolvers/lens.ts
@@ -31,7 +31,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
     return Object.fromEntries(items.map(i => [i.ownedBy, i.handle])) || {};
   } catch (e) {
-    capture(e);
+    capture(e, { addresses });
     return {};
   }
 }

--- a/src/addressResolvers/unstoppableDomains.ts
+++ b/src/addressResolvers/unstoppableDomains.ts
@@ -17,7 +17,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
     return Object.fromEntries(Object.entries(names).filter(([, name]) => !!name));
   } catch (e) {
-    capture(e);
+    capture(e, { addresses });
     return {};
   }
 }

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -1,4 +1,5 @@
 import snapshot from '@snapshot-labs/snapshot.js';
+import { getAddress } from '@ethersproject/address';
 
 export type Address = string;
 export type Handle = string;
@@ -7,4 +8,14 @@ const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.brovider.xyz';
 
 export function provider(network: string) {
   return snapshot.utils.getProvider(network, { broviderUrl });
+}
+
+export function normalizeAddresses(addresses: Address[]): Address[] {
+  return addresses
+    .map(a => {
+      try {
+        return getAddress(a);
+      } catch (e) {}
+    })
+    .filter(a => a) as Address[];
 }

--- a/test/unit/addressResolvers/index.test.ts
+++ b/test/unit/addressResolvers/index.test.ts
@@ -21,11 +21,10 @@ describe('addressResolvers', () => {
     });
 
     describe('when the params contains invalid address', () => {
-      it('rejects with an error', () => {
-        expect(lookupAddresses(['test'])).rejects.toEqual({
-          error: 'params contains invalid address',
-          code: 400
-        });
+      it('should ignore the invalid address', () => {
+        expect(
+          lookupAddresses(['test', '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7'])
+        ).resolves.toEqual({ '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'fabien.eth' });
       });
     });
 


### PR DESCRIPTION
There's a high error rate since introduction of addressResolvers (https://snapshot-labs.sentry.io/issues/4651451195/?project=4505506866593792&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0)

Most of the errors come from invalid addresses given as params.

This PR will:
- ignore all invalid addresses, and process only valid one, instead of crashing and returning a 400 error for the whole request.
- log the addresses input given to the request, to debug why is there invalid addresses
