### PR TITLE
test: disable coverage by default for faster local runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test
-        run: yarn test
+        run: yarn test:coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@
 export default {
   roots: ['<rootDir>/test'],
   clearMocks: true,
-  collectCoverage: true,
+  collectCoverage: false,
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
   collectCoverageFrom: ['./src/**'],

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "dev": "nodemon src/index.ts",
     "start": "node dist/src/index.js",
     "test": "jest",
-    "test:integration": "jest --runInBand --collectCoverage=false --forceExit test/integration",
-    "test:e2e": "jest --runInBand --collectCoverage=false --forceExit test/e2e/"
+    "test:coverage": "jest --coverage",
+    "test:integration": "jest --runInBand --forceExit test/integration",
+    "test:e2e": "jest --runInBand --forceExit test/e2e/"
   },
   "dependencies": {
     "@adraffy/ens-normalize": "^1.10.0",


### PR DESCRIPTION
## Summary
- `jest.config.ts`: default `collectCoverage` to `false` so `yarn test` runs without coverage overhead locally
- `package.json`: add `test:coverage` script; drop now-redundant `--collectCoverage=false` from `test:integration` and `test:e2e`
- `.github/workflows/test.yml`: CI now runs `yarn test:coverage` so Codecov still gets reports

## Test plan
- [ ] `yarn test` runs without generating a `coverage/` directory
- [ ] `yarn test:coverage` generates coverage as before
- [ ] CI run uploads coverage to Codecov successfully