### PR TITLE
fix: handle null handle object from lens

### DIFF
--- a/src/addressResolvers/lens.ts
+++ b/src/addressResolvers/lens.ts
@@ -39,7 +39,9 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
     const items = await apiCall('ownedBy', addresses);
 
     return (
-      Object.fromEntries(items.map(i => [i.handle.ownedBy, `${i.handle.localName}.lens`])) || {}
+      Object.fromEntries(
+        items.filter(i => i.handle).map(i => [i.handle.ownedBy, `${i.handle.localName}.lens`])
+      ) || {}
     );
   } catch (e) {
     capture(e, { input: { addresses } });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Lens is sometimes returning response like 

```js
[
  {
    handle: {
      ownedBy: '0x75f7BA92E923C500f955bf58266413ec69a26382',
      localName: 'gonewyork'
    }
  },
  { handle: null }
]
```

with a null handle object instead of just skipping it

## 💊 Fixes / Solution

Fix #148

Ignore and skip parsing object when handle is null

## 🛠️ Tests

Turn on only the Lens resolver in src/addressResolvers/index.ts `RESOLVERS` constant

Test with following request

```bash
curl -X POST http://localhost:3008/ -H "Content-Type: application/json" -d '{"method": "lookup_addresses", "params": ["0x2935771e6cf78431Fd50Cc4badf3aADCd73b8B1C",
"0x110B8b6717C4Da32d86A8D3ef78964d44f9D61F0",
"0x53607dcF5E15657D81825C14b6a90f717418DCdA",
"0xaFF7a6BF3205A031dAeb9Dd5B0C7f8F1f6dfBcd1",
"0x4CB98Dc2C7E6Ae4c331eedbe665C277b56F52d24",
"0xefE0Cc2f7cdC55efFa6b6b1378A8e2Ca49b692C5",
"0x67cdb2b891a9e8179BACd1009FBcE3e3c4E27F86",
"0xE642EEEa1C42e6976fa55b69Fd1dDe2135f5Db47",
"0x0BAC6DBd438bE80D16137d235837A6177e2c9648",
"0x44aaAD8961Ab1707131a8F4229E34c66BB3Da6A4",
"0x3fD3dcd7Bda97A7627264adCaD23E513517E8f35"] }'
```

Before fix, this should trigger a `TypeError Cannot read properties of null (reading 'ownedBy')`, after fix, it should returns lens results