### PR TITLE
fix: fix `resolver` query params being ignored

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -93,8 +93,12 @@ router.get(`/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
     if (type === 'space-sx') currentResolvers = constants.resolvers['space-sx'];
     if (type === 'space-cover-sx') currentResolvers = constants.resolvers['space-cover-sx'];
 
-    if (resolver && !currentResolvers.includes(resolver)) {
-      return res.status(500).json({ status: 'error', error: 'invalid resolvers' });
+    if (resolver) {
+      if (!currentResolvers.includes(resolver)) {
+        return res.status(500).json({ status: 'error', error: 'invalid resolvers' });
+      }
+
+      currentResolvers = [resolver];
     }
 
     const files = await Promise.all(currentResolvers.map(r => resolvers[r](address, network)));


### PR DESCRIPTION
Fix issue where the `?resolver=lens` query params is being ignored