### PR TITLE
fix: do not process functions on empty input

### DIFF
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -15,9 +15,13 @@ export async function lookupAddresses(addresses: Address[]) {
     });
   }
 
+  const normalizedAddresses = normalizeAddresses(addresses);
+
+  if (normalizedAddresses.length === 0) return 0;
+
   return Object.fromEntries(
     Object.entries(
-      await cache(normalizeAddresses(addresses), async (addresses: Address[]) => {
+      await cache(normalizedAddresses, async (addresses: Address[]) => {
         const results = await Promise.all(RESOLVERS.map(r => r.lookupAddresses(addresses)));
 
         return Object.fromEntries(


### PR DESCRIPTION
Do not call lookupAddress resolvers when the address args is empty