### PR TITLE
fix: use shortTtl for empty address resolver cache entries

### DIFF
--- a/src/addressResolvers/cache.ts
+++ b/src/addressResolvers/cache.ts
@@ -21,7 +21,9 @@ export function setCache(payload: Record<string, string>) {
 
   const transaction = redis.multi();
   Object.entries(payload).map(([key, value]) =>
-    transaction.set(`${KEY_PREFIX}:${key}`, value || '', { EX: constants.ttl })
+    transaction.set(`${KEY_PREFIX}:${key}`, value || '', {
+      EX: value ? constants.ttl : constants.shortTtl
+    })
   );
 
   return transaction.exec();


### PR DESCRIPTION
### Issue

Test case on sx-monorepo fail with
<img width="1116" height="344" alt="image" src="https://github.com/user-attachments/assets/d8761f32-1638-4be9-aedc-0973c59b1316" />

This was because at some point, `wanki.moe`. returned null and the cache stored it


## Summary
- Failed name resolutions were cached with the same 12h TTL as successful ones
- A transient failure (e.g. a 5s CCIP-read timeout) could block a valid name from resolving for up to 12 hours — hit this with `wanki.moe`, which resolves fine via ethers but returned `{}` from stamp because of a stale empty cache entry
- Empty values now expire after `shortTtl` (1h); real resolutions keep the full `ttl` (12h)

## Test plan

Run locally (`yarn start`, listens on :3008) with Redis available.

**Trigger a successful resolution — should be cached 12h:**
```bash
curl -s -X POST http://localhost:3008 \
  -H "Content-Type: application/json" \
  -d '{"method":"resolve_names","params":["vitalik.eth"],"network":1}'
# {"jsonrpc":"2.0","result":{"vitalik.eth":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"},"id":null}

redis-cli TTL address-resolvers:vitalik.eth
# ~43200 (ttl)
```

**Trigger an unresolvable name — should be cached 1h (shortTtl), not 12h:**
```bash
curl -s -X POST http://localhost:3008 \
  -H "Content-Type: application/json" \
  -d '{"method":"resolve_names","params":["nonexistent-random-name-xyz.com"],"network":1}'
# {"jsonrpc":"2.0","result":{},"id":null}

redis-cli TTL address-resolvers:nonexistent-random-name-xyz.com
# ~3600 (shortTtl) — before this fix it was ~43200
```

**Clear cache endpoint still works:**
```bash
curl -s http://localhost:3008/clear/name/vitalik.eth
# {"status":"ok"}
```

- [ ] Existing cache integration tests still pass
- [ ] TTL values on Redis keys match expected (12h positive, 1h empty)