### PR TITLE
fix(ens): resolve names set via off-chain resolvers (CCIP-Read)

### DIFF
--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -43,6 +43,20 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
     );
     const validNames = normalizeEns(reverseRecords);
 
+    // The batch contract only reads on-chain reverse records. Names served by
+    // off-chain resolvers (CCIP-Read) need provider.lookupAddress, which follows
+    // the OffchainLookup flow via the ENS UniversalResolver.
+    const missing = normalizedAddresses.map((_, i) => i).filter(i => !validNames[i]);
+    const lookups = await Promise.allSettled(
+      missing.map(idx => provider.lookupAddress(normalizedAddresses[idx]))
+    );
+    const fallbackNames = normalizeEns(
+      lookups.map(r => (r.status === 'fulfilled' && r.value) || '')
+    );
+    missing.forEach((idx, j) => {
+      if (fallbackNames[j]) validNames[idx] = fallbackNames[j];
+    });
+
     return Object.fromEntries(
       normalizedAddresses
         .map((address, index) => [address, validNames[index]])

--- a/test/integration/addressResolvers/ens.test.ts
+++ b/test/integration/addressResolvers/ens.test.ts
@@ -10,3 +10,15 @@ testAddressResolver({
   blankAddress: '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1',
   invalidDomains: ['domain.crypto', 'domain.lens', 'domain.com']
 });
+
+describe('ENS address resolver: CCIP-Read fallback', () => {
+  // avsa.eth's primary name is set via an off-chain resolver that the batch
+  // getNames contract doesn't follow, so the fallback to provider.lookupAddress
+  // is required.
+  it('resolves names that the batch contract misses', async () => {
+    const address = '0x809FA673fe2ab515FaA168259cB14E2BeDeBF68e';
+    await expect(lookupAddresses([address])).resolves.toEqual({
+      [address]: 'avsa.eth'
+    });
+  }, 15e3);
+});


### PR DESCRIPTION
Closes snapshot-labs/workflow#810

## The issue

Some ENS addresses have a primary name set but `lookup_addresses` returns nothing for them. Example: `0x809FA673fe2ab515FaA168259cB14E2BeDeBF68e` should resolve to `avsa.eth` (Avsa, ENS co-founder), and [app.ens.domains shows it correctly](https://app.ens.domains/0x809fa673fe2ab515faa168259cb14e2bedebf68e). Stamp doesn't, so anything that uses stamp (snapshot.box profile pages, vote lists, etc.) shows a truncated address instead of the name.

## Why

Stamp uses the on-chain batch `ReverseRecords` contract (`0x3671aE…`) to look up names. That contract does:

1. Read the reverse record on-chain → gets the name.
2. Verify it by calling `addr()` on the forward resolver.

Modern ENS primary names — set via the new app.ens.domains flow, L2 names, namestone-style records, cb.id subdomains — store the forward address **off-chain** behind a CCIP-Read ([EIP-3668](https://eips.ethereum.org/EIPS/eip-3668)) resolver. The batch contract uses a plain `staticcall`, can't follow the off-chain redirect, so verification fails and it returns an empty string.

## Fix

When the batch contract returns empty for an address, fall back to `provider.lookupAddress(address)`. ethers handles CCIP-Read natively (via the ENS UniversalResolver), so it resolves these names correctly.

Standard addresses are unaffected — they still go through the fast batch path in a single RPC.

## How to test

Run stamp locally (`yarn dev`), then:

```bash
# Before this fix: returns {}
# After this fix: returns { "0x809FA673…F68e": "avsa.eth" }
curl -X POST http://localhost:3003 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "lookup_addresses",
    "params": ["0x809FA673fe2ab515FaA168259cB14E2BeDeBF68e"]
  }'
```

If Redis is running and has a stale empty entry cached for this address, clear it first:

```bash
curl -X POST http://localhost:3003 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "clear_cache",
    "params": ["0x809FA673fe2ab515FaA168259cB14E2BeDeBF68e", "address"]
  }'
```

### Regression check

Standard on-chain ENS still resolves via the fast path:

```bash
curl -X POST http://localhost:3003 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "lookup_addresses",
    "params": [
      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
      "0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC"
    ]
  }'
# → { "0xd8dA…": "vitalik.eth", "0xE6D0…": "sdntestens.eth" }
```

## Deployment note

Stamp's Redis cache stores empty results for 12h (`constants.ttl`). After deploy, affected addresses won't show their new names until either the cache expires or `clear_cache` is called per address.