### PR TITLE
fix: filter out expired ENS handles from results

### DIFF
--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -65,7 +65,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
       `query Domains {
         domains(where: {
           name_in: ["${normalizedHandles.join('","')}"],
-          expiryDate_lt: "${Math.floor(Date.now() / 1e3)}"}
+          expiryDate_gt: "${Math.floor(Date.now() / 1e3)}"}
         ) {
           name
           resolvedAddress {

--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -63,7 +63,10 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
     } = await graphQlCall(
       'https://api.thegraph.com/subgraphs/name/ensdomains/ens',
       `query Domains {
-        domains(where: {name_in: ["${normalizedHandles.join('","')}"]}) {
+        domains(where: {
+          name_in: ["${normalizedHandles.join('","')}"],
+          expiryDate_lt: "${Math.floor(Date.now() / 1e3)}"}
+        ) {
           name
           resolvedAddress {
             id

--- a/test/unit/addressResolvers/ens.test.ts
+++ b/test/unit/addressResolvers/ens.test.ts
@@ -8,5 +8,15 @@ testAddressResolver(
   '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC',
   'sdntestens.eth',
   '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1',
-  ['domain.crypto', 'domain.lens', 'domain.com']
+  ['domain.crypto', 'domain.lens', 'domain.com'],
+  () => {
+    return;
+  },
+  () => {
+    describe('when passing an expired domain name', () => {
+      it('should ignore results for expired domains', () => {
+        return expect(resolveNames(['49415.eth'])).resolves.toEqual({});
+      });
+    });
+  }
 );

--- a/test/unit/addressResolvers/helper.ts
+++ b/test/unit/addressResolvers/helper.ts
@@ -7,7 +7,13 @@ export default function testAddressResolver(
   validAddress,
   validDomain,
   blankAddress,
-  invalidDomains
+  invalidDomains,
+  extraLookupAddressesTests = () => {
+    return;
+  },
+  extraResolveNamesTests = () => {
+    return;
+  }
 ) {
   describe(`${name} address resolver`, () => {
     describe('lookupAddresses()', () => {
@@ -40,6 +46,8 @@ export default function testAddressResolver(
           );
         }, 10e3);
       });
+
+      extraLookupAddressesTests();
     });
 
     describe('resolveNames()', () => {
@@ -64,6 +72,8 @@ export default function testAddressResolver(
           });
         }, 10e3);
       });
+
+      extraResolveNamesTests();
     });
   });
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When resolving ENS address from ENS's subgraph, we're returning all names associated to the address, without taking into account expiration date.

## 💊 Fixes / Solution

Fix #147

We should filter out expired domains from the results.

## 🚧 Changes

- Filter out expired domains from ENS results.
- Add relevant tests

## 🛠️ Tests

Test with the following query

```bash
curl -X POST http://localhost:3008/ -H "Content-Type: application/json" -d '{"method": "resolve_names", "params": ["49415.eth"] }'
```

This domain is expired (https://app.ens.domains/49415.eth)

Before fix, it returns

`{"jsonrpc":"2.0","result":{"49415.eth":"0xD3F0DC8F0aE3b5cd6FCB4a7e5dBC3154554d17F3"},"id":null}`

After fix, it returns

`{"jsonrpc":"2.0","result":{},"id":null}`