### PR TITLE
fix(lookupDomains): absorb per-resolver failures

### DIFF
--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -26,7 +26,7 @@ export default async function lookupDomains(
 
   RESOLVERS.forEach(resolver => {
     chainIds.forEach(chain => {
-      promises.push(resolver(address, chain));
+      promises.push(resolver(address, chain).catch(() => []));
     });
   });
 

--- a/test/unit/lookupDomains.test.ts
+++ b/test/unit/lookupDomains.test.ts
@@ -1,0 +1,42 @@
+import { FetchError } from '../../src/addressResolvers/utils';
+import lookupDomains from '../../src/lookupDomains';
+import ens from '../../src/lookupDomains/ens';
+import shibarium from '../../src/lookupDomains/shibarium';
+import unstoppableDomains from '../../src/lookupDomains/unstoppableDomains';
+
+jest.mock('../../src/lookupDomains/ens', () => ({
+  __esModule: true,
+  DEFAULT_CHAIN_ID: '1',
+  default: jest.fn()
+}));
+jest.mock('../../src/lookupDomains/shibarium', () => ({
+  __esModule: true,
+  DEFAULT_CHAIN_ID: '109',
+  default: jest.fn()
+}));
+jest.mock('../../src/lookupDomains/unstoppableDomains', () => ({
+  __esModule: true,
+  DEFAULT_CHAIN_ID: '146',
+  default: jest.fn()
+}));
+
+const VALID_ADDRESS = '0x24F15402C6Bb870554489b2fd2049A85d75B982f';
+const CHAINS = ['1', '109', '146'];
+
+describe('lookupDomains - resolver failures', () => {
+  it('does not propagate a resolver failure and returns the other resolvers results', async () => {
+    (ens as jest.Mock).mockRejectedValue(new FetchError());
+    (shibarium as jest.Mock).mockResolvedValue(['boorger.shib']);
+    (unstoppableDomains as jest.Mock).mockResolvedValue([]);
+
+    await expect(lookupDomains(VALID_ADDRESS, CHAINS)).resolves.toEqual(['boorger.shib']);
+  });
+
+  it('returns an empty array when every resolver fails', async () => {
+    (ens as jest.Mock).mockRejectedValue(new FetchError());
+    (shibarium as jest.Mock).mockRejectedValue(new FetchError());
+    (unstoppableDomains as jest.Mock).mockRejectedValue(new FetchError());
+
+    await expect(lookupDomains(VALID_ADDRESS, CHAINS)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
Fix https://github.com/snapshot-labs/stamp/issues/493

## Roadmap context

Step **2 of 3** in cleaning up resolver error handling. End goal: resolvers throw raw errors, orchestrators own capture/silence policy, `FetchError` sentinel deleted, api.ts catch-all is a pure safety net for unexpected errors, and `lookup_domains` is best-effort.

1. **#492 (merged)** — stopgap: api.ts skips re-capturing `FetchError`, class gets a name/message. Fixed the Sentry noise (STAMP-6V / STAMP-35) at the boundary, changed no behavior.
2. **This PR** — behavior change, isolated on purpose: one failing resolver/chain no longer rejects the whole `lookup_domains` request; it contributes `[]` and the client gets a partial 200 instead of a 500.
3. **#496** — refactor, no behavior change: move capture into the orchestrators, delete per-resolver try/catch and the `FetchError` sentinel entirely. Blocked on this PR: its `lookupDomains` half (capture + swallow at index) only makes sense once partial success is the accepted contract.

## Summary

`lookupDomains` fans out over `[ens, shibarium, unstoppableDomains]` × chains via `Promise.all` with **no per-resolver error handling**. Each resolver captures (with context) or silences its own error and then throws a bare `FetchError`, which rejects the whole `Promise.all` and turns the entire request into a 500 — even when other resolvers succeeded.

> **Note (post-#492):** this PR originally also fixed the Sentry double-capture (STAMP-35): the escaped `FetchError` was re-captured context-free at api.ts. #492 has since fixed that at the boundary, so the Sentry motivation is gone. What remains — and what this PR is now solely about — is the **request behavior**: best-effort partial results instead of all-or-nothing.

## Why this is the right fix

Propagation was correct in the **single-resolver origin** (#231), where `lookupDomains` was one ENS call and api.ts was its only error boundary. It was never revisited when the function became a fan-out (#362, #394) — both pure feature additions that didn't touch error handling. The sibling fan-out `addressResolvers._call` already swallows per-resolver failures with `try { … } catch {}` for exactly this reason.

This change brings `lookupDomains` in line with that established pattern: catch each resolver's rejection and return `[]`, so one failing chain no longer rejects the lookup or escapes to api.ts. The api.ts catch remains a genuine safety net for *unexpected* errors (e.g. `getOwner`); informative capture + silencing stay at the resolver layer (until #496 centralizes them).

## Behavior change

Previously, **any** single resolver/chain failure rejected the whole `lookup_domains` request → the client got a **500**. Now the failing resolver contributes `[]` and the other chains' results are still returned → the client gets a **partial 200**.

This path is **not cached** (no redis/cache layer on `lookup_domains`, unlike `lookup_addresses`/`resolve_names`), so the partial result is per-request only and self-corrects on the next call — there is no risk of caching an incomplete result. The new behavior matches how `addressResolvers` already treats per-resolver failures.

Side effect on #492's code: once failures are absorbed here, no `FetchError` reaches the api.ts catch-all from this path anymore, making the `instanceof FetchError` skip dead code on the live path. That's expected — #496 deletes it along with the class.

## Test plan

- [x] Added `test/unit/lookupDomains.test.ts` (fully mocked resolvers; CI runs it via `test:coverage`) — a resolver rejecting no longer propagates and the other resolvers' results are returned; all-fail returns `[]`. Fails before the change, passes after.
- [x] `yarn typecheck`
- [x] `yarn lint`