### PR TITLE
fix: drop node-canvas, render blockies via SVG + sharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@unstoppabledomains/resolution": "^9.2.2",
     "@webinterop/dns-connect": "^0.3.1",
     "axios": "^0.25.0",
-    "canvas": "^3.2.3",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@adraffy/ens-normalize": "^1.10.0",
     "@aws-sdk/client-s3": "^3.352.0",
-    "@download/blockies": "^1.0.3",
     "@ethersproject/address": "^5.7.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",

--- a/src/resolvers/blockie.ts
+++ b/src/resolvers/blockie.ts
@@ -1,11 +1,101 @@
-import { renderIcon } from '@download/blockies';
-import { createCanvas } from 'canvas';
+import sharp from 'sharp';
 import { max } from '../constants.json';
 import { resize } from '../utils';
 
+// Xorshift PRNG, color and grid logic ported verbatim from @download/blockies
+// (src/blockies.mjs) so the generated identicons stay visually identical to the
+// previous node-canvas based implementation. Only the canvas rasterisation is
+// replaced: instead of painting rects onto a canvas we emit an equivalent SVG
+// and let sharp turn it into a webp.
+const randseed = new Array(4);
+
+function seedrand(seed: string) {
+  randseed.fill(0);
+
+  for (let i = 0; i < seed.length; i++) {
+    randseed[i % 4] = (randseed[i % 4] << 5) - randseed[i % 4] + seed.charCodeAt(i);
+  }
+}
+
+function rand() {
+  const t = randseed[0] ^ (randseed[0] << 11);
+
+  randseed[0] = randseed[1];
+  randseed[1] = randseed[2];
+  randseed[2] = randseed[3];
+  randseed[3] = randseed[3] ^ (randseed[3] >> 19) ^ t ^ (t >> 8);
+
+  return (randseed[3] >>> 0) / ((1 << 31) >>> 0);
+}
+
+function createColor() {
+  const h = Math.floor(rand() * 360);
+  const s = `${rand() * 60 + 40}%`;
+  const l = `${(rand() + rand() + rand() + rand()) * 25}%`;
+
+  return `hsl(${h},${s},${l})`;
+}
+
+function createImageData(size: number) {
+  const width = size;
+  const height = size;
+
+  const dataWidth = Math.ceil(width / 2);
+  const mirrorWidth = width - dataWidth;
+
+  const data: number[] = [];
+  for (let y = 0; y < height; y++) {
+    let row: number[] = [];
+    for (let x = 0; x < dataWidth; x++) {
+      row[x] = Math.floor(rand() * 2.3);
+    }
+    const r = row.slice(0, mirrorWidth);
+    r.reverse();
+    row = row.concat(r);
+
+    for (let i = 0; i < row.length; i++) {
+      data.push(row[i]);
+    }
+  }
+
+  return data;
+}
+
+function renderSvg(seed: string, size: number, scale: number) {
+  seedrand(seed);
+
+  // The call order (color, bgcolor, spotcolor) must match buildOpts in
+  // @download/blockies, otherwise the PRNG stream diverges and the output
+  // changes.
+  const color = createColor();
+  const bgcolor = createColor();
+  const spotcolor = createColor();
+
+  const imageData = createImageData(size);
+  const width = Math.sqrt(imageData.length);
+  const dimension = size * scale;
+
+  const rects: string[] = [];
+  for (let i = 0; i < imageData.length; i++) {
+    if (imageData[i]) {
+      const row = Math.floor(i / width);
+      const col = i % width;
+      const fill = imageData[i] === 1 ? color : spotcolor;
+
+      rects.push(
+        `<rect x="${col * scale}" y="${row * scale}" width="${scale}" height="${scale}" fill="${fill}"/>`
+      );
+    }
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${dimension}" height="${dimension}" shape-rendering="crispEdges"><rect width="${dimension}" height="${dimension}" fill="${bgcolor}"/>${rects.join(
+    ''
+  )}</svg>`;
+}
+
 export default async function resolve(address) {
-  const canvas = createCanvas(64, 64);
-  renderIcon({ seed: address, scale: 64 }, canvas);
-  const input = canvas.toBuffer();
+  const svg = renderSvg(address, 8, 64);
+  const input = await sharp(Buffer.from(svg, 'utf-8')).png().toBuffer();
+
   return await resize(input, max, max);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,14 +3752,6 @@ caniuse-lite@^1.0.30001587:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001608.tgz#7ae6e92ffb300e4b4ec2f795e0abab456ec06cc0"
   integrity sha512-cjUJTQkk9fQlJR2s4HMuPMvTiRggl0rAVMtthQuyOlDWuqHXqN8azLq+pi8B2TjwKJ32diHjUqRIKeFX4z1FoA==
 
-canvas@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-3.2.3.tgz#6ea9697a778aaaa9ab8e2c040917ac6d41848ad4"
-  integrity sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==
-  dependencies:
-    node-addon-api "^7.0.0"
-    prebuild-install "^7.1.3"
-
 cardinal@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-2.1.1.tgz#7cc1055d822d212954d07b085dea251cc7bc5505"
@@ -6256,11 +6248,6 @@ napi-build-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
   integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
 
-napi-build-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
-  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
-
 napi-postinstall@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/napi-postinstall/-/napi-postinstall-0.3.4.tgz#7af256d6588b5f8e952b9190965d6b019653bbb9"
@@ -6287,11 +6274,6 @@ node-addon-api@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
-
-node-addon-api@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
-  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.7.0, node-fetch@v2.7.0:
   version "2.7.0"
@@ -6553,24 +6535,6 @@ prebuild-install@^7.1.1:
     minimist "^1.2.3"
     mkdirp-classic "^0.5.3"
     napi-build-utils "^1.0.1"
-    node-abi "^3.3.0"
-    pump "^3.0.0"
-    rc "^1.2.7"
-    simple-get "^4.0.0"
-    tar-fs "^2.0.0"
-    tunnel-agent "^0.6.0"
-
-prebuild-install@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
-  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
-  dependencies:
-    detect-libc "^2.0.0"
-    expand-template "^2.0.3"
-    github-from-package "0.0.0"
-    minimist "^1.2.3"
-    mkdirp-classic "^0.5.3"
-    napi-build-utils "^2.0.0"
     node-abi "^3.3.0"
     pump "^3.0.0"
     rc "^1.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,11 +1000,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@download/blockies@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@download/blockies/-/blockies-1.0.3.tgz#9aea770f9de72f3f947f1b3a53ee1e92f8dc4a68"
-  integrity sha512-iGDh2M6pFuXg9kyW+U//963LKylSLFpLG5hZvUppCjhkiDwsYquQPyamxCQlLASYySS3gGKAki2eWG9qIHKCew==
-
 "@emnapi/core@1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"


### PR DESCRIPTION
blockie.ts was the only consumer of node-canvas: it painted an NxN rect grid onto a canvas, then handed the buffer to sharp for resize/encode.

This rewrites it to emit an equivalent SVG (a background rect plus one rect per non-background cell, at the same 8x8 grid / scale 64 geometry) and rasterize with sharp, mirroring the approach the jazzicon resolver already uses.

Output is unchanged. The Xorshift PRNG, color and grid logic are ported verbatim from @download/blockies and called in the same order (color, bgcolor, spotcolor, then grid), so the PRNG stream does not diverge. Verified against the original lib for several addresses: background color, foreground color and the exact set of non-background cells are byte-identical. The only differences are sub-perceptual per-channel rasterizer rounding between canvas and sharp on identical HSL values and geometry.

This removes the node-canvas dependency entirely (it was the sole user), which also eliminates the macOS sharp-vs-canvas dual-GLib dylib clash that surfaces during local test runs.

Checks: yarn lint, yarn typecheck (tsc --noEmit) and yarn build all pass; no remaining canvas imports; canvas removed from package.json and yarn.lock.

Note: please verify blockie output parity in review.