### PR TITLE
chore: remove polygon from snapshot resolver

### DIFF
--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -12,7 +12,6 @@ const API_URLS = {
   's-tn': `${process.env.HUB_URL_TN ?? 'https://testnet.hub.snapshot.org'}/graphql`,
   // SX mainnets
   eth: UNIFIED_API_URL,
-  matic: UNIFIED_API_URL,
   arb1: UNIFIED_API_URL,
   oeth: UNIFIED_API_URL,
   base: UNIFIED_API_URL,

--- a/test/integration/resolvers/space-sx.test.ts
+++ b/test/integration/resolvers/space-sx.test.ts
@@ -24,13 +24,6 @@ describe('resolvers', () => {
         expect(result.length).toBeGreaterThan(100);
       });
 
-      it('should resolve on polygon', async () => {
-        const result = await resolvers['space-sx']('0x80D0Ffd8739eABF16436074fF64DC081c60C833A');
-
-        expect(result).toBeInstanceOf(Buffer);
-        expect(result.length).toBeGreaterThan(100);
-      });
-
       it('should resolve on optimism', async () => {
         const result = await resolvers['space-sx']('0x2EF7E7CF469f5296011664682D58b57D38a3c83f');
 


### PR DESCRIPTION
This PR removes the polygon network from the list of supported network by snapshot-x api

Resolver is dead since the removal of the polygon network on sx, leading to failing test.