### PR TITLE
chore: object sent to sentry should be an Error object

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,8 @@ router.post('/', async (req, res) => {
     if (result.error) return rpcError(res, result.code || 500, result.error, id);
     return rpcSuccess(res, result, id);
   } catch (e) {
-    capture(e);
+    const err = e as any;
+    capture(err.error ? new Error(err.error) : err);
     return rpcError(res, 500, e, id);
   }
 });


### PR DESCRIPTION
Fix #124 
Fix [STAMP-8](https://snapshot-labs.sentry.io/issues/4654387973/?referrer=github_integration)

Errors sent to Sentry should always be an Error object