### PR TITLE
fix(addressResolvers): skip non-EVM addresses in shibarium lookup

### DIFF
--- a/src/addressResolvers/shibarium.ts
+++ b/src/addressResolvers/shibarium.ts
@@ -1,6 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { Address, Handle } from '../utils';
-import { FetchError, isSilencedError, withoutEmptyValues } from './utils';
+import { FetchError, isEvmAddress, isSilencedError, withoutEmptyValues } from './utils';
 import { DNSConnect } from '@webinterop/dns-connect';
 import constants from '../constants.json';
 
@@ -9,6 +9,10 @@ const CHAIN_ID = '109';
 const NETWORK = 'BONE';
 const TLD = 'shib';
 
+function normalizeAddresses(addresses: Address[]): Address[] {
+  return addresses.filter(isEvmAddress);
+}
+
 // TODO: Support unicode names, by converting to punycode
 // see https://docs.d3.app/resolve-d3-names#d3-connect-sdk
 function normalizeHandles(handles: Handle[]): Handle[] {
@@ -16,17 +20,21 @@ function normalizeHandles(handles: Handle[]): Handle[] {
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
+  const normalizedAddresses = normalizeAddresses(addresses);
+
+  if (normalizedAddresses.length === 0) return {};
+
   try {
     const dnsConnect = new DNSConnect({
       dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
     });
 
     const results = await Promise.all(
-      addresses.map(async address => dnsConnect.reverseResolve(address, NETWORK))
+      normalizedAddresses.map(async address => dnsConnect.reverseResolve(address, NETWORK))
     );
 
     return withoutEmptyValues(
-      Object.fromEntries(addresses.map((address, index) => [address, results[index]]))
+      Object.fromEntries(normalizedAddresses.map((address, index) => [address, results[index]]))
     );
   } catch (e) {
     if (!isSilencedError(e)) {

--- a/test/integration/addressResolvers/shibarium.test.ts
+++ b/test/integration/addressResolvers/shibarium.test.ts
@@ -10,3 +10,13 @@ testAddressResolver({
   blankAddress: '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
   invalidDomains: ['domain.crypto', 'domain.eth', 'domain.com', 'inexistent-domain-for-test.shib']
 });
+
+describe('Shibarium lookupAddresses() input filtering', () => {
+  // 64-hex Starknet-shaped addresses exceed the 63-octet DNS label limit when
+  // combined with the `0x` prefix, which caused @webinterop/dns-connect to throw.
+  // See STAMP-36.
+  it('drops non-EVM (Starknet-shaped) addresses without calling DNS', async () => {
+    const starknetAddress = '0x03fe982f868b8fa9077b26e318a46ecfd61685859664f192b7a96aaf3ab75843';
+    await expect(lookupAddresses([starknetAddress])).resolves.toEqual({});
+  });
+});

--- a/test/integration/addressResolvers/shibarium.test.ts
+++ b/test/integration/addressResolvers/shibarium.test.ts
@@ -19,4 +19,12 @@ describe('Shibarium lookupAddresses() input filtering', () => {
     const starknetAddress = '0x03fe982f868b8fa9077b26e318a46ecfd61685859664f192b7a96aaf3ab75843';
     await expect(lookupAddresses([starknetAddress])).resolves.toEqual({});
   });
+
+  it('returns results for valid EVM addresses even when mixed with non-EVM', async () => {
+    const evmAddress = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
+    const starknetAddress = '0x03fe982f868b8fa9077b26e318a46ecfd61685859664f192b7a96aaf3ab75843';
+    await expect(lookupAddresses([evmAddress, starknetAddress])).resolves.toEqual({
+      [evmAddress]: 'boorger.shib'
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds an `isEvmAddress` filter to `shibarium.lookupAddresses`, matching the pattern already used by every other EVM resolver (`ens`, `lens`, `spaceId`, `unstoppableDomains`).

## Root cause

64-hex Starknet-shaped inputs produce a first DNS label of `0x` + 64 hex = 66 characters, exceeding the RFC 1035 §2.3.4 limit of 63 octets. Cloudflare DoH responds with `{"error":"Invalid query name ..."}` and no `Status` field, so `@webinterop/dns-connect`'s DoH resolver throws ``Received error status from DNS server: undefined.``. Reproduced by `curl`ing the DoH endpoint directly with the exact `input.addresses` from Sentry. Behavior is deterministic for every Starknet address — consistent with the 15k+ event volume on STAMP-36.

The throw is caught at `src/addressResolvers/index.ts:56` (`catch (e) {}`), so user requests are unaffected, but `capture()` floods Sentry on every Starknet lookup.

## Test plan

- [x] New test in `test/integration/addressResolvers/shibarium.test.ts` feeds the exact STAMP-36 input and asserts `lookupAddresses(...)` resolves to `{}` without throwing or hitting DNS.
- [x] Existing shibarium integration tests still pass (7/7).
- [x] `yarn typecheck` clean.
- [x] `yarn lint` clean.

Fixes STAMP-36