### PR TITLE
added Farcaster resolver for both custody and verified address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 # Remove some common IDE working directories
 .idea
 .vscode
+try.ts

--- a/src/resolvers/farcaster.ts
+++ b/src/resolvers/farcaster.ts
@@ -27,8 +27,9 @@ export default async function resolve(address) {
 
         const url = getUrl(data[Object.keys(data)[0]][0].pfp_url);
         if (!url) return false;
-        
+
         const input = await fetchHttpImage(url);
+        
         return await resize(input, max, max);
     } catch (e) {
         return false;

--- a/src/resolvers/farcaster.ts
+++ b/src/resolvers/farcaster.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import { getAddress, isAddress } from '@ethersproject/address';
+import { fetchHttpImage, axiosDefaultParams } from './utils';
+import { getUrl, resize } from '../utils';
+import { max } from '../constants.json';
+
+
+const EXTERNAL_FARCASTER_API_URL = 'https://api.neynar.com'; 
+const EXTERNAL_API_KEY = "NEYNAR_API_DOCS";
+
+
+export default async function resolve(address) { 
+    if (!isAddress(address)) return false;
+    const eth_address = getAddress(address);
+    
+    try {
+        let { data } = await axios({
+            url: `${EXTERNAL_FARCASTER_API_URL}/v2/farcaster/user/bulk-by-address`,
+            method: 'GET',
+            params: {
+                addresses: eth_address
+            }, 
+            headers: {accept: 'application/json', api_key: EXTERNAL_API_KEY},
+            ...axiosDefaultParams
+        })
+        if (!data[Object.keys(data)[0]][0].pfp_url) return false;
+        const url = getUrl(data[Object.keys(data)[0]][0].pfp_url);
+        if (!url) return false;
+        const input = await fetchHttpImage(url);
+        return await resize(input, max, max);
+    } catch (e) {
+        return false;
+    }
+}

--- a/src/resolvers/farcaster.ts
+++ b/src/resolvers/farcaster.ts
@@ -10,8 +10,8 @@ const EXTERNAL_API_KEY = "NEYNAR_API_DOCS";
 
 
 export default async function resolve(address) { 
-    if (!isAddress(address)) return false;
     const eth_address = getAddress(address);
+    if (!isAddress(address)) return false;
     
     try {
         let { data } = await axios({
@@ -24,8 +24,10 @@ export default async function resolve(address) {
             ...axiosDefaultParams
         })
         if (!data[Object.keys(data)[0]][0].pfp_url) return false;
+
         const url = getUrl(data[Object.keys(data)[0]][0].pfp_url);
         if (!url) return false;
+        
         const input = await fetchHttpImage(url);
         return await resize(input, max, max);
     } catch (e) {


### PR DESCRIPTION
On the protocol level Farcaster doesn't store verified and connected addresses, only custody addresses. Initially my suggestion was on using the Farcaster API, but this only covers custody addresses. Here I use Neynar API to resolve both custody and connected addresses. 
N.B Neynar lets us use their free API keys, but we may need to upgrade to paid, depending on the request being made second.