### PR TITLE
fix(addressResolvers): silence transient D3 DNS SERVFAIL errors (STAMP-36)

### DIFF
--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -52,6 +52,10 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
     'is not supported',
     'execution reverted',
     'status=504',
+    // SERVFAIL (2) is a transient external-resolver failure. Other statuses stay
+    // visible as they may signal a real problem (e.g. FORMERR 1 = malformed query);
+    // NXDOMAIN (3) never reaches here (dns-connect returns it as an empty result).
+    'Received error status from DNS server: 2.',
     ...(additionalMessages || [])
   ];
   const codes = [error.error?.code, error.error?.status, error.code, error.response?.status];

--- a/test/integration/addressResolvers/utils.test.ts
+++ b/test/integration/addressResolvers/utils.test.ts
@@ -98,5 +98,17 @@ describe('utils', () => {
 
       expect(isSilencedError(axiosError)).toBe(false);
     });
+
+    it('silences transient SERVFAIL DNS server status (2)', () => {
+      // @webinterop/dns-connect throws "Received error status from DNS server: N"
+      // for non-zero RCODEs. Status 2 (SERVFAIL) is a transient external-resolver
+      // failure. See STAMP-36.
+      expect(isSilencedError(new Error('Received error status from DNS server: 2.'))).toBe(true);
+    });
+
+    it('does not silence other DNS server statuses (e.g. FORMERR)', () => {
+      // Status 1 (FORMERR) indicates a malformed query on our side — keep it visible.
+      expect(isSilencedError(new Error('Received error status from DNS server: 1.'))).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Problem

The Shibarium/D3 address resolver calls `@webinterop/dns-connect`'s `reverseResolve`, which throws `Received error status from DNS server: N` for any non-zero DNS RCODE. Status 2 = **SERVFAIL**, a transient failure on D3's *public* DNS resolver. `isSilencedError` didn't recognize it, so every occurrence was captured to Sentry.

**Sentry issue:** [STAMP-36](https://snapshot-labs.sentry.io/issues/STAMP-36) — 15k+ events.

## Scope: SERVFAIL (2) only — not all DNS errors

`dns-connect` throws for every non-zero RCODE, so a blanket message match would silence *all* DNS errors. This intentionally silences **only status 2 (SERVFAIL)** — the transient resolver failure actually observed in STAMP-36.

Deliberately **left visible**:
- **1 FORMERR** (and other statuses) — would indicate a malformed query / real bug on our side
- **5 REFUSED** — could mean the resolver is rate-limiting/refusing us, which we'd want to know about
- **3 NXDOMAIN** — never reaches this throw; `dns-connect` already returns it as an empty result

## Follow-up to #437

[#437](https://github.com/snapshot-labs/stamp/pull/437) also targeted STAMP-36 by filtering non-EVM addresses (oversized DNS labels → error on a **missing** Status field). STAMP-36 kept firing because the dominant cause is a **present** non-zero Status (SERVFAIL) on valid EVM addresses — which the address filter never touches. (Same two-step pattern as STAMP-7: #434 → #435.)

## Root cause confirmed transient

Replayed the exact 11-address payload from the Sentry event against the live resolver 5× in a row — all succeeded.

## Test plan

- [x] `tsc --noEmit`: clean
- [x] `eslint`: clean
- [x] Unit tests: SERVFAIL (2) silenced; FORMERR (1) **not** silenced

Fixes STAMP-36
