### PR TITLE
fix: allow larger max size for all cover types

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -1,5 +1,6 @@
 {
   "max": 500,
+  "maxCover": 1500,
   "ttl": 43200,
   "shortTtl": 3600,
   "resolvers": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export async function parseQuery(id, type, query) {
 
   address = address.toLowerCase();
   const size = 64;
-  const maxSize = type === 'space-cover-sx' ? 1500 : 500;
+  const maxSize = type.includes('-cover') ? constants.maxCover : constants.max;
   let s = query.s ? parseInt(query.s) : size;
   if (s < 1 || s > maxSize || isNaN(s)) s = size;
   let w = query.w ? parseInt(query.w) : s;


### PR DESCRIPTION
This PR allow a larger max size for all image type including `-cover`.

Else, the newly introduced `user-cover` type is capped to only 500, but should behave like `space-cover-xxx`