### PR TITLE
feat: add .bnb names resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@ethersproject/address": "^5.7.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
+    "@ethersproject/hash": "^5.8.0",
     "@ethersproject/providers": "^5.7.2",
     "@metamask/jazzicon": "^2.0.0",
     "@self.id/core": "^0.3.0",

--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -4,6 +4,7 @@ import * as unstoppableDomainResolver from './unstoppableDomains';
 import * as starknetResolver from './starknet';
 import * as snapshotResolver from './snapshot';
 import * as shibariumResolver from './shibarium';
+import * as spaceIdResolver from './spaceId';
 import cache, { clear } from './cache';
 import {
   normalizeAddresses,
@@ -21,7 +22,8 @@ const RESOLVERS = [
   unstoppableDomainResolver,
   lensResolver,
   starknetResolver,
-  shibariumResolver
+  shibariumResolver,
+  spaceIdResolver
 ];
 const MAX_LOOKUP_ADDRESSES = 50;
 const MAX_RESOLVE_NAMES = 5;

--- a/src/addressResolvers/spaceId.ts
+++ b/src/addressResolvers/spaceId.ts
@@ -1,0 +1,106 @@
+import { namehash } from '@ethersproject/hash';
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { Address, batchContractCalls, EMPTY_ADDRESS, Handle } from '../utils';
+import { provider as getProvider, isEvmAddress, isSilencedError, FetchError } from './utils';
+
+// NOTE: Space ID supports multiple networks and TLDs, this file only implements BNB with .bnb TLD
+// https://www.space.id/
+export const NAME = 'Space ID';
+
+const NETWORK = '56'; // BNB
+const TLD = '.bnb';
+const BNB_REGISTRY_CONTRACT = '0x08CEd32a7f3eeC915Ba84415e9C07a7286977956';
+const REGISTRY_ABI = ['function resolver(bytes32 node) external view returns (address address)'];
+const RESOLVER_ABI = [
+  'function addr(bytes32 node) external view returns (address address)',
+  'function name(bytes32 node) view returns (string name)'
+];
+
+const provider = getProvider(NETWORK, { timeout: 5e3 });
+
+function normalizeAddresses(addresses: Address[]): Address[] {
+  return addresses.filter(isEvmAddress);
+}
+
+function normalizeHandles(handles: Handle[]): Handle[] {
+  return handles.filter(h => h.endsWith(TLD));
+}
+
+// Call the relevant contracts to get the mapping of namehash -> address/handle
+// 1. Get the resolver address for each namehash from the registry contract
+// 2. Get the address/handle for each namehash from the relevant resolver contract
+//
+// Flow from https://github.com/Space-ID/web3-name-sdk/blob/main/packages/core/src/tlds/web3name/index.ts
+async function resolveNameHashes(
+  hashes: string[],
+  fnName: string
+): Promise<Record<string, Address | Handle>> {
+  try {
+    // Fetch the mapping of namehash -> resolver address
+    const resolvers: Record<string, Address> = await batchContractCalls(
+      NETWORK,
+      provider,
+      REGISTRY_ABI,
+      hashes,
+      new Array(hashes.length).fill(BNB_REGISTRY_CONTRACT),
+      'resolver'
+    );
+
+    Object.keys(resolvers).forEach(hash => {
+      if (resolvers[hash] === EMPTY_ADDRESS) delete resolvers[hash];
+    });
+
+    if (Object.keys(resolvers).length === 0) return {};
+
+    // Fetch the mapping of namehash -> address/handle
+    return await batchContractCalls(
+      NETWORK,
+      provider,
+      RESOLVER_ABI,
+      Object.keys(resolvers),
+      Object.values(resolvers),
+      fnName
+    );
+  } catch (e) {
+    if (!isSilencedError(e)) {
+      capture(e, { input: { hashes, fnName } });
+    }
+    throw new FetchError();
+  }
+}
+
+export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
+  const normalizedAddresses = normalizeAddresses(addresses);
+
+  if (normalizedAddresses.length === 0) return {};
+
+  const reverseNamehashes = normalizedAddresses.map(addr => {
+    return namehash(`${addr.slice(2)}.addr.reverse`);
+  });
+  const names: Record<string, Handle> = await resolveNameHashes(reverseNamehashes, 'name');
+  const results = {};
+
+  Object.entries(names).forEach(([hash, name]) => {
+    const addr = normalizedAddresses[reverseNamehashes.indexOf(hash)];
+    if (addr && name.endsWith(TLD)) results[addr] = name;
+  });
+
+  return results;
+}
+
+export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
+  const normalizedHandles = normalizeHandles(handles);
+
+  if (normalizedHandles.length === 0) return {};
+
+  const namehashes = normalizedHandles.map(namehash);
+  const addresses: Record<string, Address> = await resolveNameHashes(namehashes, 'addr');
+  const results = {};
+
+  Object.entries(addresses).forEach(([hash, addr]) => {
+    const handle = normalizedHandles[namehashes.indexOf(hash)];
+    if (handle) results[handle] = addr;
+  });
+
+  return results;
+}

--- a/src/addressResolvers/unstoppableDomains.ts
+++ b/src/addressResolvers/unstoppableDomains.ts
@@ -8,7 +8,7 @@ import {
   FetchError,
   isEvmAddress
 } from './utils';
-import { Address, Handle } from '../utils';
+import { Address, batchContractCalls, Handle } from '../utils';
 
 export const NAME = 'Unstoppable Domains';
 const NETWORK = '137';
@@ -33,12 +33,14 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
   if (normalizedAddresses.length === 0) return {};
 
   try {
-    const multi = new snapshot.utils.Multicaller(NETWORK, provider, ABI);
-    normalizedAddresses.forEach(address =>
-      multi.call(address, CONTRACT_ADDRESS, 'reverseNameOf', [address])
+    const names: Record<Address, Handle> = await batchContractCalls(
+      NETWORK,
+      provider,
+      ABI,
+      normalizedAddresses,
+      new Array(normalizedAddresses.length).fill(CONTRACT_ADDRESS),
+      'reverseNameOf'
     );
-
-    const names = (await multi.execute()) as Record<Address, Handle>;
 
     return withoutEmptyValues(names);
   } catch (e) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,3 +209,28 @@ export function graphQlCall(
     data
   });
 }
+
+/**
+ * Executes batch contract calls using multicall pattern
+ * @param network - The network identifier
+ * @param provider - The blockchain provider instance
+ * @param abi - The contract ABI as an array of strings
+ * @param args - Array of arguments to pass to the function calls
+ * @param addresses - Array of contract addresses to call
+ * @param fnName - The name of the function to call on each contract
+ * @returns Promise that resolves to the results of all contract calls
+ */
+export async function batchContractCalls(
+  network: string,
+  provider: StaticJsonRpcProvider,
+  abi: string[],
+  args: any[],
+  addresses: Address[],
+  fnName: string
+) {
+  const multicall = new snapshot.utils.Multicaller(network, provider, abi);
+
+  args.forEach((arg, i) => multicall.call(`${fnName}.${arg}`, addresses[i], fnName, [arg]));
+
+  return (await multicall.execute())[fnName];
+}

--- a/test/integration/addressResolvers/spaceId.test.ts
+++ b/test/integration/addressResolvers/spaceId.test.ts
@@ -1,0 +1,12 @@
+import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/spaceId';
+import testAddressResolver from './helper';
+
+testAddressResolver({
+  name: 'Space ID',
+  lookupAddresses,
+  resolveNames,
+  validAddress: '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6',
+  validDomain: 'boorger.bnb',
+  blankAddress: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+  invalidDomains: ['domain.crypto', 'domain.eth', 'domain.com', 'inexistent-domain-for-test.bnb']
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,6 +1041,19 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
+"@ethersproject/abstract-provider@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz#7581f9be601afa1d02b95d26b9d9840926a35b0c"
+  integrity sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+
 "@ethersproject/abstract-signer@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
@@ -1051,6 +1064,17 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/abstract-signer@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
+  integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/address@^5.6.1", "@ethersproject/address@^5.7.0":
   version "5.7.0"
@@ -1063,12 +1087,30 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
 
+"@ethersproject/address@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
+  integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+
 "@ethersproject/base64@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
   integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/base64@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.8.0.tgz#61c669c648f6e6aad002c228465d52ac93ee83eb"
+  integrity sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
 
 "@ethersproject/basex@^5.7.0":
   version "5.7.0"
@@ -1087,6 +1129,15 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bignumber@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
+  integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@^5.6.1", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
@@ -1094,12 +1145,26 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/bytes@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
+  integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/constants@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
   integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/constants@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
+  integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
 
 "@ethersproject/contracts@^5.6.2", "@ethersproject/contracts@^5.7.0":
   version "5.7.0"
@@ -1131,6 +1196,21 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hash@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.8.0.tgz#b8893d4629b7f8462a90102572f8cd65a0192b4c"
+  integrity sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/hdnode@^5.7.0":
   version "5.7.0"
@@ -1177,10 +1257,23 @@
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
+  integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/logger@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.8.0.tgz#f0232968a4f87d29623a0481690a2732662713d6"
+  integrity sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==
 
 "@ethersproject/networks@^5.7.0":
   version "5.7.1"
@@ -1188,6 +1281,13 @@
   integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/networks@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.8.0.tgz#8b4517a3139380cba9fb00b63ffad0a979671fde"
+  integrity sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/pbkdf2@^5.7.0":
   version "5.7.0"
@@ -1203,6 +1303,13 @@
   integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/properties@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.8.0.tgz#405a8affb6311a49a91dabd96aeeae24f477020e"
+  integrity sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/providers@^5.6.8", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
@@ -1246,6 +1353,14 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/rlp@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.8.0.tgz#5a0d49f61bc53e051532a5179472779141451de5"
+  integrity sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/sha2@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
@@ -1267,6 +1382,18 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
+"@ethersproject/signing-key@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.8.0.tgz#9797e02c717b68239c6349394ea85febf8893119"
+  integrity sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    bn.js "^5.2.1"
+    elliptic "6.6.1"
+    hash.js "1.1.7"
+
 "@ethersproject/strings@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
@@ -1275,6 +1402,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/strings@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.8.0.tgz#ad79fafbf0bd272d9765603215ac74fd7953908f"
+  integrity sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/transactions@^5.7.0":
   version "5.7.0"
@@ -1290,6 +1426,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
     "@ethersproject/signing-key" "^5.7.0"
+
+"@ethersproject/transactions@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.8.0.tgz#1e518822403abc99def5a043d1c6f6fe0007e46b"
+  integrity sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
 
 "@ethersproject/units@^5.7.0":
   version "5.7.0"
@@ -1331,6 +1482,17 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/web@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.8.0.tgz#3e54badc0013b7a801463a7008a87988efce8a37"
+  integrity sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==
+  dependencies:
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/wordlists@^5.7.0":
   version "5.7.0"
@@ -3788,6 +3950,19 @@ elliptic@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
+elliptic@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/stamp/issues/410

This PR adds the support for resolving:

- address -> .bnb name
- .bnb name -> address 

Which will allow the snapshot UI to display .bnb name associated to an address.

## Test

```bash
curl \
  -X POST \
  -H 'Content-Type: application/json' \
  -d '  {
    "method": "lookup_addresses",
    "params": ["0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6", "0xb5932a6B7d50A966AEC6C74C97385412Fb497540", "0x2e552E3aD9f7446e9caB378c008315E0C26c0398"]
  }' \
  'http://localhost:3008'
```

Will return 

```json
{
  "jsonrpc": "2.0",
  "result": {
    "0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6": "boorger.eth",
    "0xb5932a6B7d50A966AEC6C74C97385412Fb497540": "spaceid.bnb",
    "0x2e552E3aD9f7446e9caB378c008315E0C26c0398": "allen.bnb"
  },
  "id": null
}
```

NOTE: first one (`boorger.eth`) will show the .eth first due to priority, even if it has a .bnb name (https://bscscan.com/address/0x220bc93d88c0af11f1159ea89a885d5add3a7cf6).

```bash
curl \
  -X POST \
  -H 'Content-Type: application/json' \
  -d '  {
    "method": "resolve_names",
    "params": ["boorger.bnb", "hello-world-from-mars.bnb", "spaceid.bnb", "snapshot.bnb"]
  }' \
  'http://localhost:3008'
```

Will return 

```json
{
  "jsonrpc": "2.0",
  "result": {
    "boorger.bnb": "0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6",
    "spaceid.bnb": "0xb5932a6B7d50A966AEC6C74C97385412Fb497540",
    "snapshot.bnb": "0xcC478222804b7AA3505272B702C0c2Df65e10976"
  },
  "id": null
}
```