### PR TITLE
fix: filter out invalid input before processing

### DIFF
--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -7,7 +7,7 @@ import { provider as getProvider, graphQlCall, Address, Handle } from './utils';
 const NETWORK = '1';
 const provider = getProvider(NETWORK);
 
-function normalizeNames(names: string[]) {
+function normalizeHandles(names: string[]) {
   return names.map(name => {
     try {
       return ens_normalize(name) === name ? name : '';
@@ -27,7 +27,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
       ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [addresses]],
       { blockTag: 'latest' }
     );
-    const validNames = normalizeNames(reverseRecords);
+    const validNames = normalizeHandles(reverseRecords);
 
     return Object.fromEntries(
       addresses
@@ -41,7 +41,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
-  const normalizedHandles = handles.filter(handle => handle.endsWith('.eth'));
+  const normalizedHandles = normalizeHandles(handles).filter(h => h);
 
   if (normalizedHandles.length === 0) return {};
 

--- a/src/addressResolvers/unstoppableDomains.ts
+++ b/src/addressResolvers/unstoppableDomains.ts
@@ -7,7 +7,7 @@ const NETWORK = '137';
 const provider = getProvider(NETWORK);
 
 function normalizeHandles(handles: Handle[]): Handle[] {
-  return handles;
+  return handles.map(h => (h.match(RegExp('^[.a-z0-9-]+$')) ? h : ''));
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
@@ -31,7 +31,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
   const abi = ['function ownerOf(uint256 tokenId) external view returns (address address)'];
 
-  const normalizedHandles = normalizeHandles(handles);
+  const normalizedHandles = normalizeHandles(handles).filter(h => h);
 
   if (normalizedHandles.length === 0) return {};
 

--- a/src/addressResolvers/unstoppableDomains.ts
+++ b/src/addressResolvers/unstoppableDomains.ts
@@ -6,6 +6,10 @@ import { provider as getProvider, Address, Handle, withoutEmptyValues } from './
 const NETWORK = '137';
 const provider = getProvider(NETWORK);
 
+function normalizeHandles(handles: Handle[]): Handle[] {
+  return handles;
+}
+
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
   const abi = ['function reverseNameOf(address addr) view returns (string reverseUri)'];
 
@@ -27,9 +31,13 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
   const abi = ['function ownerOf(uint256 tokenId) external view returns (address address)'];
 
+  const normalizedHandles = normalizeHandles(handles);
+
+  if (normalizedHandles.length === 0) return {};
+
   try {
     const results = await Promise.all(
-      handles.map(async handle => {
+      normalizedHandles.map(async handle => {
         try {
           const tokenId = new Resolution().namehash(handle, NamingServiceName.UNS);
           return await snapshot.utils.call(
@@ -49,10 +57,10 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
     );
 
     return withoutEmptyValues(
-      Object.fromEntries(handles.map((handle, index) => [handle, results[index]]))
+      Object.fromEntries(normalizedHandles.map((handle, index) => [handle, results[index]]))
     );
   } catch (e) {
-    capture(e, { handles });
+    capture(e, { handles: normalizedHandles });
     return {};
   }
 }

--- a/test/unit/addressResolvers/ens.test.ts
+++ b/test/unit/addressResolvers/ens.test.ts
@@ -7,5 +7,6 @@ testAddressResolver(
   resolveNames,
   '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC',
   'sdntestens.eth',
-  '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1'
+  '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1',
+  ['domain.crypto', 'domain.lens', 'domain.com']
 );

--- a/test/unit/addressResolvers/lens.test.ts
+++ b/test/unit/addressResolvers/lens.test.ts
@@ -7,5 +7,6 @@ testAddressResolver(
   resolveNames,
   '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
   'fabien.lens',
-  '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1'
+  '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1',
+  ['domain.crypto', 'domain.eth', 'domain.com']
 );

--- a/test/unit/addressResolvers/unstoppableDomains.test.ts
+++ b/test/unit/addressResolvers/unstoppableDomains.test.ts
@@ -7,5 +7,6 @@ testAddressResolver(
   resolveNames,
   '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
   'snapshot.crypto',
-  '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1'
+  '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1',
+  ['domain.eth', 'domain.lens', 'domain.com']
 );

--- a/test/unit/addressResolvers/utils.ts
+++ b/test/unit/addressResolvers/utils.ts
@@ -4,7 +4,8 @@ export default function testAddressResolver(
   resolveNames,
   validAddress,
   validDomain,
-  blankAddress
+  blankAddress,
+  invalidDomains
 ) {
   describe(`${name} address resolver`, () => {
     describe('lookupAddresses()', () => {
@@ -54,7 +55,7 @@ export default function testAddressResolver(
 
       describe('when mix of domains with and without associated address', () => {
         it('returns an object with only handles associated to an address', () => {
-          return expect(resolveNames([validDomain, 'test.snapshotdomain'])).resolves.toEqual({
+          return expect(resolveNames([...invalidDomains, validDomain])).resolves.toEqual({
             [validDomain]: validAddress
           });
         }, 10e3);


### PR DESCRIPTION
This PR validates handles input, and filter out invalid domains before calling the resolver.


- ENS handle validation coming from ens_normalize package
- Lens validation regex coming from their error graphql error message (`Expected value of type \"Handle!\", found \"Fabien@.lens\"; Handle only supports lower case characters, numbers, - and _. Handle must be minimum of 5 length and maximum of 31 length - fabien@.lens`)
- UnstoppableDomains validation regex coming from https://github.com/unstoppabledomains/resolution/blob/3c10dced96d25c7de5247ca5234a29d8c9699830/src/utils/prepareAndValidate.ts