### PR TITLE
chore: move CI to Node 22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,5 @@ jobs:
   lint:
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     with:
-      target: '18'
+      target: '22'
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
 
       - name: Setup Redis

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "engines": {
-    "node": ">=18.12"
+    "node": ">=22.6.0"
   },
   "scripts": {
     "generate-chains": "node ./dist/src/scripts/generate-chains.js",


### PR DESCRIPTION
## What

Move CI to Node 22 (Active LTS until Apr 2027):

- Workflow `target` set to `'22'` on lint, test, and create-sentry-release
- `package.json` `engines.node` set to `>=22.6.0` (matches sx-monorepo)

## Why

Node 18 is EOL. Newer `@snapshot-labs/eslint-config` requires `eslint-visitor-keys@5` whose engine needs `^20.19.0 || ^22.13.0 || >=24` — bumping CI to Node 22 unblocks the dependabot bump. Matches `blockfinder#505` (already merged) and `sx-monorepo` (already on Node 22).

## Test

CI `lint (22)` + `test (22)` should both go green on Node 22.

## ⚠️ Known blockers

- `sharp@^0.30.1` — no Node 22 prebuilt binary (sharp prebuilds start at 0.33+). Bump to `^0.33` (latest 0.34.5) in a separate PR landing first.
- `canvas@^3.2.3` — engine `^18.12.0 || >=20.9.0`. Should work on Node 22 but verify install actually fetches a prebuilt binary.