### PR TITLE
fix: check response status in unstoppable domains lookup

### DIFF
--- a/src/lookupDomains/unstoppableDomains.ts
+++ b/src/lookupDomains/unstoppableDomains.ts
@@ -23,8 +23,21 @@ async function fetchDomains(
     }
   );
 
-  return response.json();
+  if (!response.ok) {
+    throw new Error(
+      `Unstoppable Domains API error: HTTP ${response.status} ${response.statusText}`
+    );
+  }
+
+  const data = await response.json();
+
+  if (!Array.isArray(data?.data)) {
+    throw new Error('Unstoppable Domains API error: response body is missing a data array');
+  }
+
+  return data;
 }
+
 export default async function lookupDomains(address: Address, chainId: string): Promise<Handle[]> {
   if (chainId !== DEFAULT_CHAIN_ID) return [];
 

--- a/test/integration/lookupDomains/unstoppableDomains.test.ts
+++ b/test/integration/lookupDomains/unstoppableDomains.test.ts
@@ -26,7 +26,11 @@ describe('lookupDomains/unstoppableDomains', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    process.env.UNSTOPPABLE_DOMAINS_API_KEY = apiKey;
+    if (apiKey === undefined) {
+      delete process.env.UNSTOPPABLE_DOMAINS_API_KEY;
+    } else {
+      process.env.UNSTOPPABLE_DOMAINS_API_KEY = apiKey;
+    }
   });
 
   it('reports the HTTP status when the API is rate limited', async () => {

--- a/test/integration/lookupDomains/unstoppableDomains.test.ts
+++ b/test/integration/lookupDomains/unstoppableDomains.test.ts
@@ -1,0 +1,100 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { FetchError } from '../../../src/addressResolvers/utils';
+import lookupDomains, { DEFAULT_CHAIN_ID } from '../../../src/lookupDomains/unstoppableDomains';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+const ADDRESS = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
+
+function mockFetch(response: { status: number; statusText: string; body: any }) {
+  return jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status,
+    statusText: response.statusText,
+    json: async () => response.body
+  } as Response);
+}
+
+describe('lookupDomains/unstoppableDomains', () => {
+  const apiKey = process.env.UNSTOPPABLE_DOMAINS_API_KEY;
+
+  beforeEach(() => {
+    process.env.UNSTOPPABLE_DOMAINS_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env.UNSTOPPABLE_DOMAINS_API_KEY = apiKey;
+  });
+
+  it('reports the HTTP status when the API is rate limited', async () => {
+    mockFetch({
+      status: 429,
+      statusText: 'Too Many Requests',
+      body: { message: 'API rate limit exceeded' }
+    });
+
+    await expect(lookupDomains(ADDRESS, DEFAULT_CHAIN_ID)).rejects.toBeInstanceOf(FetchError);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Unstoppable Domains API error: HTTP 429 Too Many Requests'
+      }),
+      { input: { address: ADDRESS } }
+    );
+  });
+
+  it('reports the HTTP status when the API rejects the credentials', async () => {
+    mockFetch({
+      status: 401,
+      statusText: 'Unauthorized',
+      body: { message: 'Invalid authentication credentials' }
+    });
+
+    await expect(lookupDomains(ADDRESS, DEFAULT_CHAIN_ID)).rejects.toBeInstanceOf(FetchError);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Unstoppable Domains API error: HTTP 401 Unauthorized'
+      }),
+      { input: { address: ADDRESS } }
+    );
+  });
+
+  it('reports a descriptive error when a 200 body has no data array', async () => {
+    mockFetch({ status: 200, statusText: 'OK', body: { next: null } });
+
+    await expect(lookupDomains(ADDRESS, DEFAULT_CHAIN_ID)).rejects.toBeInstanceOf(FetchError);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Unstoppable Domains API error: response body is missing a data array'
+      }),
+      { input: { address: ADDRESS } }
+    );
+  });
+
+  it('never surfaces a TypeError to Sentry on a non-200 response', async () => {
+    mockFetch({ status: 500, statusText: 'Internal Server Error', body: {} });
+
+    await expect(lookupDomains(ADDRESS, DEFAULT_CHAIN_ID)).rejects.toBeInstanceOf(FetchError);
+    expect(capture).not.toHaveBeenCalledWith(expect.any(TypeError), expect.anything());
+  });
+
+  it('returns the domains on a successful response', async () => {
+    mockFetch({
+      status: 200,
+      statusText: 'OK',
+      body: { data: [{ meta: { domain: 'boorger.sonic' } }], next: null }
+    });
+
+    await expect(lookupDomains(ADDRESS, DEFAULT_CHAIN_ID)).resolves.toEqual(['boorger.sonic']);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not call the API on an unsupported chain', async () => {
+    const fetchSpy = mockFetch({ status: 200, statusText: 'OK', body: { data: [], next: null } });
+
+    await expect(lookupDomains(ADDRESS, '1')).resolves.toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`fetchDomains` in `src/lookupDomains/unstoppableDomains.ts` called `response.json()` without checking `response.ok`. On a non-200 the Unstoppable Domains API returns `{"message": "..."}` with no `data` array, so `data.data.map(...)` threw `TypeError: Cannot read properties of undefined (reading 'map')` — which is the error that reached Sentry, naming neither the provider nor the status code that actually caused it.

Fixes #487

## Reproduction

Both the incident condition and a live non-200 produce the reported Sentry signature on `master`:

```
[mocked 429] thrown to caller : FetchError ""
[mocked 429] sent to Sentry   : TypeError - Cannot read properties of undefined (reading 'map')
[live 401]   sent to Sentry   : TypeError - Cannot read properties of undefined (reading 'map')
```

The live case is a real request to `api.unstoppabledomains.com` with an invalid key; it returns `401 {"message":"Invalid authentication credentials"}`. Any non-200 hits the same path, so the 429 during the incident window and a 401 are indistinguishable to the code.

After this change:

```
[mocked 429] sent to Sentry   : Error - Unstoppable Domains API error: HTTP 429 Too Many Requests
[live 401]   sent to Sentry   : Error - Unstoppable Domains API error: HTTP 401 Unauthorized
```

## Changes

- `fetchDomains` throws `Unstoppable Domains API error: HTTP <status> <statusText>` when `!response.ok`.
- `Array.isArray(data.data)` is checked before returning, so a malformed 200 body reports what is wrong instead of surfacing as the same opaque `TypeError`.

Both mirror the handling already in `src/lookupDomains/shibarium.ts`.

- New suite `test/integration/lookupDomains/unstoppableDomains.test.ts` (6 tests). The four covering 429 / 401 / malformed-200 / no-TypeError fail on `master` with `TypeError: Cannot read properties of undefined (reading 'map')` and pass here.

## Two adjacent findings, deliberately not changed here

Raising these rather than folding them in, since both are behaviour decisions rather than part of this crash.

**1. Sentry volume is unchanged.** The error is now descriptive and groups as one actionable issue, but a rate-limiting window still produces one capture per request — 502 in the incident. A 429 is a transient upstream failure of the same family as the `504` and timeout codes already in `isSilencedError`. It was left visible because silencing it would also hide a genuine quota problem; say the word if you would rather it were silenced.

**2. A single provider failure takes down the whole `lookup_domains` call.** `src/lookupDomains/index.ts:33` uses `Promise.all`, and this resolver rejects with `FetchError`, so an Unstoppable Domains outage discards the ENS and Shibarium results too and the endpoint 500s. Measured on `0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6`:

```
baseline (UD off)  -> ["boorger.eth","whopper.boorger.eth"]
UD returns 429     -> THREW FetchError, ENS results discarded
```

`shibarium.ts` already degrades to a partial result instead of throwing. Making this resolver match would contain provider outages, but it is a real semantic change (a silent `[]` reads as "this address owns no domains"), so it is worth deciding separately.

## Testing

```
$ yarn lint       -> Done in 6.93s.
$ yarn typecheck  -> Done in 10.96s.
$ yarn build      -> Done in 9.87s.
$ npx prettier --check <changed files>  -> All matched files use Prettier code style!

$ npx jest test/integration/lookupDomains/unstoppableDomains.test.ts
  Tests: 6 passed, 6 total     (4 of them fail on master)
```

Three pre-existing failures in `test/integration/lookupDomains.test.ts` (shibarium, unstoppable domains, multi-chain) reproduce identically on unmodified `master` locally — they need `D3_API_KEY_MAINNET` and `UNSTOPPABLE_DOMAINS_API_KEY`, which only CI has. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
