### PR TITLE
feat: use lossy webp encoding (quality 80).

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ export function sha256(str) {
 export async function resize(input, w, h) {
   return sharp(input)
     .resize(w, h)
-    .webp({ lossless: true })
+    .webp()
     .toBuffer();
 }
 


### PR DESCRIPTION
Using reduced quality greatly reduces image size (images are 90% smaller). Quality is reduced slightly, but not really noticable. You can try what quality 80 for WebP looks like on https://squoosh.app/

Closes: https://github.com/snapshot-labs/stamp/issues/243