### PR TITLE
fix: resolve starknet NFT images via content-type detection

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@
  */
 
 export default {
+  roots: ['<rootDir>/test'],
   clearMocks: true,
   collectCoverage: true,
   coverageDirectory: 'coverage',

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -1,8 +1,8 @@
-import fetch from 'node-fetch';
+import axios from 'axios';
 import { getUrl, resize } from '../utils';
 import { provider as getProvider } from '../addressResolvers/utils';
 import { max } from '../constants.json';
-import { fetchHttpImage } from './utils';
+import { axiosDefaultParams, fetchHttpImage } from './utils';
 
 const DEFAULT_IMG_URL = 'https://starknet.id/api/identicons/0';
 const provider = getProvider('0x534e5f4d41494e');
@@ -33,24 +33,36 @@ async function getImage(domainOrAddress: string): Promise<string | null> {
   return (await provider.getStarkProfile(address))?.profilePicture ?? null;
 }
 
+async function fetchImageOrMetadata(url: string): Promise<Buffer | { image?: string }> {
+  const response = await axios({
+    url,
+    responseType: 'arraybuffer',
+    ...axiosDefaultParams
+  });
+  const contentType: string = response.headers['content-type'] || '';
+  const data = Buffer.from(response.data);
+  if (contentType.includes('application/json')) {
+    return JSON.parse(data.toString('utf-8'));
+  }
+  return data;
+}
+
 export default async function resolve(domainOrAddress: string) {
   try {
-    let img_url = await getImage(domainOrAddress);
+    const img_url = await getImage(domainOrAddress);
 
-    if (img_url === DEFAULT_IMG_URL) return false;
+    if (!img_url || img_url === DEFAULT_IMG_URL) return false;
 
-    if (img_url?.startsWith('https://api.starkurabu.com')) {
-      const response = await fetch(img_url);
-      const data = await response.json();
+    const fetched = await fetchImageOrMetadata(getUrl(img_url));
+    const buffer = Buffer.isBuffer(fetched)
+      ? fetched
+      : fetched.image
+      ? await fetchHttpImage(getUrl(fetched.image))
+      : null;
 
-      img_url = data.image;
-    }
+    if (!buffer) return false;
 
-    if (!img_url) return false;
-
-    const input = await fetchHttpImage(getUrl(img_url));
-
-    return await resize(input, max, max);
+    return await resize(buffer, max, max);
   } catch (e) {
     return false;
   }

--- a/test/integration/resolvers/starknet.test.ts
+++ b/test/integration/resolvers/starknet.test.ts
@@ -33,7 +33,7 @@ describe('resolvers', () => {
 
     describe('with an NFT image', () => {
       it('should resolve with handle', async () => {
-        const result = await resolvers.starknet('fricoben.stark');
+        const result = await resolvers.starknet('pragmarob.stark');
 
         expect(result).toBeInstanceOf(Buffer);
         expect(result.length).toBeGreaterThan(1000);
@@ -41,7 +41,7 @@ describe('resolvers', () => {
 
       it('should resolve with address', async () => {
         const result = await resolvers.starknet(
-          '0x072d4f3fa4661228ed0c9872007fc7e12a581e000fad7b8f3e3e5bf9e6133207'
+          '0x007b275f7524f39b99a51c7134bc44204fedc5dd1e982e920eb2047c6c2a71f0'
         );
 
         expect(result).toBeInstanceOf(Buffer);


### PR DESCRIPTION
## Summary
- Replace the hardcoded `api.starkurabu.com` check in the starknet resolver with a generic content-type-based handler, so any JSON metadata response is followed to its inner `image` field.
- Refresh the NFT image test fixtures (`fricoben.stark` → `pragmarob.stark`) to addresses/handles that currently resolve.
- Scope Jest to `test/` via `roots` in `jest.config.ts`.

> Note: this PR fixes only the starknet resolver test. Other tests in the suite may still fail — those are out of scope here and will be addressed separately.

## Test plan
- [x] `yarn jest test/integration/resolvers/starknet.test.ts` — 5/5 pass
- [ ] Verify the app serves an image at: http://localhost:3008/avatar/0x007b275f7524f39b99a51c7134bc44204fedc5dd1e982e920eb2047c6c2a71f0?resolver=starknet
  - Expected: matches the IPFS-resolved NFT image https://snapshot.4everland.link/ipfs/QmZS7maV678eJW7wJaVXJc28aKXzdZrwS1hmBmSy6bUVJh/1925.jpg (Duo #1925)