### PR TITLE
feat: add support for starknet avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cdn.stamp.fyi/**token**/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e
 
 ### Identifier
 
-The identifier can be an address (case insensitive), ENS name, CAIP-10, EIP-3770 or DID.
+The identifier can be an address (case insensitive), ENS name, CAIP-10, EIP-3770, DID or Starknet domain.
 
 #### Examples
 
@@ -36,6 +36,7 @@ cdn.stamp.fyi/avatar/**0xeF8305E140ac520225DAf050e2f71d5fBcC543e7**
 cdn.stamp.fyi/avatar/**fabien.eth**  
 cdn.stamp.fyi/token/**eth:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**  
 cdn.stamp.fyi/token/**eip155:1:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**
+cdn.stamp.fyi/token/**checkpoint.stark**
 
 ### Params
 
@@ -62,6 +63,8 @@ cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?**cb=1**
 #### [Blockie](/src/resolvers/blockie.ts)
 
 #### [Jazzicon](/src/resolvers/jazzicon.ts)
+
+#### [Starknet](/src/resolvers/starknet.ts)
 
 ### Integrations
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ cdn.stamp.fyi/avatar/**0xeF8305E140ac520225DAf050e2f71d5fBcC543e7**
 cdn.stamp.fyi/avatar/**fabien.eth**  
 cdn.stamp.fyi/token/**eth:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**  
 cdn.stamp.fyi/token/**eip155:1:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**
-cdn.stamp.fyi/token/**checkpoint.stark**
+cdn.stamp.fyi/avatar/**checkpoint.stark**
+cdn.stamp.fyi/avatar/**0x07FF6B17f07c4d83236E3Fc5f94259A19D1Ed41bBCf1822397EA17882E9b038d**
 
 ### Params
 

--- a/src/constants.json
+++ b/src/constants.json
@@ -3,7 +3,7 @@
   "ttl": 86400,
   "shortTtl": 3600,
   "resolvers": {
-    "avatar": ["lens", "ens", "snapshot"],
+    "avatar": ["lens", "ens", "snapshot", "starknet"],
     "token": ["trustwallet", "zapper"],
     "space": ["space"],
     "space-sx": ["space-sx"],

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -8,6 +8,7 @@ import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from
 import selfid from './selfid';
 import lens from './lens';
 import zapper from './zapper';
+import starknet from './starknet';
 
 export default {
   blockie,
@@ -20,5 +21,6 @@ export default {
   'space-cover-sx': sxResolveCover,
   selfid,
   lens,
-  zapper
+  zapper,
+  starknet
 };

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -3,17 +3,50 @@ import { getUrl, resize } from '../utils';
 import { max } from '../constants.json';
 import { fetchHttpImage, axiosDefaultParams } from './utils';
 
-export default async function resolve(address: string) {
-  try {
-    if (!address.endsWith('.stark')) {
-      throw new Error('Unsupported domain');
-    }
+async function getImageFromDomain(domain: string): Promise<string> {
+  const res = await axios.get(
+    `https://api.starknet.id/domain_to_data?domain=${domain}`,
+    axiosDefaultParams
+  );
+  return res.data.img_url;
+}
 
+async function getImageFromAddress(address: string): Promise<string> {
+  const tokenIdRes = await axios.get(
+    `https://api.starknet.id/addr_to_token_id?addr=${address}`,
+    axiosDefaultParams
+  );
+  const tokenId = tokenIdRes.data.token_id;
+
+  if (tokenId) {
     const res = await axios.get(
-      `https://api.starknet.id/domain_to_data?domain=${address}`,
+      `https://api.starknet.id/id_to_data?id=${tokenId}`,
       axiosDefaultParams
     );
-    const { img_url } = res.data;
+    return res.data.img_url;
+  }
+
+  throw new Error('No image found for starknet address');
+}
+
+export default async function resolve(domainOrAddress: string) {
+  try {
+    let img_url: string | null = null;
+    if (domainOrAddress.includes('.')) {
+      if (!domainOrAddress.endsWith('.stark')) {
+        throw new Error('Unsupported starknet domain');
+      }
+      img_url = await getImageFromDomain(domainOrAddress);
+    } else if (domainOrAddress.startsWith('0x')) {
+      if (!/^0x[a-f0-9]{64}$/i.test(domainOrAddress)) {
+        throw new Error('Invalid starknet address');
+      }
+      img_url = await getImageFromAddress(domainOrAddress);
+    }
+
+    if (!img_url) {
+      throw new Error('No starknet image found');
+    }
 
     const input = await fetchHttpImage(getUrl(img_url));
     return await resize(input, max, max);

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { getUrl, resize } from '../utils';
+import { max } from '../constants.json';
+import { fetchHttpImage, axiosDefaultParams } from './utils';
+
+export default async function resolve(address: string) {
+  try {
+    if (!address.endsWith('.stark')) {
+      throw new Error('Unsupported domain');
+    }
+
+    const res = await axios.get(
+      `https://api.starknet.id/domain_to_data?domain=${address}`,
+      axiosDefaultParams
+    );
+    const { img_url } = res.data;
+
+    const input = await fetchHttpImage(getUrl(img_url));
+    return await resize(input, max, max);
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -29,18 +29,20 @@ async function getImageFromAddress(address: string): Promise<string> {
   throw new Error('No image found for starknet address');
 }
 
+function isStarknetAddress(address: string): boolean {
+  return /^0x[a-f0-9]{64}$/i.test(address);
+}
+
+function isStarknetDomain(domain: string): boolean {
+  return domain.endsWith('.stark');
+}
+
 export default async function resolve(domainOrAddress: string) {
   try {
     let img_url: string | null = null;
-    if (domainOrAddress.includes('.')) {
-      if (!domainOrAddress.endsWith('.stark')) {
-        throw new Error('Unsupported starknet domain');
-      }
+    if (isStarknetDomain(domainOrAddress)) {
       img_url = await getImageFromDomain(domainOrAddress);
-    } else if (domainOrAddress.startsWith('0x')) {
-      if (!/^0x[a-f0-9]{64}$/i.test(domainOrAddress)) {
-        throw new Error('Invalid starknet address');
-      }
+    } else if (isStarknetAddress(domainOrAddress)) {
       img_url = await getImageFromAddress(domainOrAddress);
     }
 

--- a/test/unit/resolvers/starknet.test.ts
+++ b/test/unit/resolvers/starknet.test.ts
@@ -1,0 +1,18 @@
+import resolvers from '../../../src/resolvers';
+
+describe('resolvers', () => {
+  describe('starknet', () => {
+    it('should return false if missing', async () => {
+      const result = await resolvers.starknet('test-checkpoint.stark');
+
+      expect(result).toBe(false);
+    });
+
+    it('should resolve', async () => {
+      const result = await resolvers.starknet('checkpoint.stark');
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(1000);
+    });
+  });
+});

--- a/test/unit/resolvers/starknet.test.ts
+++ b/test/unit/resolvers/starknet.test.ts
@@ -6,13 +6,22 @@ describe('resolvers', () => {
       const result = await resolvers.starknet('test-checkpoint.stark');
 
       expect(result).toBe(false);
-    });
+    }, 10e3);
 
-    it('should resolve', async () => {
+    it('should resolve a domain', async () => {
       const result = await resolvers.starknet('checkpoint.stark');
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);
-    });
+    }, 10e3);
+
+    it('should resolve an address', async () => {
+      const result = await resolvers.starknet(
+        '0x07FF6B17f07c4d83236E3Fc5f94259A19D1Ed41bBCf1822397EA17882E9b038d'
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(1000);
+    }, 10e3);
   });
 });

--- a/test/unit/resolvers/starknet.test.ts
+++ b/test/unit/resolvers/starknet.test.ts
@@ -9,7 +9,7 @@ describe('resolvers', () => {
     }, 10e3);
 
     it('should resolve a domain', async () => {
-      const result = await resolvers.starknet('checkpoint.stark');
+      const result = await resolvers.starknet('fricoben.stark');
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);
@@ -17,7 +17,7 @@ describe('resolvers', () => {
 
     it('should resolve an address', async () => {
       const result = await resolvers.starknet(
-        '0x07FF6B17f07c4d83236E3Fc5f94259A19D1Ed41bBCf1822397EA17882E9b038d'
+        '0x061b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3'
       );
 
       expect(result).toBeInstanceOf(Buffer);


### PR DESCRIPTION
Add support for Starknet avatar from domain (see https://docs.starknet.id/devs/starknetid-api#domain-to-data)

Fix #175 

Test with 

- http://localhost:3008/avatar/checkpoint.stark
- http://localhost:3008/avatar/0x07FF6B17f07c4d83236E3Fc5f94259A19D1Ed41bBCf1822397EA17882E9b038d

Should return the same image

Coming later in another PR: resolving Starknet avatar from address