### PR TITLE
fix: keep original input formatting when returning

### DIFF
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -2,7 +2,14 @@ import * as ensResolver from './ens';
 import * as lensResolver from './lens';
 import * as unstoppableDomainResolver from './unstoppableDomains';
 import cache from './cache';
-import { Address, Handle, normalizeAddresses, normalizeHandles, withoutEmptyValues } from './utils';
+import {
+  Address,
+  Handle,
+  normalizeAddresses,
+  normalizeHandles,
+  withoutEmptyValues,
+  mapOriginalInput
+} from './utils';
 import { timeAddressResolverResponse as timeResponse } from '../helpers/metrics';
 
 const RESOLVERS = [ensResolver, unstoppableDomainResolver, lensResolver];
@@ -48,17 +55,21 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
-  return await _call(
+  const result = await _call(
     'lookupAddresses',
     Array.from(new Set(normalizeAddresses(addresses))),
     MAX_LOOKUP_ADDRESSES
   );
+
+  return mapOriginalInput(addresses, result);
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
-  return await _call(
+  const result = await _call(
     'resolveNames',
     Array.from(new Set(normalizeHandles(handles))),
     MAX_RESOLVE_NAMES
   );
+
+  return mapOriginalInput(handles, result);
 }

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -35,7 +35,7 @@ export function normalizeAddresses(addresses: Address[]): Address[] {
   return addresses
     .map(a => {
       try {
-        return getAddress(a);
+        return getAddress(a.toLowerCase());
       } catch (e) {}
     })
     .filter(a => a) as Address[];

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -42,7 +42,7 @@ export function normalizeAddresses(addresses: Address[]): Address[] {
 }
 
 export function normalizeHandles(handles: Handle[]): Handle[] {
-  return handles.filter(h => /^[^\s]*\.[^\s]*$/.test(h));
+  return handles.filter(h => /^[^\s]*\.[^\s]*$/.test(h)).map(h => h.toLowerCase());
 }
 
 export function isSilencedContractError(error: any): boolean {
@@ -57,18 +57,15 @@ export function mapOriginalInput(
   input: string[],
   results: Record<string, string>
 ): Record<string, string> {
-  const inputLc = input.map(i => {
-    try {
-      return getAddress(i);
-    } catch (e) {
-      return i;
-    }
-  });
+  const inputLc = input.map(i => i.toLowerCase());
+  const resultLc = Object.fromEntries(
+    Object.entries(results).map(([key, value]) => [key.toLowerCase(), value])
+  );
 
   return withoutEmptyValues(
     Object.fromEntries(
       inputLc.map((key, index) => {
-        return [input[index], results[key]];
+        return [input[index], resultLc[key]];
       })
     )
   );

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -52,3 +52,24 @@ export function isSilencedContractError(error: any): boolean {
     ) || error.code === 'TIMEOUT'
   );
 }
+
+export function mapOriginalInput(
+  input: string[],
+  results: Record<string, string>
+): Record<string, string> {
+  const inputLc = input.map(i => {
+    try {
+      return getAddress(i);
+    } catch (e) {
+      return i;
+    }
+  });
+
+  return withoutEmptyValues(
+    Object.fromEntries(
+      inputLc.map((key, index) => {
+        return [input[index], results[key]];
+      })
+    )
+  );
+}

--- a/test/unit/addressResolvers/index.test.ts
+++ b/test/unit/addressResolvers/index.test.ts
@@ -50,6 +50,20 @@ describe('addressResolvers', () => {
           '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'fabien.eth'
         });
       }, 10e3);
+
+      it('keeps the original input case formatting', () => {
+        return expect(
+          lookupAddresses([
+            '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
+            '0xEF8305E140AC520225DAF050E2F71D5FBCC543E7',
+            '0xef8305e140ac520225daf050e2f71d5fbcc543e7'
+          ])
+        ).resolves.toEqual({
+          '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'fabien.eth',
+          '0xEF8305E140AC520225DAF050E2F71D5FBCC543E7': 'fabien.eth',
+          '0xef8305e140ac520225daf050e2f71d5fbcc543e7': 'fabien.eth'
+        });
+      }, 10e3);
     });
 
     describe('when cached', () => {
@@ -79,12 +93,19 @@ describe('addressResolvers', () => {
       });
 
       it('should return the cached results', async () => {
-        await setCache({ '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'test.eth' });
+        await setCache({
+          '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'test.eth',
+          '0xef8305e140ac520225daf050e2f71d5fbcc543e7': 'test1.eth'
+        });
 
         return expect(
-          lookupAddresses(['0xeF8305E140ac520225DAf050e2f71d5fBcC543e7'])
+          lookupAddresses([
+            '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
+            '0xef8305e140ac520225daf050e2f71d5fbcc543e7'
+          ])
         ).resolves.toEqual({
-          '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'test.eth'
+          '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'test.eth',
+          '0xef8305e140ac520225daf050e2f71d5fbcc543e7': 'test.eth'
         });
       });
     });
@@ -118,6 +139,16 @@ describe('addressResolvers', () => {
           'test-snapshot.eth': undefined
         });
       }, 10e3);
+
+      it('keeps the original case formatting', () => {
+        return expect(
+          resolveNames(['snapshot.crypto', 'SNAPSHOT.CRYPTO', 'Snapshot.Crypto'])
+        ).resolves.toEqual({
+          'snapshot.crypto': '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
+          'SNAPSHOT.CRYPTO': '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
+          'Snapshot.Crypto': '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7'
+        });
+      }, 10e3);
     });
 
     describe('when cached', () => {
@@ -136,10 +167,11 @@ describe('addressResolvers', () => {
       });
 
       it('should return the cached results', async () => {
-        await setCache({ 'snapshot.crypto': '0x0' });
+        await setCache({ 'snapshot.crypto': '0x0', 'SNAPSHOT.CRYPTO': '0x1' });
 
-        return expect(resolveNames(['snapshot.crypto'])).resolves.toEqual({
-          'snapshot.crypto': '0x0'
+        return expect(resolveNames(['snapshot.crypto', 'SNAPSHOT.CRYPTO'])).resolves.toEqual({
+          'snapshot.crypto': '0x0',
+          'SNAPSHOT.CRYPTO': '0x0'
         });
       });
     });


### PR DESCRIPTION
Fix #155

Keep the original input case formatting when returning result

When sending `['a.eth', 'A.ETH']`, will return result like 

```ts
{
'a.eth': '0x0',
'A.ETH': '0x0'
}
```

-> return a value for each original input, to avoid any processing from the caller side, even if the address os the same. This is done only after getting result from api and caching, so we don't pass `a.eth` and `A.ETH` to api.

## Test

```bash
curl -X POST http://localhost:3008/ -H "Content-Type: application/json" -d '{"method": "resolve_names", "params": ["snapshot.crypto", "SNAPSHOT.CRYPTO"] }'

// result
{"jsonrpc":"2.0","result":{"snapshot.crypto":"0xeF8305E140ac520225DAf050e2f71d5fBcC543e7","SNAPSHOT.CRYPTO":"0xeF8305E140ac520225DAf050e2f71d5fBcC543e7"},"id":null}
```

```bash
curl -X POST http://localhost:3008/ -H "Content-Type: application/json" -d '{"method": "lookup_addresses", "params": ["0xeF8305E140ac520225DAf050e2f71d5fBcC543e7", "0xEF8305E140AC520225DAF050E2F71D5FBCC543E7"] }'

// result
{"jsonrpc":"2.0","result":{"0xeF8305E140ac520225DAf050e2f71d5fBcC543e7":"fabien.eth","0xEF8305E140AC520225DAF050E2F71D5FBCC543E7":"fabien.eth"},"id":null}