### PR TITLE
chore: update start:test script to include build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "prettier": "^1.19.1",
     "start-server-and-test": "^2.0.3",
     "ts-jest": "^28.0.4"
+  },
+  "engines": {
+    "node": ">=18.20.4 <19"
   }
 }


### PR DESCRIPTION
Resolves: #276

Since it's also required to run it on the correct Node.js version, I also added the ["engines"](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines) key in package.json. I chose 18.20.4 because that is the version used when I run `nvm use 18` and everything works. I know it breaks on the latest node version 22 and 21 was working still but I didn't track it down further because compatibility with later node.js version should be achived instead.