### PR TITLE
fix: handle jsonRpcError when silencing contrat call errors

### DIFF
--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -49,7 +49,10 @@ export function isSilencedError(error: any): boolean {
   return (
     ['invalid token ID', 'is not supported', 'execution reverted'].some(m =>
       error.message?.includes(m)
-    ) || ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT'].some(c => error.code?.includes(c))
+    ) ||
+    ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT'].some(c =>
+      (error.error?.code || error.code)?.includes(c)
+    )
   );
 }
 

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -50,7 +50,7 @@ export function isSilencedError(error: any): boolean {
     ['invalid token ID', 'is not supported', 'execution reverted'].some(m =>
       error.message?.includes(m)
     ) ||
-    ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT'].some(c =>
+    ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET'].some(c =>
       (error.error?.code || error.code)?.includes(c)
     )
   );


### PR DESCRIPTION
When silencing timeout error, also take into account timeout error from brovider JsonRpcError

Also add `ECONNRESET` to list of silenced error (https://snapshot-labs.sentry.io/issues/4495021166/?project=4505506866593792&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=3)