### PR TITLE
feat: add query params to target avatar resolver

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -93,11 +93,7 @@ router.get(`/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
     if (type === 'space-sx') currentResolvers = constants.resolvers['space-sx'];
     if (type === 'space-cover-sx') currentResolvers = constants.resolvers['space-cover-sx'];
 
-    if (resolver) {
-      currentResolvers = currentResolvers.filter(r => resolver.includes(r));
-    }
-
-    if (!currentResolvers.length) {
+    if (resolver && !currentResolvers.includes(resolver)) {
       return res.status(500).json({ status: 'error', error: 'invalid resolvers' });
     }
 

--- a/src/constants.json
+++ b/src/constants.json
@@ -4,7 +4,7 @@
   "shortTtl": 3600,
   "resolvers": {
     "avatar": ["snapshot", "ens", "lens", "farcaster", "starknet"],
-    "token": [ "zapper", "trustwallet"],
+    "token": ["trustwallet", "zapper"],
     "space": ["space"],
     "space-sx": ["space-sx"],
     "space-cover-sx": ["space-cover-sx"]

--- a/src/constants.json
+++ b/src/constants.json
@@ -3,8 +3,8 @@
   "ttl": 86400,
   "shortTtl": 3600,
   "resolvers": {
-    "avatar": ["lens", "ens", "snapshot", "starknet", "farcaster"],
-    "token": ["trustwallet", "zapper"],
+    "avatar": ["snapshot", "ens", "lens", "farcaster", "starknet"],
+    "token": [ "zapper", "trustwallet"],
     "space": ["space"],
     "space-sx": ["space-sx"],
     "space-cover-sx": ["space-cover-sx"]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,8 @@ export async function parseQuery(id, type, query) {
     w,
     h,
     fallback: query.fb === 'jazzicon' ? 'jazzicon' : 'blockie',
-    cb: query.cb
+    cb: query.cb,
+    resolver: query.resolver
   };
 }
 


### PR DESCRIPTION
Add an optional `?resolver=` query params to `/avatar/[ID]` API endpoint, to target a specific resolver.

This is useful for testing, since we can fetch avatar from specific resolver directly, without editing the code.

With `?resolver=`, cache is disabled

This PR also fix avatar's resolving order, to be `["snapshot", "ens", "lens", "farcaster", "starknet"]`

### Test 

- http://localhost:3008/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?resolvers=ens
- http://localhost:3008/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?resolvers=lens
- http://localhost:3008/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?resolvers=farcaster

All these urls should return directly the avatar associated to the resolver.