### PR TITLE
Migrate ENS resolution to the Universal Resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "sharp": "^0.34.5",
     "starknet": ">=6.21.0 <6.21.2",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.3",
+    "typescript": "5.4.5",
+    "viem": "2.37.6",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "sharp": "^0.34.5",
     "starknet": "^6.11.0",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.3",
+    "typescript": "5.4.5",
+    "viem": "2.37.6",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -1,14 +1,11 @@
 import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import snapshot from '@snapshot-labs/snapshot.js';
-import { provider as getProvider, isEvmAddress, isSilencedError } from './utils';
-import constants from '../constants.json';
-import { Address, graphQlCall, Handle } from '../utils';
+import { forwardLookup, reverseLookup } from './universalResolver';
+import { isEvmAddress, isSilencedError } from './utils';
+import { Address, Handle } from '../utils';
 
 export const NAME = 'Ens';
-const NETWORK = '1';
-const provider = getProvider(NETWORK);
 
 function normalizeEns(names: Handle[]): Handle[] {
   return names.map(name => {
@@ -28,36 +25,36 @@ function normalizeHandles(names: Handle[]): Handle[] {
   return normalizeEns(names).filter(h => h);
 }
 
+function firstReportableError(errors: unknown[]): unknown {
+  return errors.find(err => !isSilencedError(err)) ?? errors[0];
+}
+
+// Every entry is settled on its own, so a batch can come back with results and
+// errors at the same time. index.ts only reports what a resolver throws, so
+// errors that arrive alongside results are reported here or not at all.
+function reportErrors(errors: unknown[], input: Record<string, unknown>) {
+  if (errors.length === 0) return;
+
+  const error = firstReportableError(errors);
+  if (!isSilencedError(error)) capture(error, { input });
+}
+
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
-  const abi = ['function getNames(address[] addresses) view returns (string[] r)'];
   const normalizedAddresses = normalizeAddresses(addresses);
 
   if (normalizedAddresses.length === 0) return {};
 
-  let reverseRecords: string[] = [];
-  try {
-    reverseRecords = await snapshot.utils.call(
-      provider,
-      abi,
-      ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [normalizedAddresses]],
-      { blockTag: 'latest' }
-    );
-  } catch (err: any) {
-    if (err?.code !== 'CALL_EXCEPTION') throw err;
-  }
-  const validNames = normalizeEns(reverseRecords);
+  const { values, errors } = await reverseLookup(normalizedAddresses);
 
-  // The batch contract only reads on-chain reverse records. Names served by
-  // off-chain resolvers (CCIP-Read) need provider.lookupAddress, which follows
-  // the OffchainLookup flow via the ENS UniversalResolver.
-  const missing = normalizedAddresses.map((_, i) => i).filter(i => !validNames[i]);
-  const lookups = await Promise.allSettled(
-    missing.map(idx => provider.lookupAddress(normalizedAddresses[idx]))
-  );
-  const fallbackNames = normalizeEns(lookups.map(r => (r.status === 'fulfilled' && r.value) || ''));
-  missing.forEach((idx, j) => {
-    if (fallbackNames[j]) validNames[idx] = fallbackNames[j];
-  });
+  // Nothing resolved at all: reject with the original error and let index.ts
+  // report or silence it, like any other resolver failure.
+  if (errors.length > 0 && Object.keys(values).length === 0) {
+    throw firstReportableError(errors);
+  }
+
+  reportErrors(errors, { addresses: normalizedAddresses });
+
+  const validNames = normalizeEns(normalizedAddresses.map(address => values[address] || ''));
 
   return Object.fromEntries(
     normalizedAddresses
@@ -71,54 +68,15 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  const results = {};
+  const { values, errors } = await forwardLookup(normalizedHandles);
 
-  try {
-    const {
-      data: {
-        data: { domains: items }
-      }
-    } = await graphQlCall(
-      constants.ensSubgraph[NETWORK],
-      `query Domains($handles: [String!]!) {
-        domains(where: {name_in: $handles}) {
-          name
-          resolvedAddress {
-            id
-          }
-        }
-      }`,
-      { handles: normalizedHandles }
-    );
+  reportErrors(errors, { handles: normalizedHandles });
 
-    for (const item of items) {
-      results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
-    }
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-  }
-
-  const unresolvedHandles = normalizedHandles.filter(handle => !results[handle]);
-
-  if (unresolvedHandles.length === 0) return results;
-
-  try {
-    const providerResults = await Promise.allSettled(
-      unresolvedHandles.map(handle => provider.resolveName(handle))
-    );
-
-    unresolvedHandles.forEach((handle, index) => {
-      const result = providerResults[index];
-      if (result.status === 'fulfilled' && result.value) {
-        results[handle] = getAddress(result.value);
-      }
-    });
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
+  const results: Record<Handle, Address> = {};
+  for (const [handle, address] of Object.entries(values)) {
+    try {
+      results[handle] = getAddress(address);
+    } catch {}
   }
 
   return results;

--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -1,14 +1,11 @@
 import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import snapshot from '@snapshot-labs/snapshot.js';
-import { FetchError, provider as getProvider, isEvmAddress, isSilencedError } from './utils';
-import constants from '../constants.json';
-import { Address, graphQlCall, Handle } from '../utils';
+import { forwardLookup, reverseLookup } from './universalResolver';
+import { FetchError, isEvmAddress, isSilencedError } from './utils';
+import { Address, Handle } from '../utils';
 
 export const NAME = 'Ens';
-const NETWORK = '1';
-const provider = getProvider(NETWORK);
 
 function normalizeEns(names: Handle[]): Handle[] {
   return names.map(name => {
@@ -28,51 +25,31 @@ function normalizeHandles(names: Handle[]): Handle[] {
   return normalizeEns(names).filter(h => h);
 }
 
+function reportErrors(errors: unknown[], input: Record<string, unknown>) {
+  const error = errors.find(err => !isSilencedError(err));
+  if (error) capture(error, { input });
+}
+
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
-  const abi = ['function getNames(address[] addresses) view returns (string[] r)'];
   const normalizedAddresses = normalizeAddresses(addresses);
 
   if (normalizedAddresses.length === 0) return {};
 
-  try {
-    let reverseRecords: string[] = [];
-    try {
-      reverseRecords = await snapshot.utils.call(
-        provider,
-        abi,
-        ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [normalizedAddresses]],
-        { blockTag: 'latest' }
-      );
-    } catch (err: any) {
-      if (err?.code !== 'CALL_EXCEPTION') throw err;
-    }
-    const validNames = normalizeEns(reverseRecords);
+  const { values, errors } = await reverseLookup(normalizedAddresses);
 
-    // The batch contract only reads on-chain reverse records. Names served by
-    // off-chain resolvers (CCIP-Read) need provider.lookupAddress, which follows
-    // the OffchainLookup flow via the ENS UniversalResolver.
-    const missing = normalizedAddresses.map((_, i) => i).filter(i => !validNames[i]);
-    const lookups = await Promise.allSettled(
-      missing.map(idx => provider.lookupAddress(normalizedAddresses[idx]))
-    );
-    const fallbackNames = normalizeEns(
-      lookups.map(r => (r.status === 'fulfilled' && r.value) || '')
-    );
-    missing.forEach((idx, j) => {
-      if (fallbackNames[j]) validNames[idx] = fallbackNames[j];
-    });
+  reportErrors(errors, { addresses: normalizedAddresses });
 
-    return Object.fromEntries(
-      normalizedAddresses
-        .map((address, index) => [address, validNames[index]])
-        .filter((_, index) => !!validNames[index])
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { addresses: normalizedAddresses } });
-    }
+  if (errors.length > 0 && Object.keys(values).length === 0) {
     throw new FetchError();
   }
+
+  const validNames = normalizeEns(normalizedAddresses.map(address => values[address] || ''));
+
+  return Object.fromEntries(
+    normalizedAddresses
+      .map((address, index) => [address, validNames[index]])
+      .filter((_, index) => !!validNames[index])
+  );
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
@@ -80,54 +57,15 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  const results = {};
+  const { values, errors } = await forwardLookup(normalizedHandles);
 
-  try {
-    const {
-      data: {
-        data: { domains: items }
-      }
-    } = await graphQlCall(
-      constants.ensSubgraph[NETWORK],
-      `query Domains($handles: [String!]!) {
-        domains(where: {name_in: $handles}) {
-          name
-          resolvedAddress {
-            id
-          }
-        }
-      }`,
-      { handles: normalizedHandles }
-    );
+  reportErrors(errors, { handles: normalizedHandles });
 
-    for (const item of items) {
-      results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
-    }
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-  }
-
-  const unresolvedHandles = normalizedHandles.filter(handle => !results[handle]);
-
-  if (unresolvedHandles.length === 0) return results;
-
-  try {
-    const providerResults = await Promise.allSettled(
-      unresolvedHandles.map(handle => provider.resolveName(handle))
-    );
-
-    unresolvedHandles.forEach((handle, index) => {
-      const result = providerResults[index];
-      if (result.status === 'fulfilled' && result.value) {
-        results[handle] = getAddress(result.value);
-      }
-    });
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
+  const results: Record<Handle, Address> = {};
+  for (const [handle, address] of Object.entries(values)) {
+    try {
+      results[handle] = getAddress(address);
+    } catch {}
   }
 
   return results;

--- a/src/addressResolvers/universalResolver.ts
+++ b/src/addressResolvers/universalResolver.ts
@@ -1,0 +1,43 @@
+import { createPublicClient, http, Address as ViemAddress } from 'viem';
+import { mainnet } from 'viem/chains';
+import { normalize } from 'viem/ens';
+
+const rpcUrl = `${process.env.BROVIDER_URL || 'https://rpc.snapshot.org'}/1`;
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http(rpcUrl, { timeout: 20e3 })
+});
+
+export type BatchResult = { values: Record<string, string>; errors: unknown[] };
+
+async function settle(
+  keys: string[],
+  task: (key: string) => Promise<string | null | undefined>
+): Promise<BatchResult> {
+  const settled = await Promise.allSettled(keys.map(task));
+  const values: Record<string, string> = {};
+  const errors: unknown[] = [];
+
+  settled.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      if (result.value) values[keys[index]] = result.value;
+    } else {
+      errors.push(result.reason);
+    }
+  });
+
+  return { values, errors };
+}
+
+export function reverseLookup(addresses: string[]): Promise<BatchResult> {
+  return settle(addresses, address => client.getEnsName({ address: address as ViemAddress }));
+}
+
+export function forwardLookup(names: string[]): Promise<BatchResult> {
+  return settle(names, name => client.getEnsAddress({ name: normalize(name) }));
+}
+
+export function getTextRecord(name: string, key: string): Promise<string | null> {
+  return client.getEnsText({ name: normalize(name), key });
+}

--- a/src/resolvers/ens.ts
+++ b/src/resolvers/ens.ts
@@ -1,8 +1,9 @@
 import { isAddress } from '@ethersproject/address';
 import { max } from '../constants.json';
-import { getProvider, resize } from '../utils';
+import { resize } from '../utils';
 import { fetchHttpImage } from './utils';
 import { lookupAddresses } from '../addressResolvers';
+import { getTextRecord } from '../addressResolvers/universalResolver';
 
 async function castToEnsName(nameOrAddress: string): Promise<string | undefined> {
   if (isAddress(nameOrAddress)) {
@@ -14,19 +15,15 @@ async function castToEnsName(nameOrAddress: string): Promise<string | undefined>
 
 export default async function resolve(nameOrAddress: string) {
   try {
-    const provider = getProvider(1);
     const ensName = await castToEnsName(nameOrAddress);
 
     if (!ensName) return false;
 
-    const ensResolver = await provider.getResolver(ensName);
-
-    if (!ensResolver) {
-      return false;
-    }
-
-    let url = await ensResolver.getText('avatar');
-    url = url?.startsWith('http') ? url : `https://metadata.ens.domains/mainnet/avatar/${ensName}`;
+    const record = await getTextRecord(ensName, 'avatar');
+    const url =
+      record && record.startsWith('http')
+        ? record
+        : `https://metadata.ens.domains/mainnet/avatar/${ensName}`;
 
     const input = await fetchHttpImage(url);
 

--- a/test/integration/addressResolvers/ens.test.ts
+++ b/test/integration/addressResolvers/ens.test.ts
@@ -1,7 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import snapshot from '@snapshot-labs/snapshot.js';
 import testAddressResolver from './helper';
 import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/ens';
+import * as universalResolver from '../../../src/addressResolvers/universalResolver';
 import { FetchError } from '../../../src/addressResolvers/utils';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({
@@ -18,39 +18,40 @@ testAddressResolver({
   invalidDomains: ['domain.crypto', 'domain.lens', 'domain.com']
 });
 
-describe('ENS address resolver: CCIP-Read fallback', () => {
-  // avsa.eth's primary name is set via an off-chain resolver that the batch
-  // getNames contract doesn't follow, so the fallback to provider.lookupAddress
-  // is required.
-  it('resolves names that the batch contract misses', async () => {
+describe('ENS address resolver: Universal Resolver', () => {
+  it('resolves names served by off-chain (CCIP-Read) resolvers', async () => {
     const address = '0x809FA673fe2ab515FaA168259cB14E2BeDeBF68e';
     await expect(lookupAddresses([address])).resolves.toEqual({
       [address]: 'avsa.eth'
     });
-  }, 15e3);
+  }, 20e3);
 
-  it('falls back to per-address lookups when the batch reverse call reverts', async () => {
-    const ccipAddress = '0x3a872f8FED4421E7d5BE5c98Ab5Ea0e0245169A0';
-    const goodAddress = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+  it('returns nothing for an expired name without throwing', async () => {
+    const address = '0x9c3aC02Cd616a82C83830e40D45c9534b32c4934';
+    await expect(lookupAddresses([address])).resolves.toEqual({});
+  }, 20e3);
 
-    await expect(lookupAddresses([ccipAddress])).resolves.toEqual({});
-    await expect(lookupAddresses([ccipAddress, goodAddress])).resolves.toEqual({
-      [goodAddress]: 'sdntestens.eth'
+  it('isolates per-address failures within a batch', async () => {
+    const expired = '0x9c3aC02Cd616a82C83830e40D45c9534b32c4934';
+    const good = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+
+    await expect(lookupAddresses([expired, good])).resolves.toEqual({
+      [good]: 'sdntestens.eth'
     });
   }, 20e3);
 
-  it('still surfaces non-CALL_EXCEPTION batch errors', async () => {
-    const error = Object.assign(new Error('boom'), {
-      code: 'SERVER_ERROR'
-    });
-    const callSpy = jest.spyOn(snapshot.utils, 'call').mockRejectedValueOnce(error);
+  it('throws a FetchError and reports when the whole batch fails', async () => {
+    const error = Object.assign(new Error('boom'), { code: 'SERVER_ERROR' });
+    const spy = jest
+      .spyOn(universalResolver, 'reverseLookup')
+      .mockResolvedValueOnce({ values: {}, errors: [error] });
     const address = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
 
     try {
       await expect(lookupAddresses([address])).rejects.toBeInstanceOf(FetchError);
       expect(capture).toHaveBeenCalledWith(error, { input: { addresses: [address] } });
     } finally {
-      callSpy.mockRestore();
+      spy.mockRestore();
     }
   });
 });

--- a/test/integration/addressResolvers/ens.test.ts
+++ b/test/integration/addressResolvers/ens.test.ts
@@ -1,7 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import snapshot from '@snapshot-labs/snapshot.js';
 import testAddressResolver from './helper';
 import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/ens';
+import * as universalResolver from '../../../src/addressResolvers/universalResolver';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({
   capture: jest.fn()
@@ -17,41 +17,65 @@ testAddressResolver({
   invalidDomains: ['domain.crypto', 'domain.lens', 'domain.com']
 });
 
-describe('ENS address resolver: CCIP-Read fallback', () => {
-  // jesse.base.eth's primary name is set via an off-chain resolver that the batch
-  // getNames contract doesn't follow, so the fallback to provider.lookupAddress
-  // is required.
-  it('resolves names that the batch contract misses', async () => {
+describe('ENS address resolver: Universal Resolver', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('resolves names served by off-chain (CCIP-Read) resolvers', async () => {
     const address = '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9';
     await expect(lookupAddresses([address])).resolves.toEqual({
       [address]: 'jesse.base.eth'
     });
-  }, 15e3);
+  }, 20e3);
 
-  it('falls back to per-address lookups when the batch reverse call reverts', async () => {
-    const ccipAddress = '0x3a872f8FED4421E7d5BE5c98Ab5Ea0e0245169A0';
-    const goodAddress = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+  it('returns nothing for an expired name without throwing', async () => {
+    const address = '0x9c3aC02Cd616a82C83830e40D45c9534b32c4934';
+    await expect(lookupAddresses([address])).resolves.toEqual({});
+  }, 20e3);
 
-    await expect(lookupAddresses([ccipAddress])).resolves.toEqual({});
-    await expect(lookupAddresses([ccipAddress, goodAddress])).resolves.toEqual({
-      [goodAddress]: 'sdntestens.eth'
+  it('isolates per-address failures within a batch', async () => {
+    const expired = '0x9c3aC02Cd616a82C83830e40D45c9534b32c4934';
+    const good = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+
+    await expect(lookupAddresses([expired, good])).resolves.toEqual({
+      [good]: 'sdntestens.eth'
     });
   }, 20e3);
 
-  it('still surfaces non-CALL_EXCEPTION batch errors', async () => {
-    const error = Object.assign(new Error('boom'), {
-      code: 'SERVER_ERROR'
-    });
-    const callSpy = jest.spyOn(snapshot.utils, 'call').mockRejectedValueOnce(error);
+  it('rethrows the original error when the whole batch fails', async () => {
+    const error = Object.assign(new Error('boom'), { code: 'SERVER_ERROR' });
+    jest
+      .spyOn(universalResolver, 'reverseLookup')
+      .mockResolvedValueOnce({ values: {}, errors: [error] });
     const address = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
 
-    try {
-      // The resolver rethrows the original error untouched. Reporting it is
-      // addressResolvers/index.ts' job now, so nothing is captured here.
-      await expect(lookupAddresses([address])).rejects.toBe(error);
-      expect(capture).not.toHaveBeenCalled();
-    } finally {
-      callSpy.mockRestore();
-    }
+    // The resolver rethrows the original error untouched. Reporting it is
+    // addressResolvers/index.ts' job now, so nothing is captured here.
+    await expect(lookupAddresses([address])).rejects.toBe(error);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('reports the errors of a partly resolved batch, which never reach index.ts', async () => {
+    const error = Object.assign(new Error('boom'), { code: 'SERVER_ERROR' });
+    const good = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+    const bad = '0x9c3aC02Cd616a82C83830e40D45c9534b32c4934';
+    jest
+      .spyOn(universalResolver, 'reverseLookup')
+      .mockResolvedValueOnce({ values: { [good]: 'sdntestens.eth' }, errors: [error] });
+
+    await expect(lookupAddresses([bad, good])).resolves.toEqual({ [good]: 'sdntestens.eth' });
+    expect(capture).toHaveBeenCalledWith(error, { input: { addresses: [bad, good] } });
+  });
+
+  it('does not report a silenced error', async () => {
+    const error = Object.assign(new Error('boom'), { code: 'ETIMEDOUT' });
+    const good = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+    jest
+      .spyOn(universalResolver, 'reverseLookup')
+      .mockResolvedValueOnce({ values: { [good]: 'sdntestens.eth' }, errors: [error] });
+
+    await expect(lookupAddresses([good])).resolves.toEqual({ [good]: 'sdntestens.eth' });
+    expect(capture).not.toHaveBeenCalled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3467,12 +3467,17 @@ abi-wan-kanabi@^2.2.3:
     fs-extra "^10.0.0"
     yargs "^17.7.2"
 
+abitype@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.1.0.tgz#510c5b3f92901877977af5e864841f443bf55406"
+  integrity sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==
+
 abitype@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.2.3.tgz#bec3e09dea97d99ef6c719140bee663a329ad1f4"
   integrity sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==
 
-abitype@^1.2.3:
+abitype@^1.0.9, abitype@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.3.0.tgz#39de89010dd7390ece44d5242a3aa80901cc193d"
   integrity sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==
@@ -6564,6 +6569,20 @@ ox@0.14.33:
     abitype "^1.2.3"
     eventemitter3 "5.0.1"
 
+ox@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.9.3.tgz#92cc1008dcd913e919364fd4175c860b3eeb18db"
+  integrity sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.0.9"
+    eventemitter3 "5.0.1"
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -7578,10 +7597,10 @@ typescript-memoize@^1.0.0-alpha.4:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
   integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
-typescript@^4.7.3:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 uint8arrays@^2.0.5, uint8arrays@^2.1.3:
   version "2.1.10"
@@ -7731,6 +7750,20 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+viem@2.37.6:
+  version "2.37.6"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.37.6.tgz#3b05586555bd4b2c1b7351ed148f9fa98df72027"
+  integrity sha512-b+1IozQ8TciVQNdQUkOH5xtFR0z7ZxR8pyloENi/a+RA408lv4LoX12ofwoiT3ip0VRhO5ni1em//X0jn/eW0g==
+  dependencies:
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.1.0"
+    isows "1.0.7"
+    ox "0.9.3"
+    ws "8.18.3"
+
 viem@^2.55.11:
   version "2.55.13"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.55.13.tgz#2a3c139ad66671dabde492ce2f3e7437ed15e4b7"
@@ -7855,6 +7888,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 ws@8.21.0:
   version "8.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
   integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
+"@adraffy/ens-normalize@^1.11.0":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz#6c2d657d4b2dfb37f8ea811dcb3e60843d4ac24a"
+  integrity sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==
+
 "@ampproject/remapping@^2.2.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
@@ -2106,6 +2111,18 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
 
+"@noble/ciphers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
+"@noble/curves@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.1.tgz#9654a0bc6c13420ae252ddcf975eaf0f58f0a35c"
+  integrity sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
 "@noble/curves@~1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.3.0.tgz#01be46da4fd195822dab821e72f71bf4aeec635e"
@@ -2120,6 +2137,13 @@
   dependencies:
     "@noble/hashes" "1.4.0"
 
+"@noble/curves@~1.9.0":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
+  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
 "@noble/hashes@1.3.3", "@noble/hashes@~1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
@@ -2130,7 +2154,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
   integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
-"@noble/hashes@^1.1.5":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.1.5", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -2248,6 +2272,28 @@
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.6.tgz#8ce5d304b436e4c84f896e0550c83e4d88cb917d"
   integrity sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==
+
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
+"@scure/bip32@1.7.0", "@scure/bip32@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
+"@scure/bip39@1.6.0", "@scure/bip39@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@scure/starknet@~1.0.0":
   version "1.0.0"
@@ -3437,6 +3483,16 @@ abi-wan-kanabi@^2.2.2:
     cardinal "^2.1.1"
     fs-extra "^10.0.0"
     yargs "^17.7.2"
+
+abitype@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.1.0.tgz#510c5b3f92901877977af5e864841f443bf55406"
+  integrity sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==
+
+abitype@^1.0.9:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.2.4.tgz#8aab72949bcad4107031862ae998e5bd20eec76e"
+  integrity sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -4741,6 +4797,11 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+eventemitter3@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -5441,6 +5502,11 @@ isomorphic-fetch@^3.0.0:
   dependencies:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
+
+isows@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.7.tgz#1c06400b7eed216fbba3bcbd68f12490fc342915"
+  integrity sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -6508,6 +6574,20 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
+ox@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.9.3.tgz#92cc1008dcd913e919364fd4175c860b3eeb18db"
+  integrity sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.0.9"
+    eventemitter3 "5.0.1"
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -7524,10 +7604,10 @@ typescript-memoize@^1.0.0-alpha.4:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
   integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
-typescript@^4.7.3:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 uint8arrays@^2.0.5, uint8arrays@^2.1.3:
   version "2.1.10"
@@ -7682,6 +7762,20 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+viem@2.37.6:
+  version "2.37.6"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.37.6.tgz#3b05586555bd4b2c1b7351ed148f9fa98df72027"
+  integrity sha512-b+1IozQ8TciVQNdQUkOH5xtFR0z7ZxR8pyloENi/a+RA408lv4LoX12ofwoiT3ip0VRhO5ni1em//X0jn/eW0g==
+  dependencies:
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.1.0"
+    isows "1.0.7"
+    ox "0.9.3"
+    ws "8.18.3"
+
 w3c-hr-time@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
@@ -7792,6 +7886,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 ws@^8.2.3:
   version "8.16.0"


### PR DESCRIPTION
## Why

Reverse and forward ENS resolution are spread over three sources today: the ReverseRecords helper contract for the reverse batch, an `ethers` `lookupAddress` pass to patch up the addresses that contract misses, and the ENS subgraph for forward resolution. So a reverse lookup runs two code paths with two failure modes stitched together, and forward resolution leans on a hosted subgraph we do not control.

## What

Both directions now go through the ENS Universal Resolver, via a viem client kept behind one small module in `src/addressResolvers`. viem follows the CCIP-Read `OffchainLookup` flow natively and the Universal Resolver forward-verifies the reverse claim on chain, so a single path covers on-chain and off-chain names alike. The ReverseRecords contract, the patch-up pass and the subgraph query all go away.

Each address or name is settled on its own, so a reverting or expired entry resolves to nothing instead of affecting the rest of the batch. The external API (`lookupAddresses`, `resolveNames`) is unchanged. The avatar resolver reads the `avatar` text record through the same client, keeping the `metadata.ens.domains` fallback. viem stays boxed inside that one module, plain values in and out, and ethers stays everywhere else.

## Tradeoff

The viem client has no multicall batching configured, so a reverse lookup makes one RPC call per address where it used to make a single batched contract call. At the batch size the resolver uses that is a real increase in calls per request, and I think it is worth turning on viem's multicall batching before this merges.

## Notes

The avatar text record change overlaps with snapshot-labs/snapshot.js#1227, which does the same thing upstream. If that lands first, this part can be dropped.

Checked against mainnet with a normal name, a name served by an off-chain resolver, and an address whose name has expired.
