### PR TITLE
feat(resolvers): add Basename (Base App) avatar resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ cdn.stamp.fyi/**token**/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e
 
 ### Identifier
 
-The identifier can be an address (case insensitive), ENS name, CAIP-10, EIP-3770, DID or Starknet domain.
+The identifier can be an address (case insensitive), ENS name, Basename, CAIP-10, EIP-3770, DID or Starknet domain.
 
 #### Examples
 
 cdn.stamp.fyi/avatar/**0xeF8305E140ac520225DAf050e2f71d5fBcC543e7**  
 cdn.stamp.fyi/avatar/**fabien.eth**  
+cdn.stamp.fyi/avatar/**jesse.base.eth**  
 cdn.stamp.fyi/token/**eth:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**  
 cdn.stamp.fyi/token/**eip155:1:0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e**
 cdn.stamp.fyi/avatar/**checkpoint.stark**
@@ -52,6 +53,10 @@ cdn.stamp.fyi/avatar/0xeF8305E140ac520225DAf050e2f71d5fBcC543e7?**cb=1**
 ### Resolvers
 
 #### [ENS avatar](/src/resolvers/ens.ts)
+
+#### [Basename](/src/resolvers/basename.ts)
+
+Resolves the avatar of a [Basename](https://www.base.org/names) (`*.base.eth`) by name or by address, reading the avatar text record from the Basenames L2 resolver on Base.
 
 #### [Lens](/src/resolvers/lens.ts)
 

--- a/src/addressResolvers/basename.ts
+++ b/src/addressResolvers/basename.ts
@@ -4,100 +4,75 @@ import { namehash } from '@ethersproject/hash';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { FetchError, provider as getProvider, isEvmAddress, isSilencedError } from './utils';
-import { Address, EMPTY_ADDRESS, Handle } from '../utils';
+import { Address, EMPTY_ADDRESS, getUrl, Handle } from '../utils';
 
 export const NAME = 'Basename';
 const NETWORK = '8453';
-const TLD = 'base.eth';
-// ENSIP-11 coinType for Base: (0x80000000 | 8453) >>> 0, lowercased hex.
+const TLD = '.base.eth';
+// ENSIP-11 coinType for Base: (0x80000000 | 8453) >>> 0, in hex.
 const COIN_TYPE = '80002105';
 // Basenames L2 Resolver on Base. Source: Coinbase OnchainKit.
-const L2_RESOLVER_ADDRESS = '0xC6d566A56A1aFf6508b41f6c90ff131615583BCD';
+const RESOLVER = '0xC6d566A56A1aFf6508b41f6c90ff131615583BCD';
+const ABI = [
+  'function name(bytes32 node) view returns (string)',
+  'function addr(bytes32 node) view returns (address)',
+  'function text(bytes32 node, string key) view returns (string)'
+];
 
 const provider = getProvider(NETWORK);
 
-// Basename primary names live on Base L2, so reverse resolution uses the
-// ENSIP-11 chain-specific reverse namespace ([addr].[coinType].reverse) read
-// directly from the L2 resolver, rather than the mainnet reverse registrar.
+function call(method: string, params: any[]): Promise<string> {
+  return snapshot.utils.call(provider, ABI, [RESOLVER, method, params], { blockTag: 'latest' });
+}
+
+// Basename records live on Base L2, so reverse resolution reads the ENSIP-11
+// chain-specific reverse name ([addr].[coinType].reverse) from the L2 resolver,
+// not the mainnet reverse registrar that ENS uses.
 function reverseNode(address: Address): string {
   return namehash(`${address.toLowerCase().slice(2)}.${COIN_TYPE}.reverse`);
 }
 
 function normalizeBasename(name: Handle): Handle {
-  if (!name?.endsWith(`.${TLD}`)) return '';
-
   try {
-    return ens_normalize(name) === name ? name : '';
+    return name?.endsWith(TLD) && ens_normalize(name) === name ? name : '';
   } catch {
     return '';
   }
 }
 
-function normalizeAddresses(addresses: Address[]): Address[] {
-  return addresses.filter(isEvmAddress);
-}
-
-function normalizeHandles(names: Handle[]): Handle[] {
-  return names.map(normalizeBasename).filter(h => h);
+async function collect(
+  items: string[],
+  query: (item: string) => Promise<[string, string]>
+): Promise<Record<string, string>> {
+  try {
+    const entries = await Promise.all(items.map(query));
+    return Object.fromEntries(entries.filter(([, value]) => value));
+  } catch (err) {
+    if (!isSilencedError(err)) capture(err, { input: items });
+    throw new FetchError();
+  }
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
-  const normalizedAddresses = normalizeAddresses(addresses);
-
-  if (normalizedAddresses.length === 0) return {};
-
-  const abi = ['function name(bytes32 node) view returns (string)'];
-
-  try {
-    const names = await Promise.all(
-      normalizedAddresses.map(address =>
-        snapshot.utils.call(provider, abi, [L2_RESOLVER_ADDRESS, 'name', [reverseNode(address)]], {
-          blockTag: 'latest'
-        })
-      )
-    );
-
-    return Object.fromEntries(
-      normalizedAddresses
-        .map((address, index) => [address, normalizeBasename(names[index])])
-        .filter(([, name]) => !!name)
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { addresses: normalizedAddresses } });
-    }
-    throw new FetchError();
-  }
+  return collect(addresses.filter(isEvmAddress), async address => [
+    address,
+    normalizeBasename(await call('name', [reverseNode(address)]))
+  ]);
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
-  const normalizedHandles = normalizeHandles(handles);
+  return collect(handles.map(normalizeBasename).filter(Boolean), async handle => {
+    const address = await call('addr', [namehash(handle)]);
+    return [handle, address && address !== EMPTY_ADDRESS ? getAddress(address) : ''];
+  });
+}
 
-  if (normalizedHandles.length === 0) return {};
+// Avatar text record, used by the avatar resolver. Resolves the name against
+// Base specifically, so an address' ENS primary name can't shadow its Basename.
+export async function getAvatar(nameOrAddress: string): Promise<string | null> {
+  const name = isEvmAddress(nameOrAddress)
+    ? (await lookupAddresses([nameOrAddress]))[nameOrAddress]
+    : normalizeBasename(nameOrAddress);
 
-  const abi = ['function addr(bytes32 node) view returns (address)'];
-
-  try {
-    const addresses = await Promise.all(
-      normalizedHandles.map(handle =>
-        snapshot.utils.call(provider, abi, [L2_RESOLVER_ADDRESS, 'addr', [namehash(handle)]], {
-          blockTag: 'latest'
-        })
-      )
-    );
-
-    return Object.fromEntries(
-      normalizedHandles
-        .map((handle, index) => [
-          handle,
-          addresses[index] && addresses[index] !== EMPTY_ADDRESS ? getAddress(addresses[index]) : ''
-        ])
-        .filter(([, address]) => !!address)
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-    throw new FetchError();
-  }
+  return name ? getUrl(await call('text', [namehash(name), 'avatar'])) : null;
 }

--- a/src/addressResolvers/basename.ts
+++ b/src/addressResolvers/basename.ts
@@ -1,0 +1,103 @@
+import { ens_normalize } from '@adraffy/ens-normalize';
+import { getAddress } from '@ethersproject/address';
+import { namehash } from '@ethersproject/hash';
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import snapshot from '@snapshot-labs/snapshot.js';
+import { FetchError, provider as getProvider, isEvmAddress, isSilencedError } from './utils';
+import { Address, EMPTY_ADDRESS, Handle } from '../utils';
+
+export const NAME = 'Basename';
+const NETWORK = '8453';
+const TLD = 'base.eth';
+// ENSIP-11 coinType for Base: (0x80000000 | 8453) >>> 0, lowercased hex.
+const COIN_TYPE = '80002105';
+// Basenames L2 Resolver on Base. Source: Coinbase OnchainKit.
+const L2_RESOLVER_ADDRESS = '0xC6d566A56A1aFf6508b41f6c90ff131615583BCD';
+
+const provider = getProvider(NETWORK);
+
+// Basename primary names live on Base L2, so reverse resolution uses the
+// ENSIP-11 chain-specific reverse namespace ([addr].[coinType].reverse) read
+// directly from the L2 resolver, rather than the mainnet reverse registrar.
+function reverseNode(address: Address): string {
+  return namehash(`${address.toLowerCase().slice(2)}.${COIN_TYPE}.reverse`);
+}
+
+function normalizeBasename(name: Handle): Handle {
+  if (!name?.endsWith(`.${TLD}`)) return '';
+
+  try {
+    return ens_normalize(name) === name ? name : '';
+  } catch {
+    return '';
+  }
+}
+
+function normalizeAddresses(addresses: Address[]): Address[] {
+  return addresses.filter(isEvmAddress);
+}
+
+function normalizeHandles(names: Handle[]): Handle[] {
+  return names.map(normalizeBasename).filter(h => h);
+}
+
+export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
+  const normalizedAddresses = normalizeAddresses(addresses);
+
+  if (normalizedAddresses.length === 0) return {};
+
+  const abi = ['function name(bytes32 node) view returns (string)'];
+
+  try {
+    const names = await Promise.all(
+      normalizedAddresses.map(address =>
+        snapshot.utils.call(provider, abi, [L2_RESOLVER_ADDRESS, 'name', [reverseNode(address)]], {
+          blockTag: 'latest'
+        })
+      )
+    );
+
+    return Object.fromEntries(
+      normalizedAddresses
+        .map((address, index) => [address, normalizeBasename(names[index])])
+        .filter(([, name]) => !!name)
+    );
+  } catch (err) {
+    if (!isSilencedError(err)) {
+      capture(err, { input: { addresses: normalizedAddresses } });
+    }
+    throw new FetchError();
+  }
+}
+
+export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
+  const normalizedHandles = normalizeHandles(handles);
+
+  if (normalizedHandles.length === 0) return {};
+
+  const abi = ['function addr(bytes32 node) view returns (address)'];
+
+  try {
+    const addresses = await Promise.all(
+      normalizedHandles.map(handle =>
+        snapshot.utils.call(provider, abi, [L2_RESOLVER_ADDRESS, 'addr', [namehash(handle)]], {
+          blockTag: 'latest'
+        })
+      )
+    );
+
+    return Object.fromEntries(
+      normalizedHandles
+        .map((handle, index) => [
+          handle,
+          addresses[index] && addresses[index] !== EMPTY_ADDRESS ? getAddress(addresses[index]) : ''
+        ])
+        .filter(([, address]) => !!address)
+    );
+  } catch (err) {
+    if (!isSilencedError(err)) {
+      capture(err, { input: { handles: normalizedHandles } });
+    }
+    throw new FetchError();
+  }
+}

--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -1,3 +1,4 @@
+import * as basenameResolver from './basename';
 import cache, { clear } from './cache';
 import * as ensResolver from './ens';
 import * as lensResolver from './lens';
@@ -19,6 +20,7 @@ import { Address, Handle } from '../utils';
 const RESOLVERS = [
   snapshotResolver,
   ensResolver,
+  basenameResolver,
   unstoppableDomainResolver,
   lensResolver,
   starknetResolver,

--- a/src/constants.json
+++ b/src/constants.json
@@ -4,7 +4,7 @@
   "ttl": 43200,
   "shortTtl": 3600,
   "resolvers": {
-    "avatar": ["snapshot", "ens", "lens", "farcaster", "starknet"],
+    "avatar": ["snapshot", "ens", "basename", "lens", "farcaster", "starknet"],
     "user-cover": ["user-cover"],
     "token": ["trustwallet", "zapper", "coingecko"],
     "space": ["space"],

--- a/src/resolvers/basename.ts
+++ b/src/resolvers/basename.ts
@@ -1,52 +1,14 @@
-import { isAddress } from '@ethersproject/address';
-import { namehash } from '@ethersproject/hash';
-import snapshot from '@snapshot-labs/snapshot.js';
-import { lookupAddresses } from '../addressResolvers/basename';
+import { getAvatar } from '../addressResolvers/basename';
 import { max } from '../constants.json';
-import { getProvider, resize } from '../utils';
+import { resize } from '../utils';
 import { fetchHttpImage } from './utils';
-
-const NETWORK = 8453;
-const TLD = '.base.eth';
-// Basenames L2 Resolver on Base. Source: Coinbase OnchainKit.
-const L2_RESOLVER_ADDRESS = '0xC6d566A56A1aFf6508b41f6c90ff131615583BCD';
-const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
-
-async function castToBasename(nameOrAddress: string): Promise<string | undefined> {
-  if (isAddress(nameOrAddress)) {
-    // Resolve specifically against Base, since the address may also have an ENS
-    // primary name which would not carry the Basename avatar text record.
-    return (await lookupAddresses([nameOrAddress]))[nameOrAddress];
-  }
-
-  return nameOrAddress;
-}
-
-function toHttpUrl(url: string): string | undefined {
-  if (url.startsWith('http')) return url;
-  if (url.startsWith('ipfs://')) return `${IPFS_GATEWAY}${url.slice('ipfs://'.length)}`;
-  return undefined;
-}
 
 export default async function resolve(nameOrAddress: string) {
   try {
-    const basename = await castToBasename(nameOrAddress);
-
-    if (!basename?.endsWith(TLD)) return false;
-
-    const abi = ['function text(bytes32 node, string key) view returns (string)'];
-    const record = await snapshot.utils.call(getProvider(NETWORK), abi, [
-      L2_RESOLVER_ADDRESS,
-      'text',
-      [namehash(basename), 'avatar']
-    ]);
-
-    const url = record && toHttpUrl(record);
+    const url = await getAvatar(nameOrAddress);
     if (!url) return false;
 
-    const input = await fetchHttpImage(url);
-
-    return await resize(input, max, max);
+    return await resize(await fetchHttpImage(url), max, max);
   } catch {
     return false;
   }

--- a/src/resolvers/basename.ts
+++ b/src/resolvers/basename.ts
@@ -1,0 +1,53 @@
+import { isAddress } from '@ethersproject/address';
+import { namehash } from '@ethersproject/hash';
+import snapshot from '@snapshot-labs/snapshot.js';
+import { lookupAddresses } from '../addressResolvers/basename';
+import { max } from '../constants.json';
+import { getProvider, resize } from '../utils';
+import { fetchHttpImage } from './utils';
+
+const NETWORK = 8453;
+const TLD = '.base.eth';
+// Basenames L2 Resolver on Base. Source: Coinbase OnchainKit.
+const L2_RESOLVER_ADDRESS = '0xC6d566A56A1aFf6508b41f6c90ff131615583BCD';
+const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
+
+async function castToBasename(nameOrAddress: string): Promise<string | undefined> {
+  if (isAddress(nameOrAddress)) {
+    // Resolve specifically against Base, since the address may also have an ENS
+    // primary name which would not carry the Basename avatar text record.
+    return (await lookupAddresses([nameOrAddress]))[nameOrAddress];
+  }
+
+  return nameOrAddress;
+}
+
+function toHttpUrl(url: string): string | undefined {
+  if (url.startsWith('http')) return url;
+  if (url.startsWith('ipfs://')) return `${IPFS_GATEWAY}${url.slice('ipfs://'.length)}`;
+  return undefined;
+}
+
+export default async function resolve(nameOrAddress: string) {
+  try {
+    const basename = await castToBasename(nameOrAddress);
+
+    if (!basename?.endsWith(TLD)) return false;
+
+    const abi = ['function text(bytes32 node, string key) view returns (string)'];
+    const record = await snapshot.utils.call(getProvider(NETWORK), abi, [
+      L2_RESOLVER_ADDRESS,
+      'text',
+      [namehash(basename), 'avatar']
+    ]);
+
+    const url = record && toHttpUrl(record);
+    if (!url) return false;
+
+    const input = await fetchHttpImage(url);
+
+    return await resize(input, max, max);
+  } catch {
+    return false;
+  }
+}

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,3 +1,4 @@
+import basename from './basename';
 import blockie from './blockie';
 import coingecko from './coingecko';
 import ens from './ens';
@@ -21,6 +22,7 @@ export default {
   blockie,
   jazzicon,
   ens,
+  basename,
   trustwallet,
   coingecko,
   snapshot: sResolveUserAvatar,

--- a/test/integration/addressResolvers/basename.test.ts
+++ b/test/integration/addressResolvers/basename.test.ts
@@ -1,0 +1,12 @@
+import testAddressResolver from './helper';
+import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/basename';
+
+testAddressResolver({
+  name: 'Basename',
+  lookupAddresses,
+  resolveNames,
+  validAddress: '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9',
+  validDomain: 'jesse.base.eth',
+  blankAddress: '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1',
+  invalidDomains: ['domain.crypto', 'domain.lens', 'vitalik.eth']
+});

--- a/test/integration/resolvers/basename.test.ts
+++ b/test/integration/resolvers/basename.test.ts
@@ -1,0 +1,33 @@
+import resolvers from '../../../src/resolvers';
+
+describe('resolvers', () => {
+  jest.retryTimes(3);
+
+  describe('basename', () => {
+    it('should resolve an avatar by basename', async () => {
+      const result = await resolvers.basename('jesse.base.eth');
+
+      expect(result).toBeInstanceOf(Buffer);
+      return expect((result as Buffer).length).toBeGreaterThan(1000);
+    }, 30e3);
+
+    it('should resolve an avatar by address', async () => {
+      const result = await resolvers.basename('0x2211d1D0020DAEA8039E46Cf1367962070d77DA9');
+
+      expect(result).toBeInstanceOf(Buffer);
+      return expect((result as Buffer).length).toBeGreaterThan(1000);
+    }, 30e3);
+
+    it('should return false for an address without a basename', async () => {
+      const result = await resolvers.basename('0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1');
+
+      return expect(result).toBe(false);
+    }, 30e3);
+
+    it('should return false for a non-basename input', async () => {
+      const result = await resolvers.basename('vitalik.eth');
+
+      return expect(result).toBe(false);
+    }, 10e3);
+  });
+});


### PR DESCRIPTION
## What

Adds support for **Basename** (`*.base.eth`) identities — the avatars you see in the Base App — resolved the same way ENS is integrated, in two halves:

- **`src/addressResolvers/basename.ts`** — reverse (`address → basename`) and forward (`basename → address`) resolution against the Basenames **L2 resolver on Base** (chain `8453`). Reverse resolution uses the ENSIP-11 chain-specific reverse namespace (`[addr].80002105.reverse`), because a Basename's primary name lives on Base L2, not the mainnet reverse registrar — so the existing ENS reverse path can't find it.
- **`src/resolvers/basename.ts`** — avatar resolver. Reads the `avatar` text record from the L2 resolver and returns the resized image. Resolves by basename or by address (looking up the Base primary name *specifically*, so an address that also has an ENS primary name doesn't shadow its Basename avatar).

Registered in the address-resolver registry (`addressResolvers/index.ts`) and in the `avatar` chain (`constants.json`), after `ens`.

## Why

Base App profile pictures are Basename avatar text records — ENS-compatible, but stored on Base L2. Stamp's existing ENS resolver only checks mainnet, so these avatars weren't resolvable. This closes that gap with no new dependencies (reuses `snapshot.utils` + `@ethersproject/hash`).

## Notes

- Reverse-node derivation and the L2 resolver address (`0xC6d566A56A1aFf6508b41f6c90ff131615583BCD`) follow Coinbase's OnchainKit.
- Provider goes through `rpc.snapshot.org/8453`, consistent with the other resolvers.
- The avatar resolver also handles `ipfs://` avatar records via a gateway.

## Test plan

- `test/integration/addressResolvers/basename.test.ts` — round-trips `jesse.base.eth ↔ 0x2211…`, plus blank/invalid cases.
- `test/integration/resolvers/basename.test.ts` — resolves the avatar by name and by address, returns `false` for an address with no basename and for non-basename input.
- All 10 tests pass; `eslint` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)