### PR TITLE
fix: fix ENS avatar resolver when avatar is not HTTP

### DIFF
--- a/src/resolvers/ens.ts
+++ b/src/resolvers/ens.ts
@@ -10,9 +10,9 @@ export default async function resolve(name: string) {
       return false;
     }
 
-    const url = await ensResolver.getText('avatar');
+    let url = await ensResolver.getText('avatar');
     if (!url || !url.startsWith('http')) {
-      return false;
+      url = `https://metadata.ens.domains/mainnet/avatar/${name}`;
     }
 
     const input = (await axios({ url, responseType: 'arraybuffer' })).data as Buffer;

--- a/src/resolvers/ens.ts
+++ b/src/resolvers/ens.ts
@@ -11,9 +11,7 @@ export default async function resolve(name: string) {
     }
 
     let url = await ensResolver.getText('avatar');
-    if (!url || !url.startsWith('http')) {
-      url = `https://metadata.ens.domains/mainnet/avatar/${name}`;
-    }
+    url = url?.startsWith('http') ? url : `https://metadata.ens.domains/mainnet/avatar/${name}`;
 
     const input = (await axios({ url, responseType: 'arraybuffer' })).data as Buffer;
 


### PR DESCRIPTION
Fix #76
Fix #109 

Fix missing image on ENS name, when the avatar metadata is not starting by `http`.
This fix uses ENS own metadata resolver as fallback, as pointed out here https://github.com/snapshot-labs/stamp/issues/109#issuecomment-1798361605