### PR TITLE
test: fix flaky integration test fixtures (lookupDomains, getOwner shibarium)

### DIFF
--- a/test/integration/getOwner.test.ts
+++ b/test/integration/getOwner.test.ts
@@ -35,7 +35,9 @@ describe('getOwner', () => {
     };
 
     it('should return an address for shibarium', async () => {
-      // Resolves true as soon as any entry matches; false only if all rotted.
+      // Fires all checks concurrently; the assertion resolves true as soon as
+      // one matches (remaining in-flight requests are not cancelled), and
+      // false only once all have completed without a match (all rotted).
       const atLeastOneResolves = await new Promise<boolean>(resolve => {
         const entries = Object.entries(UNCLAIMED_SHIBARIUM);
         let pending = entries.length;

--- a/test/integration/getOwner.test.ts
+++ b/test/integration/getOwner.test.ts
@@ -14,13 +14,44 @@ describe('getOwner', () => {
   });
 
   describe('on unclaimed names', () => {
-    // This may stop working since we don't own this domain.
-    // In such case, go to https://www.shibariumscan.io/name-domains?only_active=true
-    // and find a domain that is not claimed (owner = 0x1A039289Af80a806f562396569fBC6d4A862C25c),
-    // but has a resolved address.
+    // Unclaimed mainnet .shib domains: registered through the D3 partner but
+    // never minted on-chain, so the D3 API returns them with no `owner` and
+    // getOwner() must fall back to the DNS-resolved address. Each entry rots
+    // individually when it gets claimed or expires, so the test asserts that
+    // AT LEAST ONE of this set still resolves to its expected address.
+    //
+    // When this test fails, the whole set has rotted. To refresh it, list the
+    // NFTs held by the unclaimed escrow 0x1A039289Af80a806f562396569fBC6d4A862C25c
+    // (https://shibariumscan.io/api/v2/addresses/<escrow>/nft) and keep names
+    // where getOwner(name, '109') returns a non-zero address.
+    const UNCLAIMED_SHIBARIUM: Record<string, string> = {
+      'jaguars.shib': '0x256102D1Df3DE85B59fD94f4aF9F78552B7Ebe13',
+      'mini.shib': '0xC4De848f922CD6357bDB666009204EF923702A4E',
+      'lib3rty.shib': '0x29B55b579b4A1A16bB445e2C56CB4d13af5ca095',
+      'haihai.shib': '0xbF747B8ff8f5Eaf088AD19BBCd6cD3D5bD237C2B',
+      '1980december12.shib': '0x18C2a024672293024069bB24f43595460065E84d',
+      'kbeauty.shib': '0x110edF92d6c3dBcFB4dadb67894199A565413817',
+      'honmoku.shib': '0x5B98E554a5B188D4CAD034a06C28484880eE4A16'
+    };
+
     it('should return an address for shibarium', async () => {
-      const result = await getOwner('scoobysnacks.shib', '109');
-      expect(result).toContain('0xa226a85fF338f5015cd3Da6a987CD08D70619977');
+      // Resolves true as soon as any entry matches; false only if all rotted.
+      const atLeastOneResolves = await new Promise<boolean>(resolve => {
+        const entries = Object.entries(UNCLAIMED_SHIBARIUM);
+        let pending = entries.length;
+        entries.forEach(([handle, address]) => {
+          getOwner(handle, '109')
+            .then(result => {
+              if (result.includes(address)) resolve(true);
+            })
+            .catch(() => undefined)
+            .finally(() => {
+              if (--pending === 0) resolve(false);
+            });
+        });
+      });
+
+      expect(atLeastOneResolves).toBe(true);
     });
 
     it('should return an address for puppynet', async () => {

--- a/test/integration/lookupDomains.test.ts
+++ b/test/integration/lookupDomains.test.ts
@@ -56,7 +56,8 @@ describe('lookupDomains', () => {
 
   it('should return all the addresses from the given chain', async () => {
     const result = await lookupDomains('0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6', ['1', '109']);
-    expect(result).toEqual(['boorger.eth', 'boorger.shib']);
+    expect(result).toContain('boorger.eth');
+    expect(result).toContain('boorger.shib');
   });
 
   it('should return an array of addresses for unstoppable domains', async () => {


### PR DESCRIPTION
## What

Two integration tests were failing on `master` due to external data drift, not code bugs:

- **`lookupDomains` › "should return all the addresses from the given chain"** — the test address acquired a new ENS subdomain (`whopper.boorger.eth`), and `toEqual` is order-sensitive (ENS subgraph order isn't guaranteed). Replaced the brittle exact-match with `toContain` for the two names that prove cross-chain aggregation (chain `1` ENS + chain `109` shibarium). This matches the `toContain` pattern used by every other positive assertion in the file.

- **`getOwner` › "on unclaimed names › should return an address for shibarium"** — the fixture `scoobysnacks.shib` was deleted (D3 API now returns 404, so `getOwner` returns `0x0…0`). Replaced it with a self-healing check over **7 verified unclaimed-but-resolved `.shib` domains** that passes if **at least one** still resolves. Individual rot no longer breaks CI; the test only fails if all 7 rot at once. The comment documents how to regenerate the set.

## Out of scope (no change here)

- **puppynet** failures → #422 · **starknet** → #432.

## Verification

- `lookupDomains.test.ts`: 12/12 pass
- `getOwner` unclaimed-shibarium: passes once any of the 7 names resolves (all 7 checks fire concurrently, ~6s)
- e2e `api.test.ts`: 13 passed, 0 failed
- `tsc --noEmit` and eslint clean

## Test plan

Hit the `get_owner` JSON-RPC method for the new Shibarium fixture (chain `109`). `.env` must contain `D3_API_KEY_MAINNET` — unclaimed names need the D3 lookup, otherwise `getOwner` short-circuits to `0x0…0`.

```bash
yarn dev   # http://localhost:3008

curl -s http://localhost:3008/ \
  -H 'Content-Type: application/json' \
  -d '{"method":"get_owner","params":"jaguars.shib","network":"109"}'
```

Expected:

```json
{"jsonrpc":"2.0","result":"0x256102D1Df3DE85B59fD94f4aF9F78552B7Ebe13","id":null}
```

Any of the 7 names in the set can be checked the same way (swap `params`); the test passes if at least one returns its expected address:

| params (handle) | expected `result` |
|---|---|
| jaguars.shib | 0x256102D1Df3DE85B59fD94f4aF9F78552B7Ebe13 |
| mini.shib | 0xC4De848f922CD6357bDB666009204EF923702A4E |
| lib3rty.shib | 0x29B55b579b4A1A16bB445e2C56CB4d13af5ca095 |
| haihai.shib | 0xbF747B8ff8f5Eaf088AD19BBCd6cD3D5bD237C2B |
| 1980december12.shib | 0x18C2a024672293024069bB24f43595460065E84d |
| kbeauty.shib | 0x110edF92d6c3dBcFB4dadb67894199A565413817 |
| honmoku.shib | 0x5B98E554a5B188D4CAD034a06C28484880eE4A16 |