### PR TITLE
fix: skip resolver call when all addresses are already cached

### DIFF
--- a/src/addressResolvers/cache.ts
+++ b/src/addressResolvers/cache.ts
@@ -34,9 +34,14 @@ export function setCache(payload: Record<Address, Handle>) {
 export default async function cache(addresses: Address[], callback) {
   const cache = await getCache(addresses);
   const cachedAddresses = Object.keys(cache);
+  const uncachedAddresses = addresses.filter(a => !cachedAddresses.includes(a));
 
-  const results = await callback(addresses.filter(a => !cachedAddresses.includes(a)));
-  setCache(results);
+  if (uncachedAddresses.length > 0) {
+    const results = await callback(uncachedAddresses);
+    setCache(results);
 
-  return { ...cache, ...results };
+    return { ...cache, ...results };
+  }
+
+  return cache;
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When all keys are already cached, the args passed to the callback function is an empty array

## 💊 Fixes / Solution

Fix #122 
Fix [STAMP-9](https://snapshot-labs.sentry.io/issues/4654544992/?referrer=github_integration)

We should skip calling the callback function when all keys are already cached