### PR TITLE
fix: decrease max number of `lookupAddresses` params

### DIFF
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -5,7 +5,7 @@ import cache from './cache';
 import { Address, Handle, normalizeAddresses, withoutEmptyValues } from './utils';
 
 const RESOLVERS = [ensResolver, unstoppableDomainResolver, lensResolver];
-const MAX_LOOKUP_ADDRESSES = 250;
+const MAX_LOOKUP_ADDRESSES = 50;
 const MAX_RESOLVE_NAMES = 5;
 
 export async function lookupAddresses(addresses: Address[]) {

--- a/test/unit/addressResolvers/index.test.ts
+++ b/test/unit/addressResolvers/index.test.ts
@@ -9,12 +9,12 @@ describe('addressResolvers', () => {
   });
 
   describe('lookupAddresses()', () => {
-    describe('when passing more than 250 addresses', () => {
+    describe('when passing more than 50 addresses', () => {
       it('rejects with an error', async () => {
-        const params = Array(251);
+        const params = Array(51);
 
         return expect(lookupAddresses(params)).rejects.toEqual({
-          error: 'params must contains less than 250 addresses',
+          error: 'params must contains less than 50 addresses',
           code: 400
         });
       });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Current limit of addresses accepted for `lookupAddresses` is 250. This was a generous arbitrarily number chosen, without any rational.

We're now using graphql API to resolve the addresses, and they have a different limit

## 💊 Fixes / Solution

Decrease the number of accepted addresses, to match the resolvers API limit

- Lens limit is 50
- ENS limit is 1000

## 🚧 Changes

- Decrease the limit from 250 to 50 addresses. (this should not have any impact on UI, which is sending addresses in batch of 20)