### PR TITLE
fix(addressResolvers): silence axios 504 errors (STAMP-7)

### DIFF
--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -54,10 +54,11 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
     'status=504',
     ...(additionalMessages || [])
   ];
+  const codes = [error.error?.code, error.error?.status, error.code, error.response?.status];
   return (
     messages.some(m => error.message?.includes(m) || error.error?.message?.includes(m)) ||
     ['TIMEOUT', 'ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET', 504].some(c =>
-      String(error.error?.code || error.error?.status || error.code || '').includes(String(c))
+      codes.some(v => String(v ?? '').includes(String(c)))
     )
   );
 }

--- a/test/integration/addressResolvers/utils.test.ts
+++ b/test/integration/addressResolvers/utils.test.ts
@@ -74,5 +74,29 @@ describe('utils', () => {
       expect(() => isSilencedError(wrapped)).not.toThrow();
       expect(isSilencedError(wrapped)).toBe(true);
     });
+
+    it('silences an axios 504 (status on error.response)', () => {
+      // Shape observed from Sentry STAMP-7: axios throws with the HTTP status
+      // on error.response.status, while error.code is 'ERR_BAD_RESPONSE'.
+      // The previous `||` chain short-circuited on error.code and never
+      // reached error.response.status.
+      const axiosError = {
+        message: 'Request failed with status code 504',
+        code: 'ERR_BAD_RESPONSE',
+        response: { status: 504 }
+      };
+
+      expect(isSilencedError(axiosError)).toBe(true);
+    });
+
+    it('does not silence a non-504 axios error', () => {
+      const axiosError = {
+        message: 'Request failed with status code 500',
+        code: 'ERR_BAD_RESPONSE',
+        response: { status: 500 }
+      };
+
+      expect(isSilencedError(axiosError)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `isSilencedError` chained candidate fields with `||`, so axios's `error.code = 'ERR_BAD_RESPONSE'` short-circuited and the 504 on `error.response.status` was never checked
- Iterate each candidate independently and include `error.response?.status`, which is where axios surfaces the upstream HTTP status
- Follow-up to #434, which only handled the wrapped-ethers shape

## Context
[STAMP-7](https://snapshot-labs.sentry.io/issues/STAMP-7) is the top recurring error on the avatar endpoints (256k+ occurrences). Breadcrumbs trace it to `hub.snapshot.org/graphql` returning 504, captured at `src/addressResolvers/snapshot.ts:33` because `isSilencedError` didn't recognize the axios error shape.

## Test plan
- [x] Added two unit tests covering the axios 504 shape and a non-504 axios error (to guard against over-silencing)
- [x] Existing wrapped-ethers 504 test still passes
- [ ] Monitor STAMP-7 occurrence rate after deploy

Fixes STAMP-7