### PR TITLE
fix: remove null values before processing

### DIFF
--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -57,7 +57,7 @@ export function mapOriginalInput(
   input: string[],
   results: Record<string, string>
 ): Record<string, string> {
-  const inputLc = input.filter(a => a).map(i => i.toLowerCase());
+  const inputLc = input.map(i => i?.toLowerCase());
   const resultLc = Object.fromEntries(
     Object.entries(results).map(([key, value]) => [key.toLowerCase(), value])
   );

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -57,7 +57,7 @@ export function mapOriginalInput(
   input: string[],
   results: Record<string, string>
 ): Record<string, string> {
-  const inputLc = input.map(i => i.toLowerCase());
+  const inputLc = input.filter(a => a).map(i => i.toLowerCase());
   const resultLc = Object.fromEntries(
     Object.entries(results).map(([key, value]) => [key.toLowerCase(), value])
   );


### PR DESCRIPTION
Fix #165 
Fix [STAMP-1J](https://snapshot-labs.sentry.io/issues/4868263621/?referrer=github_integration)

Remove null values before manipulation