### PR TITLE
fix: remove unecessary address formatting

### DIFF
--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 import { getUrl, resize } from '../utils';
 import { max } from '../constants.json';
 import { fetchHttpImage, axiosDefaultParams } from './utils';
-import { getChecksummedAddress } from '../utils';
 
 const HUB_URL = process.env.HUB_URL ?? 'https://hub.snapshot.org';
 
@@ -14,7 +13,7 @@ function createPropertyResolver(property: 'avatar' | 'cover') {
           url: `${HUB_URL}/graphql`,
           method: 'post',
           data: {
-            query: `query { user(id: "${getChecksummedAddress(address)}") { ${property} } }`
+            query: `query { user(id: "${address}") { ${property} } }`
           },
           ...axiosDefaultParams
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import sharp from 'sharp';
 import snapshot from '@snapshot-labs/snapshot.js';
-import { getAddress, isAddress } from '@ethersproject/address';
-import { getChecksumAddress } from 'starknet';
 import { createHash } from 'crypto';
 import { Response } from 'express';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
@@ -160,8 +158,4 @@ export function graphQlCall(url: string, query: string) {
       query
     }
   });
-}
-
-export function getChecksummedAddress(address: Address): Address {
-  return isAddress(address) ? getAddress(address) : getChecksumAddress(address);
 }


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

We format user address before sending them to the hub, which is not needed anymore, as we've added the formatting directly on the hub side.

## 💊 Fixes / Solution

Remove address formatting, delegating the logic to the hub

## Test 

Both urls should return the same image

- http://localhost:3008/avatar/0x91fd2c8d24767db4ece7069aa27832ffaf8590f3?resolver=snapshot
- http://localhost:3008/avatar/0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3?resolver=snapshot

