### PR TITLE
feat: add support for user cover

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -98,6 +98,7 @@ router.get(`/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
     if (type === 'space') currentResolvers = constants.resolvers.space;
     if (type === 'space-sx') currentResolvers = constants.resolvers['space-sx'];
     if (type === 'space-cover-sx') currentResolvers = constants.resolvers['space-cover-sx'];
+    if (type === 'user-cover') currentResolvers = constants.resolvers['user-cover'];
 
     if (resolver) {
       if (!currentResolvers.includes(resolver)) {

--- a/src/constants.json
+++ b/src/constants.json
@@ -4,6 +4,7 @@
   "shortTtl": 3600,
   "resolvers": {
     "avatar": ["snapshot", "ens", "lens", "farcaster", "starknet"],
+    "user-cover": ["user-cover"],
     "token": ["trustwallet", "zapper"],
     "space": ["space"],
     "space-sx": ["space-sx"],

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -2,7 +2,7 @@ import blockie from './blockie';
 import jazzicon from './jazzicon';
 import ens from './ens';
 import trustwallet from './trustwallet';
-import snapshot from './snapshot';
+import { resolveAvatar as sResolveAvatar, resolveCover as sResolveCover } from './snapshot';
 import space from './space';
 import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from './space-sx';
 import selfid from './selfid';
@@ -16,7 +16,8 @@ export default {
   jazzicon,
   ens,
   trustwallet,
-  snapshot,
+  snapshot: sResolveAvatar,
+  'user-cover': sResolveCover,
   space,
   'space-sx': sxResolveAvatar,
   'space-cover-sx': sxResolveCover,

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { getAddress } from '@ethersproject/address';
 import { getUrl, resize } from '../utils';
 import { max } from '../constants.json';
 import { fetchHttpImage, axiosDefaultParams } from './utils';
+import { getChecksummedAddress } from '../utils';
 
 const HUB_URL = process.env.HUB_URL ?? 'https://hub.snapshot.org';
 
@@ -14,7 +14,7 @@ function createPropertyResolver(property: 'avatar' | 'cover') {
           url: `${HUB_URL}/graphql`,
           method: 'post',
           data: {
-            query: `query { user(id: "${getAddress(address)}") { ${property} } }`
+            query: `query { user(id: "${getChecksummedAddress(address)}") { ${property} } }`
           },
           ...axiosDefaultParams
         })

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -4,25 +4,35 @@ import { getUrl, resize } from '../utils';
 import { max } from '../constants.json';
 import { fetchHttpImage, axiosDefaultParams } from './utils';
 
-const HUB_URL = process.env.HUB_URL || 'https://hub.snapshot.org';
+const HUB_URL = process.env.HUB_URL ?? 'https://hub.snapshot.org';
 
-export default async function resolve(address) {
-  try {
-    const user = (
-      await axios({
-        url: `${HUB_URL}/graphql`,
-        method: 'post',
-        data: {
-          query: `query { user(id: "${getAddress(address)}") { avatar } }`
-        },
-        ...axiosDefaultParams
-      })
-    ).data.data.user;
-    if (!user || !user.avatar) return false;
-    const url = getUrl(user.avatar);
-    const input = await fetchHttpImage(url);
-    return await resize(input, max, max);
-  } catch (e) {
-    return false;
-  }
+function createPropertyResolver(property: 'avatar' | 'cover') {
+  return async (address: string) => {
+    try {
+      const user = (
+        await axios({
+          url: `${HUB_URL}/graphql`,
+          method: 'post',
+          data: {
+            query: `query { user(id: "${getAddress(address)}") { ${property} } }`
+          },
+          ...axiosDefaultParams
+        })
+      ).data.data.user;
+
+      if (!user?.[property]) return false;
+
+      const url = getUrl(user[property]);
+      const input = await fetchHttpImage(url);
+
+      if (property === 'cover') return input;
+
+      return await resize(input, max, max);
+    } catch (e) {
+      return false;
+    }
+  };
 }
+
+export const resolveAvatar = createPropertyResolver('avatar');
+export const resolveCover = createPropertyResolver('cover');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import sharp from 'sharp';
 import snapshot from '@snapshot-labs/snapshot.js';
+import { getAddress, isAddress } from '@ethersproject/address';
+import { getChecksumAddress } from 'starknet';
 import { createHash } from 'crypto';
 import { Response } from 'express';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
@@ -158,4 +160,8 @@ export function graphQlCall(url: string, query: string) {
       query
     }
   });
+}
+
+export function getChecksummedAddress(address: Address): Address {
+  return isAddress(address) ? getAddress(address) : getChecksumAddress(address);
 }

--- a/test/integration/resolvers/snapshot.test.ts
+++ b/test/integration/resolvers/snapshot.test.ts
@@ -2,14 +2,31 @@ import resolvers from '../../../src/resolvers';
 
 describe('resolvers', () => {
   describe('snapshot', () => {
+    describe('on avatar', () => {
+      it('should return false if missing', async () => {
+        const result = await resolvers.snapshot('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
+
+        expect(result).toBe(false);
+      }, 15e3);
+
+      it('should resolve', async () => {
+        const result = await resolvers.snapshot('0xeF8305E140ac520225DAf050e2f71d5fBcC543e7');
+
+        expect(result).toBeInstanceOf(Buffer);
+        expect(result.length).toBeGreaterThan(1000);
+      }, 15e3);
+    });
+  });
+
+  describe('on cover', () => {
     it('should return false if missing', async () => {
-      const result = await resolvers.snapshot('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
+      const result = await resolvers['user-cover']('0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70');
 
       expect(result).toBe(false);
     }, 15e3);
 
     it('should resolve', async () => {
-      const result = await resolvers.snapshot('0xeF8305E140ac520225DAf050e2f71d5fBcC543e7');
+      const result = await resolvers['user-cover']('0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3');
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(1000);


### PR DESCRIPTION
Related to the new profile page introduced in https://github.com/snapshot-labs/sx-monorepo/pull/394

An user has now a `cover` property, in addition to `avatar`, similar to the sx `Space` object.

This PR will add a new `user-cover` type when requesting image, allowing to fetch an user cover image with 

```
http://localhost:3008/user-cover/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3
```

The `snapshot.ts` has been refactored to be similar to `space-sx.ts`