### PR TITLE
fix: fix ipfs gateway always timing out on test env

### DIFF
--- a/test/.env.test
+++ b/test/.env.test
@@ -1,3 +1,4 @@
 HUB_URL=https://hub.snapshot.org
 BROVIDER_URL=https://rpc.brovider.xyz
 REDIS_URL=redis://localhost:6379
+IPFS_GATEWAY=snapshot.4everland.link


### PR DESCRIPTION
In test env. use 4everland instead of cloudflare as ipfs gateway, as cloudflare is always timing out, and failing tests

After this fix, `snapshot` and `space` resolvers should not fail in test anymore