### PR TITLE
chore: do not log error on invalid ENS name

### DIFF
--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -10,7 +10,6 @@ function normalizeNames(names: string[]) {
     try {
       return ens_normalize(name) === name ? name : '';
     } catch (e) {
-      capture(e);
       return '';
     }
   });


### PR DESCRIPTION
Stop capturing error on invalid ENS parsing