### PR TITLE
fix(addressResolvers): silence wrapped ethers 504 errors

### DIFF
--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -47,14 +47,15 @@ export function normalizeHandles(handles: Handle[]): Handle[] {
 }
 
 export function isSilencedError(error: any, additionalMessages?: string[]): boolean {
+  const messages = [
+    'invalid token ID',
+    'is not supported',
+    'execution reverted',
+    'status=504',
+    ...(additionalMessages || [])
+  ];
   return (
-    [
-      'invalid token ID',
-      'is not supported',
-      'execution reverted',
-      'status=504',
-      ...(additionalMessages || [])
-    ].some(m => error.message?.includes(m)) ||
+    messages.some(m => error.message?.includes(m) || error.error?.message?.includes(m)) ||
     ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET', 504].some(c =>
       (error.error?.code || error.error?.status || error.code)?.includes(c)
     )

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -57,7 +57,7 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
   return (
     messages.some(m => error.message?.includes(m) || error.error?.message?.includes(m)) ||
     ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET', 504].some(c =>
-      (error.error?.code || error.error?.status || error.code)?.includes(c)
+      String(error.error?.code || error.error?.status || error.code || '').includes(String(c))
     )
   );
 }

--- a/test/integration/addressResolvers/utils.test.ts
+++ b/test/integration/addressResolvers/utils.test.ts
@@ -1,4 +1,8 @@
-import { normalizeHandles, withoutEmptyAddress } from '../../../src/addressResolvers/utils';
+import {
+  isSilencedError,
+  normalizeHandles,
+  withoutEmptyAddress
+} from '../../../src/addressResolvers/utils';
 
 describe('utils', () => {
   describe('normalizeHandles', () => {
@@ -43,6 +47,26 @@ describe('utils', () => {
 
     it('should handle empty object', () => {
       expect(withoutEmptyAddress({})).toEqual({});
+    });
+  });
+
+  describe('isSilencedError', () => {
+    it('silences a wrapped ethers 504 (CALL_EXCEPTION around SERVER_ERROR)', () => {
+      // Shape observed from Sentry STAMP-4B: JsonRpcProvider.checkError wraps the
+      // original SERVER_ERROR as error.error and re-throws with code CALL_EXCEPTION.
+      const wrapped = {
+        message:
+          'missing revert data in call exception; Transaction reverted without a reason string',
+        code: 'CALL_EXCEPTION',
+        error: {
+          message:
+            'bad response (status=504, headers={}, body="error code: 504", code=SERVER_ERROR, version=web/5.7.1)',
+          code: 'SERVER_ERROR',
+          status: 504
+        }
+      };
+
+      expect(isSilencedError(wrapped)).toBe(true);
     });
   });
 });

--- a/test/integration/addressResolvers/utils.test.ts
+++ b/test/integration/addressResolvers/utils.test.ts
@@ -68,5 +68,11 @@ describe('utils', () => {
 
       expect(isSilencedError(wrapped)).toBe(true);
     });
+
+    it('does not throw when nested status is a number with no code', () => {
+      const wrapped = { error: { status: 504 } };
+      expect(() => isSilencedError(wrapped)).not.toThrow();
+      expect(isSilencedError(wrapped)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
`isSilencedError` already silences 504s via the `'status=504'` message match, but only on `error.message`. Ethers' `JsonRpcProvider.checkError` wraps a `SERVER_ERROR` (504) inside a `CALL_EXCEPTION`, putting the original on `error.error`. The outer `error.message` becomes `"missing revert data in call exception..."` (no `status=504` substring), so wrapped 504s leaked through to Sentry.

This PR:
- Broadens the message check to also inspect `error.error?.message` — same patterns, one extra layer.
- Stringifies the resolved `code/status` before `.includes` — a latent bug where `(504)?.includes(...)` would throw (optional chaining doesn't short-circuit on truthy numbers). Reachable for error shapes with `status` but no `code`.

Closes:
- [STAMP-4B](https://snapshot-labs.sentry.io/issues/STAMP-4B)
- [STAMP-28](https://snapshot-labs.sentry.io/issues/STAMP-28) (39k events)
- [STAMP-30](https://snapshot-labs.sentry.io/issues/STAMP-30)

Related (same wrapping pattern but `status=500`, not silenced by this PR — separate decision): STAMP-2X, STAMP-3V, STAMP-3W, STAMP-2Y.

## Test plan
- [x] Unit test reproduces the wrapped 504 shape from Sentry — fails on `master`, passes with the fix
- [x] Unit test for `{ error: { status: 504 } }` — no throw, silences correctly
- [x] `yarn typecheck`
- [x] `yarn lint`