### PR TITLE
fix(ci): update expired sepolia ENS fixture in lookupDomains test

### DIFF
--- a/test/integration/lookupDomains.test.ts
+++ b/test/integration/lookupDomains.test.ts
@@ -12,7 +12,7 @@ describe('lookupDomains', () => {
   it('should return an array of addresses on sepolia', async () => {
     const result = await lookupDomains('0x24F15402C6Bb870554489b2fd2049A85d75B982f', '11155111');
 
-    expect(result).toContain('testchaitu.eth');
+    expect(result).toContain('chaitu.eth');
   });
 
   it('should return an empty array if the address is not provided', async () => {


### PR DESCRIPTION
## What was broken

CI `Test` has been failing on `master` (and on the `.gwei` #480 + dependabot pushes). The single failing test is `lookupDomains › should return an array of addresses on sepolia`:

```
Expected value: "testchaitu.eth"
Received array: ["chaitu.eth", "1.chaitu.eth", "1.testchaitu.eth"]
```

## Root cause

`testchaitu.eth` is a wrapped ENS name on sepolia owned by the test account. Querying the live sepolia ENS subgraph shows its `expiryDate` is `1782909240` = **2026-07-01 12:34 UTC**. `lookupDomains` filters out expired domains, so as of 2026-07-01 the name is correctly dropped and the hard-coded assertion breaks. This is a time-brittle fixture, unrelated to the .gwei PR or the snapshot.js dependency bump.

## Fix

Assert `chaitu.eth` instead. The same account owns it with `expiryDate` `2156590116` (**2038-05-04**), so the sepolia-routing check stays intact without depending on a testnet name that lapses.

## Verification

- Reproduced the original failure locally (matches CI).
- Confirmed live subgraph state: `testchaitu.eth` expired 2026-07-01, `chaitu.eth` valid to 2038.
- `jest test/integration/lookupDomains.test.ts -t sepolia` passes 3/3 runs with the fix.
- `eslint` clean on the touched file.

(Other local suite failures — shibarium/unstoppable — are environment-only: they need the `D3_API_KEY*` / `UNSTOPPABLE_DOMAINS_API_KEY` secrets that CI provides; they pass in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)