### PR TITLE
fix(starknet): resolve names on-chain instead of via api.starknet.id

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@self.id/core": "^0.3.0",
     "@snapshot-labs/snapshot-metrics": "^2.0.0",
     "@snapshot-labs/snapshot-sentry": "^3.1.0",
-    "@snapshot-labs/snapshot.js": "^0.15.1",
+    "@snapshot-labs/snapshot.js": "^0.15.2",
     "@unstoppabledomains/resolution": "^9.2.2",
     "@webinterop/dns-connect": "^0.3.1",
     "axios": "^0.25.0",

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -1,15 +1,12 @@
+import { validateAndParseAddress } from 'starknet';
 import { provider as getProvider, isStarknetAddress, withoutEmptyValues } from './utils';
 import { Address, Handle } from '../utils';
 
 export const NAME = 'Starknet';
 const NETWORK = '0x534e5f4d41494e';
 const NOT_FOUND_ERROR = 'Starkname not found';
-const EMPTY_STARKNET_ADDRESS = '0x0';
+const EMPTY_STARKNET_ADDRESS = `0x${'0'.repeat(64)}`;
 const provider = getProvider(NETWORK);
-
-function padAddress(address: Address): Address {
-  return `0x${address.replace(/^0x/, '').padStart(64, '0')}`;
-}
 
 function normalizeAddresses(addresses: Address[]): Address[] {
   return addresses.filter(isStarknetAddress);
@@ -53,6 +50,10 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
   return await resolveEach(normalizedHandles, async handle => {
     const address = await provider.getAddressFromStarkName(handle);
 
-    return !address || address === EMPTY_STARKNET_ADDRESS ? undefined : padAddress(address);
+    if (!address) return undefined;
+
+    const parsedAddress = validateAndParseAddress(address);
+
+    return parsedAddress === EMPTY_STARKNET_ADDRESS ? undefined : parsedAddress;
   });
 }

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -1,41 +1,14 @@
-import axios from 'axios';
-import { isStarknetAddress, withoutEmptyValues } from './utils';
+import { provider as getProvider, isStarknetAddress, withoutEmptyValues } from './utils';
 import { Address, Handle } from '../utils';
 
 export const NAME = 'Starknet';
-const BASE_URL = 'https://api.starknet.id';
+const NETWORK = '0x534e5f4d41494e';
+const NOT_FOUND_ERROR = 'Starkname not found';
+const EMPTY_STARKNET_ADDRESS = '0x0';
+const provider = getProvider(NETWORK);
 
-type RESOLVE_TYPE = 'addr_to_domain' | 'domain_to_addr';
-
-function buildApiUrl(resolve_type: RESOLVE_TYPE, needle: string): string {
-  return `${BASE_URL}/${resolve_type}?${
-    resolve_type === 'addr_to_domain' ? 'addr' : 'domain'
-  }=${needle}`;
-}
-
-async function apiCall(
-  resolve_type: RESOLVE_TYPE,
-  needles: string[]
-): Promise<Record<string, string>> {
-  const requests = needles.map(needle =>
-    axios.get(buildApiUrl(resolve_type, needle), { timeout: 5e3 })
-  );
-  const responses = await Promise.allSettled(requests);
-
-  return withoutEmptyValues(
-    Object.fromEntries(
-      needles.map((needle, i) => {
-        const response = responses[i];
-        let value: string | undefined;
-
-        if (response.status === 'fulfilled') {
-          value = response.value.data[resolve_type === 'addr_to_domain' ? 'domain' : 'addr'];
-        }
-
-        return [needle, value];
-      })
-    )
-  );
+function padAddress(address: Address): Address {
+  return `0x${address.replace(/^0x/, '').padStart(64, '0')}`;
 }
 
 function normalizeAddresses(addresses: Address[]): Address[] {
@@ -46,12 +19,30 @@ function normalizeHandles(handles: Handle[]): Handle[] {
   return handles.filter(h => h.endsWith('.stark'));
 }
 
+async function resolveEach(
+  needles: string[],
+  lookup: (needle: string) => Promise<string | undefined>
+): Promise<Record<string, string>> {
+  const values = await Promise.all(
+    needles.map(async needle => {
+      try {
+        return await lookup(needle);
+      } catch (err: any) {
+        if (err?.message?.includes(NOT_FOUND_ERROR)) return undefined;
+        throw err;
+      }
+    })
+  );
+
+  return withoutEmptyValues(Object.fromEntries(needles.map((needle, i) => [needle, values[i]])));
+}
+
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
   const normalizedAddresses = normalizeAddresses(addresses);
 
   if (normalizedAddresses.length === 0) return {};
 
-  return await apiCall('addr_to_domain', normalizedAddresses);
+  return await resolveEach(normalizedAddresses, address => provider.getStarkName(address));
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
@@ -59,5 +50,9 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  return await apiCall('domain_to_addr', normalizedHandles);
+  return await resolveEach(normalizedHandles, async handle => {
+    const address = await provider.getAddressFromStarkName(handle);
+
+    return !address || address === EMPTY_STARKNET_ADDRESS ? undefined : padAddress(address);
+  });
 }

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -8,8 +8,21 @@ const NOT_FOUND_ERROR = 'Starkname not found';
 const EMPTY_STARKNET_ADDRESS = `0x${'0'.repeat(64)}`;
 const provider = getProvider(NETWORK);
 
+// A 64 hex-digit string is not necessarily a valid Starknet address: anything above
+// the felt address bound makes the StarknetID call fail with an opaque
+// 'Could not get stark name', which addressResolvers/index would then report as an
+// outage. Drop those here, so that error only ever means a real failure.
+function isResolvableAddress(address: Address): boolean {
+  try {
+    validateAndParseAddress(address);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function normalizeAddresses(addresses: Address[]): Address[] {
-  return addresses.filter(isStarknetAddress);
+  return addresses.filter(a => isStarknetAddress(a) && isResolvableAddress(a));
 }
 
 function normalizeHandles(handles: Handle[]): Handle[] {

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -1,5 +1,5 @@
 import snapshot from '@snapshot-labs/snapshot.js';
-import { constants, starknetId, validateAndParseAddress } from 'starknet';
+import { CallData, constants, starknetId, validateAndParseAddress } from 'starknet';
 import {
   provider as getProvider,
   hasStarknetAddressShape,
@@ -56,21 +56,17 @@ function normalizeHandles(handles: Handle[]): Handle[] {
   return handles.filter(isStarkDomain);
 }
 
-// `CallData.compile({ address, hint: [] })`, byte for byte what starknet.js sends: the
-// address, then an empty span, which serialises to a bare length of 0.
 function addressToDomainCalldata(address: Address): string[] {
-  return [address, '0'];
+  return CallData.compile({ address, hint: [] });
 }
 
-// `CallData.compile({ domain: encodedDomain, hint: [] })`: the label count, one felt per
-// label leaf first, then the empty hint span.
 function domainToAddressCalldata(handle: Handle): string[] {
-  const labels = handle
+  const domain = handle
     .replace(/\.stark$/, '')
     .split('.')
-    .map(label => starknetId.useEncoded(label).toString(10));
+    .map(label => starknetId.useEncoded(label));
 
-  return [labels.length.toString(), ...labels, '0'];
+  return CallData.compile({ domain, hint: [] });
 }
 
 // An address with no domain answers with an empty span rather than an error, so a miss

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -2,8 +2,8 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { CallData, constants, starknetId, validateAndParseAddress } from 'starknet';
 import {
   provider as getProvider,
-  hasStarknetAddressShape,
   isStarkDomain,
+  isStarknetAddress,
   withoutEmptyValues
 } from './utils';
 import { Address, Handle } from '../utils';
@@ -37,12 +37,13 @@ const NAMING_ABI = [
   }
 ];
 
-// Shape only. The felt bound is guarded upstream, in the shared `normalizeAddresses` that
-// addressResolvers/index runs before any resolver sees the input; what is left here is the
-// part that guard does not do, rejecting EVM addresses, which are valid felts themselves.
-// The composition is pinned by test/unit/addressResolvers/starknet-batch-guard.test.ts.
+// Shape and felt range both. `addressResolvers/index` already applies the same guard upstream,
+// but resolution is one atomic multicall, so a single out-of-range 64 hex-digit value -- a
+// transaction hash, a proposal id -- would take down every name batched alongside it with a
+// `-32602` that `isSilencedError` does not silence. Cheap enough to not depend on the caller.
+// The upstream composition stays pinned by test/unit/addressResolvers/starknet-batch-guard.test.ts.
 function normalizeAddresses(addresses: Address[]): Address[] {
-  return addresses.filter(hasStarknetAddressShape);
+  return addresses.filter(isStarknetAddress);
 }
 
 function normalizeHandles(handles: Handle[]): Handle[] {

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -4,6 +4,7 @@ import {
   provider as getProvider,
   isStarkDomain,
   isStarknetAddress,
+  starkDomainLabels,
   withoutEmptyValues
 } from './utils';
 import { Address, Handle } from '../utils';
@@ -55,10 +56,7 @@ function addressToDomainCalldata(address: Address): string[] {
 }
 
 function domainToAddressCalldata(handle: Handle): string[] {
-  const domain = handle
-    .replace(/\.stark$/, '')
-    .split('.')
-    .map(label => starknetId.useEncoded(label));
+  const domain = starkDomainLabels(handle).map(label => starknetId.useEncoded(label));
 
   return CallData.compile({ domain, hint: [] });
 }

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -2,8 +2,8 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { constants, starknetId, validateAndParseAddress } from 'starknet';
 import {
   provider as getProvider,
+  hasStarknetAddressShape,
   isStarkDomain,
-  isStarknetAddress,
   withoutEmptyValues
 } from './utils';
 import { Address, Handle } from '../utils';
@@ -41,21 +41,15 @@ const NAMING_ABI = [
   }
 ];
 
-// A 64 hex-digit string is not necessarily a valid Starknet address: anything above
-// the felt address bound makes the StarknetID call fail with an opaque
-// 'Could not get stark name', which addressResolvers/index would then report as an
-// outage. Drop those here, so that error only ever means a real failure.
-function isResolvableAddress(address: Address): boolean {
-  try {
-    validateAndParseAddress(address);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
+// Both halves are load-bearing. The shape check is what rejects EVM addresses, which
+// `snapshot.utils.isStarknetAddress` reads as perfectly valid felts. And a 64 hex-digit
+// string is in turn not necessarily a valid address: anything above the felt address
+// bound is rejected by the node, and since the lookup goes through a multicall, one such
+// value fails the *whole* batch with '-32602 ... maximum field value was exceeded', which
+// `isSilencedError` does not silence, so addressResolvers/index would report an outage
+// for every address sent alongside it. Drop them both here.
 function normalizeAddresses(addresses: Address[]): Address[] {
-  return addresses.filter(a => isStarknetAddress(a) && isResolvableAddress(a));
+  return addresses.filter(a => hasStarknetAddressShape(a) && snapshot.utils.isStarknetAddress(a));
 }
 
 function normalizeHandles(handles: Handle[]): Handle[] {

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -1,4 +1,5 @@
-import { validateAndParseAddress } from 'starknet';
+import snapshot from '@snapshot-labs/snapshot.js';
+import { constants, starknetId, validateAndParseAddress } from 'starknet';
 import {
   provider as getProvider,
   isStarkDomain,
@@ -8,10 +9,37 @@ import {
 import { Address, Handle } from '../utils';
 
 export const NAME = 'Starknet';
-const NETWORK = '0x534e5f4d41494e';
-const NOT_FOUND_ERROR = 'Starkname not found';
+const NETWORK = constants.StarknetChainId.SN_MAIN;
 const EMPTY_STARKNET_ADDRESS = `0x${'0'.repeat(64)}`;
+const NAMING_CONTRACT = starknetId.getStarknetIdContract(NETWORK);
 const provider = getProvider(NETWORK);
+
+// The two entrypoints starknet.js calls one address at a time in `getStarkName` and
+// `getAddressFromStarkName`. Declared here so `snapshot.utils.multicall` can parse the
+// retdata: it keys off `name`, and needs `outputs` to know a domain comes back as a span
+// of felts while an address is a single one.
+const NAMING_ABI = [
+  {
+    name: 'address_to_domain',
+    type: 'function',
+    inputs: [
+      { name: 'address', type: 'core::starknet::contract_address::ContractAddress' },
+      { name: 'hint', type: 'core::array::Span::<core::felt252>' }
+    ],
+    outputs: [{ type: 'core::array::Span::<core::felt252>' }],
+    state_mutability: 'view'
+  },
+  {
+    name: 'domain_to_address',
+    type: 'function',
+    inputs: [
+      { name: 'domain', type: 'core::array::Span::<core::felt252>' },
+      { name: 'hint', type: 'core::array::Span::<core::felt252>' }
+    ],
+    outputs: [{ type: 'core::starknet::contract_address::ContractAddress' }],
+    state_mutability: 'view'
+  }
+];
 
 // A 64 hex-digit string is not necessarily a valid Starknet address: anything above
 // the felt address bound makes the StarknetID call fail with an opaque
@@ -34,22 +62,47 @@ function normalizeHandles(handles: Handle[]): Handle[] {
   return handles.filter(isStarkDomain);
 }
 
-async function resolveEach(
-  needles: string[],
-  lookup: (needle: string) => Promise<string | undefined>
-): Promise<Record<string, string>> {
-  const values = await Promise.all(
-    needles.map(async needle => {
-      try {
-        return await lookup(needle);
-      } catch (err: any) {
-        if (err?.message?.includes(NOT_FOUND_ERROR)) return undefined;
-        throw err;
-      }
-    })
-  );
+// `CallData.compile({ address, hint: [] })`, byte for byte what starknet.js sends: the
+// address, then an empty span, which serialises to a bare length of 0.
+function addressToDomainCalldata(address: Address): string[] {
+  return [address, '0'];
+}
 
-  return withoutEmptyValues(Object.fromEntries(needles.map((needle, i) => [needle, values[i]])));
+// `CallData.compile({ domain: encodedDomain, hint: [] })`: the label count, one felt per
+// label leaf first, then the empty hint span.
+function domainToAddressCalldata(handle: Handle): string[] {
+  const labels = handle
+    .replace(/\.stark$/, '')
+    .split('.')
+    .map(label => starknetId.useEncoded(label).toString(10));
+
+  return [labels.length.toString(), ...labels, '0'];
+}
+
+// An address with no domain answers with an empty span rather than an error, so a miss
+// is a value here instead of a throw. Anything that does throw out of `multicall` is an
+// RPC or network fault and is left to propagate to `index.ts`, which captures it.
+function decodeDomain(span: unknown): Handle | undefined {
+  if (!Array.isArray(span) || span.length === 0) return undefined;
+
+  return starknetId.useDecoded(span.map(felt => BigInt(felt))) || undefined;
+}
+
+function decodeAddress(rawAddress: unknown): Address | undefined {
+  if (typeof rawAddress !== 'string') return undefined;
+
+  const address = validateAndParseAddress(rawAddress);
+
+  return address === EMPTY_STARKNET_ADDRESS ? undefined : address;
+}
+
+async function callNamingContract(entrypoint: string, calldata: string[][]): Promise<any[]> {
+  return await snapshot.utils.multicall(
+    NETWORK,
+    provider,
+    NAMING_ABI,
+    calldata.map(args => [NAMING_CONTRACT, entrypoint, args])
+  );
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
@@ -57,7 +110,16 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  return await resolveEach(normalizedAddresses, address => provider.getStarkName(address));
+  const results = await callNamingContract(
+    'address_to_domain',
+    normalizedAddresses.map(addressToDomainCalldata)
+  );
+
+  return withoutEmptyValues(
+    Object.fromEntries(
+      normalizedAddresses.map((address, i) => [address, decodeDomain(results[i]?.[0])])
+    )
+  );
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
@@ -65,13 +127,14 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  return await resolveEach(normalizedHandles, async handle => {
-    const address = await provider.getAddressFromStarkName(handle);
+  const results = await callNamingContract(
+    'domain_to_address',
+    normalizedHandles.map(domainToAddressCalldata)
+  );
 
-    if (!address) return undefined;
-
-    const parsedAddress = validateAndParseAddress(address);
-
-    return parsedAddress === EMPTY_STARKNET_ADDRESS ? undefined : parsedAddress;
-  });
+  return withoutEmptyValues(
+    Object.fromEntries(
+      normalizedHandles.map((handle, i) => [handle, decodeAddress(results[i]?.[0])])
+    )
+  );
 }

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -37,10 +37,12 @@ const NAMING_ABI = [
   }
 ];
 
-// The shape check alone is not enough: a 64 hex-digit string can still be over the felt
-// address bound, and one such value fails the *whole* multicall batch, not just itself.
+// Shape only. The felt bound is guarded upstream, in the shared `normalizeAddresses` that
+// addressResolvers/index runs before any resolver sees the input; what is left here is the
+// part that guard does not do, rejecting EVM addresses, which are valid felts themselves.
+// The composition is pinned by test/unit/addressResolvers/starknet-batch-guard.test.ts.
 function normalizeAddresses(addresses: Address[]): Address[] {
-  return addresses.filter(a => hasStarknetAddressShape(a) && snapshot.utils.isStarknetAddress(a));
+  return addresses.filter(hasStarknetAddressShape);
 }
 
 function normalizeHandles(handles: Handle[]): Handle[] {

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -38,11 +38,10 @@ const NAMING_ABI = [
   }
 ];
 
-// Shape and felt range both. `addressResolvers/index` already applies the same guard upstream,
-// but resolution is one atomic multicall, so a single out-of-range 64 hex-digit value -- a
-// transaction hash, a proposal id -- would take down every name batched alongside it with a
-// `-32602` that `isSilencedError` does not silence. Cheap enough to not depend on the caller.
-// The upstream composition stays pinned by test/unit/addressResolvers/starknet-batch-guard.test.ts.
+// Shape and felt range both. `addressResolvers/index` guards the same bound upstream, but this
+// resolver is exported and its batch is atomic: one out-of-range 64 hex-digit value -- a
+// transaction hash, a proposal id -- takes down every name alongside it with a `-32602` that
+// `isSilencedError` does not silence. Too cheap to be worth depending on the caller for.
 function normalizeAddresses(addresses: Address[]): Address[] {
   return addresses.filter(isStarknetAddress);
 }

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -1,5 +1,10 @@
 import { validateAndParseAddress } from 'starknet';
-import { provider as getProvider, isStarknetAddress, withoutEmptyValues } from './utils';
+import {
+  provider as getProvider,
+  isStarkDomain,
+  isStarknetAddress,
+  withoutEmptyValues
+} from './utils';
 import { Address, Handle } from '../utils';
 
 export const NAME = 'Starknet';
@@ -26,7 +31,7 @@ function normalizeAddresses(addresses: Address[]): Address[] {
 }
 
 function normalizeHandles(handles: Handle[]): Handle[] {
-  return handles.filter(h => h.endsWith('.stark'));
+  return handles.filter(isStarkDomain);
 }
 
 async function resolveEach(

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -14,10 +14,6 @@ const EMPTY_STARKNET_ADDRESS = `0x${'0'.repeat(64)}`;
 const NAMING_CONTRACT = starknetId.getStarknetIdContract(NETWORK);
 const provider = getProvider(NETWORK);
 
-// The two entrypoints starknet.js calls one address at a time in `getStarkName` and
-// `getAddressFromStarkName`. Declared here so `snapshot.utils.multicall` can parse the
-// retdata: it keys off `name`, and needs `outputs` to know a domain comes back as a span
-// of felts while an address is a single one.
 const NAMING_ABI = [
   {
     name: 'address_to_domain',
@@ -41,13 +37,8 @@ const NAMING_ABI = [
   }
 ];
 
-// Both halves are load-bearing. The shape check is what rejects EVM addresses, which
-// `snapshot.utils.isStarknetAddress` reads as perfectly valid felts. And a 64 hex-digit
-// string is in turn not necessarily a valid address: anything above the felt address
-// bound is rejected by the node, and since the lookup goes through a multicall, one such
-// value fails the *whole* batch with '-32602 ... maximum field value was exceeded', which
-// `isSilencedError` does not silence, so addressResolvers/index would report an outage
-// for every address sent alongside it. Drop them both here.
+// The shape check alone is not enough: a 64 hex-digit string can still be over the felt
+// address bound, and one such value fails the *whole* multicall batch, not just itself.
 function normalizeAddresses(addresses: Address[]): Address[] {
   return addresses.filter(a => hasStarknetAddressShape(a) && snapshot.utils.isStarknetAddress(a));
 }
@@ -69,9 +60,6 @@ function domainToAddressCalldata(handle: Handle): string[] {
   return CallData.compile({ domain, hint: [] });
 }
 
-// An address with no domain answers with an empty span rather than an error, so a miss
-// is a value here instead of a throw. Anything that does throw out of `multicall` is an
-// RPC or network fault and is left to propagate to `index.ts`, which captures it.
 function decodeDomain(span: unknown): Handle | undefined {
   if (!Array.isArray(span) || span.length === 0) return undefined;
 

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -27,10 +27,14 @@ export function isStarknetAddress(address: Address): boolean {
 export function isStarkDomain(domain: Handle): boolean {
   if (!/^[a-z0-9-这来]+(\.[a-z0-9-这来]+)*\.stark$/.test(domain)) return false;
 
-  return domain
-    .replace(/\.stark$/, '')
-    .split('.')
-    .every(label => starknetId.useEncoded(label) < constants.PRIME);
+  return starkDomainLabels(domain).every(label => starknetId.useEncoded(label) < constants.PRIME);
+}
+
+// Shared with `domainToAddressCalldata` in addressResolvers/starknet.ts: this decomposition
+// picks the labels `isStarkDomain` validates, and the same labels are what later reach the
+// contract, so the two must not drift apart.
+export function starkDomainLabels(domain: Handle): string[] {
+  return domain.replace(/\.stark$/, '').split('.');
 }
 
 export function provider(

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -10,7 +10,14 @@ export function isEvmAddress(address: Address): boolean {
 
 // `snapshot.utils.isStarknetAddress` is a felt-range check: `true` for an EVM address too.
 export function isStarknetAddress(address: Address): boolean {
-  return /^0x[a-fA-F0-9]{64}$/.test(address) && snapshot.utils.isStarknetAddress(address);
+  return hasStarknetAddressShape(address) && snapshot.utils.isStarknetAddress(address);
+}
+
+// A shape check only, and deliberately not named after `snapshot.utils.isStarknetAddress`:
+// that one asks whether the value is a felt below the address bound, and answers `true`
+// for an EVM address. This one is what tells the two address formats apart.
+export function hasStarknetAddressShape(address: Address): boolean {
+  return /^0x[a-fA-F0-9]{64}$/.test(address);
 }
 
 // StarknetID's encoder skips any character outside this class instead of rejecting it,

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -9,15 +9,9 @@ export function isEvmAddress(address: Address): boolean {
   return /^0x[a-fA-F0-9]{40}$/.test(address);
 }
 
-// The felt range on its own answers `true` for an EVM address, so both halves are needed.
+// `snapshot.utils.isStarknetAddress` is a felt-range check: `true` for an EVM address too.
 export function isStarknetAddress(address: Address): boolean {
-  return hasStarknetAddressShape(address) && snapshot.utils.isStarknetAddress(address);
-}
-
-// Shape only, and deliberately not named after `snapshot.utils.isStarknetAddress`: that one
-// answers `true` for an EVM address, so it cannot tell the two address formats apart.
-export function hasStarknetAddressShape(address: Address): boolean {
-  return /^0x[a-fA-F0-9]{64}$/.test(address);
+  return /^0x[a-fA-F0-9]{64}$/.test(address) && snapshot.utils.isStarknetAddress(address);
 }
 
 // StarknetID's encoder skips characters outside its alphabet instead of rejecting them, so

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -13,6 +13,15 @@ export function isStarknetAddress(address: Address): boolean {
   return /^0x[a-fA-F0-9]{64}$/.test(address) && snapshot.utils.isStarknetAddress(address);
 }
 
+// StarknetID's encoder skips any character outside this class instead of rejecting it,
+// so `a!b.stark` encodes exactly like `ab.stark` and resolves to that owner, and
+// `!!!.stark` encodes to felt 0, which maps to a real account. Checking the suffix is
+// therefore not enough: the whole handle has to match the character class StarknetID
+// itself accepts (`isStarkDomain` in lfglabs-dev/starknetid.js), subdomains included.
+export function isStarkDomain(domain: Handle): boolean {
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)*\.stark$/.test(domain);
+}
+
 export function provider(
   network: string,
   providerOptions: { broviderUrl?: string; timeout?: number } = { broviderUrl, timeout: 5e3 }

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -24,8 +24,15 @@ export function isStarknetAddress(address: Address): boolean {
 // `'a'.repeat(47) + 'b'` resolves and `'a'.repeat(48)` is over-prime, both 48 characters. One
 // over-prime label fails the *whole* multicall with a `-32602` that `isSilencedError` does not
 // silence, taking down every name batched alongside it.
+//
+// The 48 character cap keeps nothing out that the felt bound would have let in -- the smallest
+// felt a 49 character label can encode to is 38^48, already past the prime -- but it stops a
+// multi-megabyte label from reaching `useEncoded`, whose BigInt loop grows worse than
+// quadratically and runs before the first await. `resolve_names` caps the array at 5 entries
+// and never the strings, so without it one unauthenticated request blocks the event loop for
+// minutes.
 export function isStarkDomain(domain: Handle): boolean {
-  if (!/^[a-z0-9-这来]+(\.[a-z0-9-这来]+)*\.stark$/.test(domain)) return false;
+  if (!/^[a-z0-9-这来]{1,48}(\.[a-z0-9-这来]{1,48})*\.stark$/.test(domain)) return false;
 
   return starkDomainLabels(domain).every(label => starknetId.useEncoded(label) < constants.PRIME);
 }

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -20,26 +20,21 @@ export function isStarknetAddress(address: Address): boolean {
 // `bigAlphabet` glyphs (`这来`), which the encoder does consume, so they round-trip and cannot
 // collide -- and `来baba这.stark` is registered on mainnet.
 //
-// The felt bound is guarded directly because length is the wrong proxy for it:
-// `'a'.repeat(47) + 'b'` resolves and `'a'.repeat(48)` is over-prime, both 48 characters. One
+// Both bounds on a label are needed. The felt is the real invariant and length is no proxy for
+// it: `'a'.repeat(47) + 'b'` resolves where `'a'.repeat(48)` is over-prime, both 48 characters.
+// The cap rejects nothing the felt check would have kept -- 49 characters encode to 38^48 at
+// the very least, already past the prime -- but it keeps a multi-megabyte label away from
+// `useEncoded`, whose BigInt loop grows worse than quadratically before the first await. One
 // over-prime label fails the *whole* multicall with a `-32602` that `isSilencedError` does not
 // silence, taking down every name batched alongside it.
-//
-// The 48 character cap keeps nothing out that the felt bound would have let in -- the smallest
-// felt a 49 character label can encode to is 38^48, already past the prime -- but it stops a
-// multi-megabyte label from reaching `useEncoded`, whose BigInt loop grows worse than
-// quadratically and runs before the first await. `resolve_names` caps the array at 5 entries
-// and never the strings, so without it one unauthenticated request blocks the event loop for
-// minutes.
 export function isStarkDomain(domain: Handle): boolean {
   if (!/^[a-z0-9-这来]{1,48}(\.[a-z0-9-这来]{1,48})*\.stark$/.test(domain)) return false;
 
   return starkDomainLabels(domain).every(label => starknetId.useEncoded(label) < constants.PRIME);
 }
 
-// Shared with `domainToAddressCalldata` in addressResolvers/starknet.ts: this decomposition
-// picks the labels `isStarkDomain` validates, and the same labels are what later reach the
-// contract, so the two must not drift apart.
+// Shared with `domainToAddressCalldata` in addressResolvers/starknet.ts: the labels validated
+// here are the labels later sent to the contract, and a second copy of this step could drift.
 export function starkDomainLabels(domain: Handle): string[] {
   return domain.replace(/\.stark$/, '').split('.');
 }

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -9,36 +9,27 @@ export function isEvmAddress(address: Address): boolean {
   return /^0x[a-fA-F0-9]{40}$/.test(address);
 }
 
-// `snapshot.utils.isStarknetAddress` is a felt-range check: `true` for an EVM address too.
+// The felt range on its own answers `true` for an EVM address, so both halves are needed.
 export function isStarknetAddress(address: Address): boolean {
   return hasStarknetAddressShape(address) && snapshot.utils.isStarknetAddress(address);
 }
 
-// A shape check only, and deliberately not named after `snapshot.utils.isStarknetAddress`:
-// that one asks whether the value is a felt below the address bound, and answers `true`
-// for an EVM address. This one is what tells the two address formats apart.
+// Shape only, and deliberately not named after `snapshot.utils.isStarknetAddress`: that one
+// answers `true` for an EVM address, so it cannot tell the two address formats apart.
 export function hasStarknetAddressShape(address: Address): boolean {
   return /^0x[a-fA-F0-9]{64}$/.test(address);
 }
 
-// StarknetID's encoder skips any character outside its alphabet instead of rejecting it,
-// so `a!b.stark` encodes exactly like `ab.stark` and resolves to that owner, and
-// `!!!.stark` encodes to felt 0, which maps to a real account. Checking the suffix is
-// therefore not enough: every label has to match the alphabet, subdomains included.
+// StarknetID's encoder skips characters outside its alphabet instead of rejecting them, so
+// `a!b.stark` encodes exactly like `ab.stark` and would resolve to that owner. Every label has
+// to match, subdomains included. The alphabet is starknet.js's `basicAlphabet` plus the two
+// `bigAlphabet` glyphs (`这来`), which the encoder does consume, so they round-trip and cannot
+// collide -- and `来baba这.stark` is registered on mainnet.
 //
-// That alphabet is starknet.js's `basicAlphabet` (`[a-z0-9-]`) *plus* the two-glyph
-// `bigAlphabet` (`这来`). Those two are safe to admit: unlike a skipped character, the
-// encoder consumes them and advances the multiplier, so they round-trip through
-// `useDecoded` and cannot collide with a shorter handle. They are also in live use --
-// `来baba这.stark` is registered on mainnet.
-//
-// The character class alone is not sufficient either. A label whose felt reaches the
-// field prime is rejected by the node, and because resolution is a single atomic
-// multicall, that one value fails the *whole* batch with `-32602 ... maximum field value
-// was exceeded` -- which `isSilencedError` does not silence, so it would report an outage
-// for every name sent alongside it. Length is the wrong proxy for that bound:
-// `'a'.repeat(47) + 'b'` is 48 characters and resolves, `'a'.repeat(48)` is 48 characters
-// and is over-prime. Guard on the felt itself.
+// The felt bound is guarded directly because length is the wrong proxy for it:
+// `'a'.repeat(47) + 'b'` resolves and `'a'.repeat(48)` is over-prime, both 48 characters. One
+// over-prime label fails the *whole* multicall with a `-32602` that `isSilencedError` does not
+// silence, taking down every name batched alongside it.
 export function isStarkDomain(domain: Handle): boolean {
   if (!/^[a-z0-9-这来]+(\.[a-z0-9-这来]+)*\.stark$/.test(domain)) return false;
 

--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -1,5 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import snapshot from '@snapshot-labs/snapshot.js';
+import { constants, starknetId } from 'starknet';
 import { Address, EMPTY_ADDRESS, Handle } from '../utils';
 
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
@@ -20,13 +21,31 @@ export function hasStarknetAddressShape(address: Address): boolean {
   return /^0x[a-fA-F0-9]{64}$/.test(address);
 }
 
-// StarknetID's encoder skips any character outside this class instead of rejecting it,
+// StarknetID's encoder skips any character outside its alphabet instead of rejecting it,
 // so `a!b.stark` encodes exactly like `ab.stark` and resolves to that owner, and
 // `!!!.stark` encodes to felt 0, which maps to a real account. Checking the suffix is
-// therefore not enough: the whole handle has to match the character class StarknetID
-// itself accepts (`isStarkDomain` in lfglabs-dev/starknetid.js), subdomains included.
+// therefore not enough: every label has to match the alphabet, subdomains included.
+//
+// That alphabet is starknet.js's `basicAlphabet` (`[a-z0-9-]`) *plus* the two-glyph
+// `bigAlphabet` (`这来`). Those two are safe to admit: unlike a skipped character, the
+// encoder consumes them and advances the multiplier, so they round-trip through
+// `useDecoded` and cannot collide with a shorter handle. They are also in live use --
+// `来baba这.stark` is registered on mainnet.
+//
+// The character class alone is not sufficient either. A label whose felt reaches the
+// field prime is rejected by the node, and because resolution is a single atomic
+// multicall, that one value fails the *whole* batch with `-32602 ... maximum field value
+// was exceeded` -- which `isSilencedError` does not silence, so it would report an outage
+// for every name sent alongside it. Length is the wrong proxy for that bound:
+// `'a'.repeat(47) + 'b'` is 48 characters and resolves, `'a'.repeat(48)` is 48 characters
+// and is over-prime. Guard on the felt itself.
 export function isStarkDomain(domain: Handle): boolean {
-  return /^[a-z0-9-]+(\.[a-z0-9-]+)*\.stark$/.test(domain);
+  if (!/^[a-z0-9-这来]+(\.[a-z0-9-这来]+)*\.stark$/.test(domain)) return false;
+
+  return domain
+    .replace(/\.stark$/, '')
+    .split('.')
+    .every(label => starknetId.useEncoded(label) < constants.PRIME);
 }
 
 export function provider(

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -1,15 +1,11 @@
 import axios from 'axios';
-import { provider as getProvider } from '../addressResolvers/utils';
+import { provider as getProvider, isStarkDomain } from '../addressResolvers/utils';
 import { max } from '../constants.json';
 import { getUrl, resize } from '../utils';
 import { axiosDefaultParams, fetchHttpImage } from './utils';
 
 const DEFAULT_IMG_URL = 'https://starknet.id/api/identicons/0';
 const provider = getProvider('0x534e5f4d41494e');
-
-function isStarknetDomain(domain: string): boolean {
-  return domain.endsWith('.stark');
-}
 
 function normalizeAddress(address: string): string {
   if (!address.match(/^(0x)?[0-9a-fA-F]{64}$/)) throw new Error('Invalid starknet address');
@@ -24,7 +20,7 @@ async function getStarknetAddress(domain: string): Promise<string | null> {
 }
 
 async function getImage(domainOrAddress: string): Promise<string | null> {
-  const address = isStarknetDomain(domainOrAddress)
+  const address = isStarkDomain(domainOrAddress)
     ? await getStarknetAddress(domainOrAddress)
     : normalizeAddress(domainOrAddress);
 

--- a/test/unit/addressResolvers/starknet-batch-guard.test.ts
+++ b/test/unit/addressResolvers/starknet-batch-guard.test.ts
@@ -73,9 +73,9 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-// starknet.ts filters on address *shape* only; the felt bound is guarded upstream, in the
-// shared `normalizeAddresses`. This pins the composition the resolver now depends on:
-// name resolution is a single atomic multicall, so one out-of-range felt fails the whole
+// starknet.ts guards the felt bound itself; this pins the other half, the shared
+// `normalizeAddresses` that addressResolvers/index runs before any resolver sees the input.
+// Name resolution is a single atomic multicall, so one out-of-range felt fails the whole
 // batch with a `-32602 ... maximum field value was exceeded` that `isSilencedError` does
 // not silence -- reported as an outage for every address queried alongside it.
 describe('Starknet batch guard', () => {

--- a/test/unit/addressResolvers/starknet-batch-guard.test.ts
+++ b/test/unit/addressResolvers/starknet-batch-guard.test.ts
@@ -1,0 +1,99 @@
+const mockCallContract = jest.fn();
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
+
+// Run the resolver fan-out on every call, without a redis round trip.
+jest.mock('../../../src/addressResolvers/cache', () => ({
+  __esModule: true,
+  default: (input: string[], callback: (input: string[]) => any) => callback(input),
+  clear: jest.fn()
+}));
+
+jest.mock('../../../src/addressResolvers/utils', () => {
+  const actual = jest.requireActual('../../../src/addressResolvers/utils');
+
+  return { ...actual, provider: () => ({ callContract: mockCallContract }) };
+});
+
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { lookupAddresses } from '../../../src/addressResolvers';
+import * as basename from '../../../src/addressResolvers/basename';
+import * as ens from '../../../src/addressResolvers/ens';
+import * as gwei from '../../../src/addressResolvers/gwei';
+import * as lens from '../../../src/addressResolvers/lens';
+import * as shibarium from '../../../src/addressResolvers/shibarium';
+import * as snapshotResolver from '../../../src/addressResolvers/snapshot';
+import * as spaceId from '../../../src/addressResolvers/spaceId';
+import * as unstoppableDomains from '../../../src/addressResolvers/unstoppableDomains';
+
+// Every resolver but Starknet, which is the one under test here.
+const OTHER_RESOLVERS = [
+  snapshotResolver,
+  ens,
+  basename,
+  unstoppableDomains,
+  lens,
+  shibarium,
+  spaceId,
+  gwei
+];
+
+const EVM_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+// Below 2^251 - 256, so a real Starknet address.
+const IN_RANGE = '0x07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
+// At the bound: the same 64 hex-digit shape, but not an address. A transaction hash or a
+// proposal id looks exactly like this, and about 97% of them land here.
+const OUT_OF_RANGE = '0x07ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00';
+
+// The two values as the felts `CallData.compile` emits, pinned rather than recomputed.
+const IN_RANGE_FELT =
+  '3617475073865317856576155523118490860061508207210341692414423635860939015053';
+const OUT_OF_RANGE_FELT =
+  '3618502788666131106986593281521497120414687020801267626233049500247285300992';
+
+const hex = (n: number) => `0x${n.toString(16)}`;
+
+// One empty domain span per call: every address resolves to no name, and nothing throws.
+function emptyDomainSpans(count: number): string[] {
+  const body = Array.from({ length: count }, () => ['0x1', '0x0']).flat();
+
+  return ['0x1', hex(body.length), ...body];
+}
+
+beforeEach(() => {
+  mockCallContract.mockImplementation(async (call: { calldata: string[] }) =>
+    emptyDomainSpans(Number(call.calldata[0]))
+  );
+  OTHER_RESOLVERS.forEach(resolver =>
+    jest.spyOn(resolver, 'lookupAddresses').mockResolvedValue({})
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// starknet.ts filters on address *shape* only; the felt bound is guarded upstream, in the
+// shared `normalizeAddresses`. This pins the composition the resolver now depends on:
+// name resolution is a single atomic multicall, so one out-of-range felt fails the whole
+// batch with a `-32602 ... maximum field value was exceeded` that `isSilencedError` does
+// not silence -- reported as an outage for every address queried alongside it.
+describe('Starknet batch guard', () => {
+  it('keeps an out-of-range 64 hex-digit value out of the naming multicall', async () => {
+    await lookupAddresses([EVM_ADDRESS, IN_RANGE, OUT_OF_RANGE]);
+
+    expect(mockCallContract).toHaveBeenCalledTimes(1);
+
+    const { calldata } = mockCallContract.mock.calls[0][0];
+    expect(calldata).toContain(IN_RANGE_FELT);
+    expect(calldata).not.toContain(OUT_OF_RANGE_FELT);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not call the contract at all when every address is out of range', async () => {
+    await expect(lookupAddresses([OUT_OF_RANGE])).resolves.toEqual({});
+
+    expect(mockCallContract).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -26,8 +26,8 @@ const PADDED_AS_FELT =
 
 const hex = (n: number) => `0x${n.toString(16)}`;
 
-// The `aggregate` retdata shape snapshot.js parses: block number, total length, then
-// each call's response prefixed with its own length.
+// The `aggregate` retdata snapshot.js parses: block number, total felt count, then each
+// call's response prefixed with its own length.
 function aggregateResponse(responses: string[][]): string[] {
   const body = responses.flatMap(response => [hex(response.length), ...response]);
 
@@ -42,7 +42,6 @@ const mockDomains = (...spans: string[][]) =>
 const mockAddresses = (...addresses: string[]) =>
   mockCallContract.mockResolvedValueOnce(aggregateResponse(addresses.map(address => [address])));
 
-// A response that stops before the slot the ABI promises.
 const mockTruncated = () => mockCallContract.mockResolvedValueOnce(aggregateResponse([[]]));
 
 beforeEach(() => {
@@ -122,9 +121,7 @@ describe('Starknet address resolver', () => {
       expect(mockCallContract).not.toHaveBeenCalled();
     });
 
-    // StarknetID's encoder drops any character outside its alphabet instead of rejecting
-    // it, so these would otherwise encode like a shorter, registered handle and come
-    // back with someone else's address. They must not reach the contract at all.
+    // These encode like a shorter, registered handle, so they must not reach the contract at all.
     it.each(['a!b.stark', '!!!.stark', '.stark', 'a b.stark', 'a_b.stark', 'ab.stark.eth'])(
       'ignores %p, without looking it up',
       async handle => {
@@ -133,17 +130,14 @@ describe('Starknet address resolver', () => {
       }
     );
 
-    // The expected felts are pinned literals captured from starknet.js, not recomputed
-    // here with the same `useEncoded` chain the resolver uses -- otherwise the assertion
-    // is only the encoding agreeing with a copy of itself.
+    // Pinned literals captured from starknet.js, deliberately not recomputed here with the same
+    // `useEncoded` the resolver calls -- that would only assert the encoder matches itself.
     it.each([
       ['ab.stark', ['38']],
       ['a-b.stark', ['2812']],
       ['123.stark', ['42967']],
       ['notion.eth.stark', ['1059716045', '10834']],
-      // `bigAlphabet`. The encoder consumes these two glyphs and advances the multiplier,
-      // so unlike `!` they round-trip and cannot collide, and the name is registered on
-      // mainnet -- rejecting it drops a real avatar to the blockie fallback.
+      // `bigAlphabet`. Registered on mainnet; rejecting it drops a real avatar to a blockie.
       ['来baba这.stark', ['11885385095']]
     ])('still resolves %p, sending label felts %p', async (handle, labels) => {
       mockAddresses(PADDED);
@@ -152,10 +146,7 @@ describe('Starknet address resolver', () => {
       expect(mockCallContract.mock.calls[0][0].calldata).toEqual(expect.arrayContaining(labels));
     });
 
-    // The node rejects a label whose felt reaches the field prime, and since the lookup
-    // is one atomic multicall that failure takes every name batched alongside it down
-    // too, as a `-32602` that `isSilencedError` does not silence. The bound is a felt
-    // value and not a character count: the first two labels here are both 48 characters.
+    // `VALID_48` and `OVER_PRIME_48` are both 48 characters: the bound is a felt, not a length.
     describe('felt bound', () => {
       const VALID_48 = `${'a'.repeat(47)}b`;
       const VALID_48_FELT =

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -16,6 +16,11 @@ const UNPADDED = '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b0
 const MIXED_CASE = '0x7FF6b17F07c4d83236e3FC5f94259a19D1ed41BBcf1822397ea17882e9B038D';
 const ZERO_ADDRESS = `0x${'0'.repeat(64)}`;
 const EVM_ADDRESS = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+// The same 64 hex-digit shape as an address, but past the felt bound: a transaction hash or a
+// proposal id looks exactly like this, and about 97% of them land here.
+const OUT_OF_RANGE = '0x07ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00';
+const OUT_OF_RANGE_FELT =
+  '3618502788666131106986593281521497120414687020801267626233049500247285300992';
 // The felt `checkpoint.stark` encodes to, as returned live by address_to_domain.
 const CHECKPOINT_FELT = '0xb5b47279a7f0c';
 // The same felt in the decimal form `CallData.compile` emits into the calldata.
@@ -246,6 +251,21 @@ describe('Starknet address resolver', () => {
     it('ignores non-starknet addresses', async () => {
       await expect(lookupAddresses([EVM_ADDRESS])).resolves.toEqual({});
       expect(mockCallContract).not.toHaveBeenCalled();
+    });
+
+    // `addressResolvers/index` filters this out upstream too, but the resolver is exported: a
+    // direct caller passing one poisons the single atomic multicall with a `-32602` that
+    // `isSilencedError` does not silence, losing every address batched alongside it.
+    it('ignores a 64 hex-digit value past the felt range', async () => {
+      mockDomains([CHECKPOINT_FELT]);
+
+      await expect(lookupAddresses([PADDED, OUT_OF_RANGE])).resolves.toEqual({
+        [PADDED]: 'checkpoint.stark'
+      });
+
+      const { calldata } = mockCallContract.mock.calls[0][0];
+      expect(calldata).toContain(PADDED_AS_FELT);
+      expect(calldata).not.toContain(OUT_OF_RANGE_FELT);
     });
   });
 });

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -19,6 +19,8 @@ const ZERO_ADDRESS = `0x${'0'.repeat(64)}`;
 const EVM_ADDRESS = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
 // The felt `checkpoint.stark` encodes to, as returned live by address_to_domain.
 const CHECKPOINT_FELT = '0xb5b47279a7f0c';
+// The same felt in the decimal form the calldata carries.
+const CHECKPOINT_LABEL_FELT = '3196585909059340';
 
 const hex = (n: number) => `0x${n.toString(16)}`;
 
@@ -118,7 +120,7 @@ describe('Starknet address resolver', () => {
       expect(mockCallContract).not.toHaveBeenCalled();
     });
 
-    // StarknetID's encoder drops any character outside [a-z0-9-] instead of rejecting
+    // StarknetID's encoder drops any character outside its alphabet instead of rejecting
     // it, so these would otherwise encode like a shorter, registered handle and come
     // back with someone else's address. They must not reach the contract at all.
     it.each(['a!b.stark', '!!!.stark', '.stark', 'a b.stark', 'a_b.stark', 'ab.stark.eth'])(
@@ -129,21 +131,73 @@ describe('Starknet address resolver', () => {
       }
     );
 
-    it.each(['ab.stark', 'notion.eth.stark', 'a-b.stark', '123.stark'])(
-      'still resolves %p',
-      async handle => {
+    it.each([
+      'ab.stark',
+      'notion.eth.stark',
+      'a-b.stark',
+      '123.stark',
+      // `bigAlphabet`. The encoder consumes these two glyphs and advances the multiplier,
+      // so unlike `!` they round-trip and cannot collide, and the name is registered on
+      // mainnet -- rejecting it drops a real avatar to the blockie fallback.
+      '来baba这.stark'
+    ])('still resolves %p', async handle => {
+      mockAddresses(PADDED);
+
+      await expect(resolveNames([handle])).resolves.toEqual({ [handle]: PADDED });
+
+      const labels = handle
+        .replace(/\.stark$/, '')
+        .split('.')
+        .map(label => starknetId.useEncoded(label).toString(10));
+
+      expect(mockCallContract.mock.calls[0][0].calldata).toEqual(expect.arrayContaining(labels));
+    });
+
+    // The node rejects a label whose felt reaches the field prime, and since the lookup
+    // is one atomic multicall that failure takes every name batched alongside it down
+    // too, as a `-32602` that `isSilencedError` does not silence. The bound is a felt
+    // value and not a character count: the first two labels here are both 48 characters.
+    describe('felt bound', () => {
+      const VALID_48 = `${'a'.repeat(47)}b`;
+      const VALID_48_FELT =
+        '177757953225819951046325525739851593013572474885857896325015713055393185792';
+      const OVER_PRIME_48 = 'a'.repeat(48);
+      const OVER_PRIME_48_FELT =
+        '6577044269355338188714044452374508941502181570776742164025581383049547874304';
+      const OVER_PRIME_49 = 'a'.repeat(49);
+
+      it('resolves a 48 character label that stays below the prime', async () => {
         mockAddresses(PADDED);
 
-        await expect(resolveNames([handle])).resolves.toEqual({ [handle]: PADDED });
+        await expect(resolveNames([`${VALID_48}.stark`])).resolves.toEqual({
+          [`${VALID_48}.stark`]: PADDED
+        });
+        expect(mockCallContract.mock.calls[0][0].calldata).toEqual(
+          expect.arrayContaining([VALID_48_FELT])
+        );
+      });
 
-        const labels = handle
-          .replace(/\.stark$/, '')
-          .split('.')
-          .map(label => starknetId.useEncoded(label).toString(10));
+      it.each([
+        ['48 characters', OVER_PRIME_48],
+        ['49 characters', OVER_PRIME_49]
+      ])('drops an over-prime label of %s, without looking it up', async (_, label) => {
+        await expect(resolveNames([`${label}.stark`])).resolves.toEqual({});
+        expect(mockCallContract).not.toHaveBeenCalled();
+      });
 
-        expect(mockCallContract.mock.calls[0][0].calldata).toEqual(expect.arrayContaining(labels));
-      }
-    );
+      it('keeps the rest of the batch when one name is over-prime', async () => {
+        mockAddresses(PADDED);
+
+        await expect(resolveNames(['checkpoint.stark', `${OVER_PRIME_48}.stark`])).resolves.toEqual(
+          { 'checkpoint.stark': PADDED }
+        );
+        expect(mockCallContract).toHaveBeenCalledTimes(1);
+
+        const { calldata } = mockCallContract.mock.calls[0][0];
+        expect(calldata).toEqual(expect.arrayContaining([CHECKPOINT_LABEL_FELT]));
+        expect(calldata).not.toContain(OVER_PRIME_48_FELT);
+      });
+    });
 
     it('resolves a whole batch in a single call', async () => {
       mockAddresses(PADDED, ZERO_ADDRESS, UNPADDED);

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -141,9 +141,7 @@ describe('Starknet address resolver', () => {
           .split('.')
           .map(label => starknetId.useEncoded(label).toString(10));
 
-        expect(mockCallContract.mock.calls[0][0].calldata).toEqual(
-          expect.arrayContaining(labels)
-        );
+        expect(mockCallContract.mock.calls[0][0].calldata).toEqual(expect.arrayContaining(labels));
       }
     );
 

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -9,7 +9,6 @@ jest.mock('../../../src/addressResolvers/utils', () => {
   };
 });
 
-import { starknetId } from 'starknet';
 import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/starknet';
 
 const PADDED = '0x07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
@@ -19,8 +18,11 @@ const ZERO_ADDRESS = `0x${'0'.repeat(64)}`;
 const EVM_ADDRESS = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
 // The felt `checkpoint.stark` encodes to, as returned live by address_to_domain.
 const CHECKPOINT_FELT = '0xb5b47279a7f0c';
-// The same felt in the decimal form the calldata carries.
+// The same felt in the decimal form `CallData.compile` emits into the calldata.
 const CHECKPOINT_LABEL_FELT = '3196585909059340';
+// `PADDED` as the single felt the compiled address_to_domain calldata carries.
+const PADDED_AS_FELT =
+  '3617475073865317856576155523118490860061508207210341692414423635860939015053';
 
 const hex = (n: number) => `0x${n.toString(16)}`;
 
@@ -131,25 +133,22 @@ describe('Starknet address resolver', () => {
       }
     );
 
+    // The expected felts are pinned literals captured from starknet.js, not recomputed
+    // here with the same `useEncoded` chain the resolver uses -- otherwise the assertion
+    // is only the encoding agreeing with a copy of itself.
     it.each([
-      'ab.stark',
-      'notion.eth.stark',
-      'a-b.stark',
-      '123.stark',
+      ['ab.stark', ['38']],
+      ['a-b.stark', ['2812']],
+      ['123.stark', ['42967']],
+      ['notion.eth.stark', ['1059716045', '10834']],
       // `bigAlphabet`. The encoder consumes these two glyphs and advances the multiplier,
       // so unlike `!` they round-trip and cannot collide, and the name is registered on
       // mainnet -- rejecting it drops a real avatar to the blockie fallback.
-      '来baba这.stark'
-    ])('still resolves %p', async handle => {
+      ['来baba这.stark', ['11885385095']]
+    ])('still resolves %p, sending label felts %p', async (handle, labels) => {
       mockAddresses(PADDED);
 
       await expect(resolveNames([handle])).resolves.toEqual({ [handle]: PADDED });
-
-      const labels = handle
-        .replace(/\.stark$/, '')
-        .split('.')
-        .map(label => starknetId.useEncoded(label).toString(10));
-
       expect(mockCallContract.mock.calls[0][0].calldata).toEqual(expect.arrayContaining(labels));
     });
 
@@ -219,6 +218,16 @@ describe('Starknet address resolver', () => {
       await expect(lookupAddresses([PADDED])).resolves.toEqual({
         [PADDED]: 'checkpoint.stark'
       });
+    });
+
+    it('sends the address as a felt followed by an empty hint span', async () => {
+      mockDomains([CHECKPOINT_FELT]);
+
+      await lookupAddresses([PADDED]);
+
+      expect(mockCallContract.mock.calls[0][0].calldata).toEqual(
+        expect.arrayContaining([PADDED_AS_FELT])
+      );
     });
 
     it('drops addresses without a name, and keeps the others', async () => {

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -87,6 +87,27 @@ describe('Starknet address resolver', () => {
       await expect(resolveNames(['domain.eth', 'domain.crypto'])).resolves.toEqual({});
       expect(mockGetAddressFromStarkName).not.toHaveBeenCalled();
     });
+
+    // StarknetID's encoder drops any character outside [a-z0-9-] instead of rejecting
+    // it, so these would otherwise encode like a shorter, registered handle and come
+    // back with someone else's address. They must not reach the contract at all.
+    it.each(['a!b.stark', '!!!.stark', '.stark', 'a b.stark', 'a_b.stark', 'ab.stark.eth'])(
+      'ignores %p, without looking it up',
+      async handle => {
+        await expect(resolveNames([handle])).resolves.toEqual({});
+        expect(mockGetAddressFromStarkName).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(['ab.stark', 'notion.eth.stark', 'a-b.stark', '123.stark'])(
+      'still resolves %p',
+      async handle => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(PADDED);
+
+        await expect(resolveNames([handle])).resolves.toEqual({ [handle]: PADDED });
+        expect(mockGetAddressFromStarkName).toHaveBeenCalledWith(handle);
+      }
+    );
   });
 
   describe('lookupAddresses()', () => {

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -1,5 +1,17 @@
 const mockCallContract = jest.fn();
 
+// `starknetId`'s members are non-configurable getters, so `jest.spyOn` cannot install on them.
+// Wrapping the encoder in a call-through mock observes it without replacing it, which keeps the
+// felt literals pinned below honest.
+jest.mock('starknet', () => {
+  const actual = jest.requireActual('starknet');
+
+  return {
+    ...actual,
+    starknetId: { ...actual.starknetId, useEncoded: jest.fn(actual.starknetId.useEncoded) }
+  };
+});
+
 jest.mock('../../../src/addressResolvers/utils', () => {
   const actual = jest.requireActual('../../../src/addressResolvers/utils');
 
@@ -9,7 +21,10 @@ jest.mock('../../../src/addressResolvers/utils', () => {
   };
 });
 
+import { starknetId } from 'starknet';
 import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/starknet';
+
+const mockUseEncoded = starknetId.useEncoded as unknown as jest.Mock;
 
 const PADDED = '0x07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
 const UNPADDED = '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
@@ -51,6 +66,7 @@ const mockTruncated = () => mockCallContract.mockResolvedValueOnce(aggregateResp
 
 beforeEach(() => {
   mockCallContract.mockReset();
+  mockUseEncoded.mockClear();
 });
 
 describe('Starknet address resolver', () => {
@@ -177,6 +193,16 @@ describe('Starknet address resolver', () => {
         ['49 characters', OVER_PRIME_49]
       ])('drops an over-prime label of %s, without looking it up', async (_, label) => {
         await expect(resolveNames([`${label}.stark`])).resolves.toEqual({});
+        expect(mockCallContract).not.toHaveBeenCalled();
+      });
+
+      // The felt check would reject this too, but only after paying the encoder, whose BigInt
+      // loop is worse than quadratic. `OVER_PRIME_49` above does not pin that: it is short
+      // enough to be cheap either way.
+      it('drops an oversized label without encoding it', async () => {
+        await expect(resolveNames([`${'a'.repeat(100_000)}.stark`])).resolves.toEqual({});
+
+        expect(mockUseEncoded).not.toHaveBeenCalled();
         expect(mockCallContract).not.toHaveBeenCalled();
       });
 

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -247,10 +247,5 @@ describe('Starknet address resolver', () => {
       await expect(lookupAddresses([EVM_ADDRESS])).resolves.toEqual({});
       expect(mockCallContract).not.toHaveBeenCalled();
     });
-
-    it('ignores a 64 hex-digit value above the felt address bound', async () => {
-      await expect(lookupAddresses([`0x${'f'.repeat(64)}`])).resolves.toEqual({});
-      expect(mockCallContract).not.toHaveBeenCalled();
-    });
   });
 });

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -1,18 +1,15 @@
-const mockGetStarkName = jest.fn();
-const mockGetAddressFromStarkName = jest.fn();
+const mockCallContract = jest.fn();
 
 jest.mock('../../../src/addressResolvers/utils', () => {
   const actual = jest.requireActual('../../../src/addressResolvers/utils');
 
   return {
     ...actual,
-    provider: () => ({
-      getStarkName: mockGetStarkName,
-      getAddressFromStarkName: mockGetAddressFromStarkName
-    })
+    provider: () => ({ callContract: mockCallContract })
   };
 });
 
+import { starknetId } from 'starknet';
 import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/starknet';
 
 const PADDED = '0x07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
@@ -20,12 +17,39 @@ const UNPADDED = '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b0
 const MIXED_CASE = '0x7FF6b17F07c4d83236e3FC5f94259a19D1ed41BBcf1822397ea17882e9B038D';
 const ZERO_ADDRESS = `0x${'0'.repeat(64)}`;
 const EVM_ADDRESS = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+// The felt `checkpoint.stark` encodes to, as returned live by address_to_domain.
+const CHECKPOINT_FELT = '0xb5b47279a7f0c';
+
+const hex = (n: number) => `0x${n.toString(16)}`;
+
+// The `aggregate` retdata shape snapshot.js parses: block number, total length, then
+// each call's response prefixed with its own length.
+function aggregateResponse(responses: string[][]): string[] {
+  const body = responses.flatMap(response => [hex(response.length), ...response]);
+
+  return ['0x1', hex(body.length), ...body];
+}
+
+const mockDomains = (...spans: string[][]) =>
+  mockCallContract.mockResolvedValueOnce(
+    aggregateResponse(spans.map(span => [hex(span.length), ...span]))
+  );
+
+const mockAddresses = (...addresses: string[]) =>
+  mockCallContract.mockResolvedValueOnce(aggregateResponse(addresses.map(address => [address])));
+
+// A response that stops before the slot the ABI promises.
+const mockTruncated = () => mockCallContract.mockResolvedValueOnce(aggregateResponse([[]]));
+
+beforeEach(() => {
+  mockCallContract.mockReset();
+});
 
 describe('Starknet address resolver', () => {
   describe('resolveNames()', () => {
     describe('address padding', () => {
       it('pads the unpadded address returned by the contract to 64 hex digits', async () => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(UNPADDED);
+        mockAddresses(UNPADDED);
 
         await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({
           'checkpoint.stark': PADDED
@@ -33,7 +57,7 @@ describe('Starknet address resolver', () => {
       });
 
       it('returns an already padded address unchanged', async () => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(PADDED);
+        mockAddresses(PADDED);
 
         await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({
           'checkpoint.stark': PADDED
@@ -41,7 +65,7 @@ describe('Starknet address resolver', () => {
       });
 
       it('lowercases a mixed-case address', async () => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(MIXED_CASE);
+        mockAddresses(MIXED_CASE);
 
         await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({
           'checkpoint.stark': PADDED
@@ -49,7 +73,7 @@ describe('Starknet address resolver', () => {
       });
 
       it('pads an EVM-shaped 40 hex digits address', async () => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(EVM_ADDRESS);
+        mockAddresses(EVM_ADDRESS);
 
         await expect(resolveNames(['evm.stark'])).resolves.toEqual({
           'evm.stark': `0x${'0'.repeat(24)}d8da6bf26964af9d7eed9e03e53415d37aa96045`
@@ -58,14 +82,14 @@ describe('Starknet address resolver', () => {
     });
 
     describe('when the name has no address', () => {
-      it.each(['0x0', '', undefined, null])('drops %p', async value => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(value);
+      it.each(['0x0', ZERO_ADDRESS])('drops %p', async value => {
+        mockAddresses(value);
 
         await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({});
       });
 
-      it('drops the zero address', async () => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(ZERO_ADDRESS);
+      it('drops a name whose slot is missing from the response', async () => {
+        mockTruncated();
 
         await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({});
       });
@@ -73,19 +97,25 @@ describe('Starknet address resolver', () => {
 
     describe('when the contract returns a value that is not an address', () => {
       it.each([
-        ['non hex characters', '0xzz'],
         ['more than 64 hex digits', `0x1${'f'.repeat(64)}`],
         ['a felt above the address bound', `0x${'f'.repeat(64)}`]
       ])('rejects on %s, leaving the report to addressResolvers/index', async (_, value) => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(value);
+        mockAddresses(value);
 
         await expect(resolveNames(['checkpoint.stark'])).rejects.toThrow();
       });
     });
 
+    it('rejects when the call fails, leaving the report to addressResolvers/index', async () => {
+      const error = new Error('fetch failed');
+      mockCallContract.mockRejectedValueOnce(error);
+
+      await expect(resolveNames(['checkpoint.stark'])).rejects.toBe(error);
+    });
+
     it('ignores non-stark handles', async () => {
       await expect(resolveNames(['domain.eth', 'domain.crypto'])).resolves.toEqual({});
-      expect(mockGetAddressFromStarkName).not.toHaveBeenCalled();
+      expect(mockCallContract).not.toHaveBeenCalled();
     });
 
     // StarknetID's encoder drops any character outside [a-z0-9-] instead of rejecting
@@ -95,46 +125,80 @@ describe('Starknet address resolver', () => {
       'ignores %p, without looking it up',
       async handle => {
         await expect(resolveNames([handle])).resolves.toEqual({});
-        expect(mockGetAddressFromStarkName).not.toHaveBeenCalled();
+        expect(mockCallContract).not.toHaveBeenCalled();
       }
     );
 
     it.each(['ab.stark', 'notion.eth.stark', 'a-b.stark', '123.stark'])(
       'still resolves %p',
       async handle => {
-        mockGetAddressFromStarkName.mockResolvedValueOnce(PADDED);
+        mockAddresses(PADDED);
 
         await expect(resolveNames([handle])).resolves.toEqual({ [handle]: PADDED });
-        expect(mockGetAddressFromStarkName).toHaveBeenCalledWith(handle);
+
+        const labels = handle
+          .replace(/\.stark$/, '')
+          .split('.')
+          .map(label => starknetId.useEncoded(label).toString(10));
+
+        expect(mockCallContract.mock.calls[0][0].calldata).toEqual(
+          expect.arrayContaining(labels)
+        );
       }
     );
+
+    it('resolves a whole batch in a single call', async () => {
+      mockAddresses(PADDED, ZERO_ADDRESS, UNPADDED);
+
+      await expect(
+        resolveNames(['checkpoint.stark', 'blank.stark', 'other.stark'])
+      ).resolves.toEqual({
+        'checkpoint.stark': PADDED,
+        'other.stark': PADDED
+      });
+      expect(mockCallContract).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('lookupAddresses()', () => {
-    it('drops addresses without a name, and keeps the others', async () => {
-      mockGetStarkName.mockResolvedValueOnce('checkpoint.stark');
-      mockGetStarkName.mockRejectedValueOnce(new Error('Starkname not found'));
+    it('decodes the domain returned as a span of felts', async () => {
+      mockDomains([CHECKPOINT_FELT]);
 
-      await expect(lookupAddresses([PADDED, ZERO_ADDRESS])).resolves.toEqual({
+      await expect(lookupAddresses([PADDED])).resolves.toEqual({
         [PADDED]: 'checkpoint.stark'
       });
     });
 
+    it('drops addresses without a name, and keeps the others', async () => {
+      mockDomains([CHECKPOINT_FELT], []);
+
+      await expect(lookupAddresses([PADDED, ZERO_ADDRESS])).resolves.toEqual({
+        [PADDED]: 'checkpoint.stark'
+      });
+      expect(mockCallContract).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops an address whose slot is missing from the response', async () => {
+      mockTruncated();
+
+      await expect(lookupAddresses([PADDED])).resolves.toEqual({});
+    });
+
     it('rejects with any other error, leaving the report to addressResolvers/index', async () => {
       const error = new Error('Could not get stark name');
-      mockGetStarkName.mockRejectedValueOnce(error);
+      mockCallContract.mockRejectedValueOnce(error);
 
       await expect(lookupAddresses([PADDED])).rejects.toBe(error);
     });
 
     it('ignores non-starknet addresses', async () => {
       await expect(lookupAddresses([EVM_ADDRESS])).resolves.toEqual({});
-      expect(mockGetStarkName).not.toHaveBeenCalled();
+      expect(mockCallContract).not.toHaveBeenCalled();
     });
 
     it('ignores a 64 hex-digit value above the felt address bound', async () => {
       await expect(lookupAddresses([`0x${'f'.repeat(64)}`])).resolves.toEqual({});
-      expect(mockGetStarkName).not.toHaveBeenCalled();
+      expect(mockCallContract).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -1,0 +1,114 @@
+const mockGetStarkName = jest.fn();
+const mockGetAddressFromStarkName = jest.fn();
+
+jest.mock('../../../src/addressResolvers/utils', () => {
+  const actual = jest.requireActual('../../../src/addressResolvers/utils');
+
+  return {
+    ...actual,
+    provider: () => ({
+      getStarkName: mockGetStarkName,
+      getAddressFromStarkName: mockGetAddressFromStarkName
+    })
+  };
+});
+
+import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/starknet';
+
+const PADDED = '0x07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
+const UNPADDED = '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
+const MIXED_CASE = '0x7FF6b17F07c4d83236e3FC5f94259a19D1ed41BBcf1822397ea17882e9B038D';
+const ZERO_ADDRESS = `0x${'0'.repeat(64)}`;
+const EVM_ADDRESS = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+describe('Starknet address resolver', () => {
+  describe('resolveNames()', () => {
+    describe('address padding', () => {
+      it('pads the unpadded address returned by the contract to 64 hex digits', async () => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(UNPADDED);
+
+        await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({
+          'checkpoint.stark': PADDED
+        });
+      });
+
+      it('returns an already padded address unchanged', async () => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(PADDED);
+
+        await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({
+          'checkpoint.stark': PADDED
+        });
+      });
+
+      it('lowercases a mixed-case address', async () => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(MIXED_CASE);
+
+        await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({
+          'checkpoint.stark': PADDED
+        });
+      });
+
+      it('pads an EVM-shaped 40 hex digits address', async () => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(EVM_ADDRESS);
+
+        await expect(resolveNames(['evm.stark'])).resolves.toEqual({
+          'evm.stark': `0x${'0'.repeat(24)}d8da6bf26964af9d7eed9e03e53415d37aa96045`
+        });
+      });
+    });
+
+    describe('when the name has no address', () => {
+      it.each(['0x0', '', undefined, null])('drops %p', async value => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(value);
+
+        await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({});
+      });
+
+      it('drops the zero address', async () => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(ZERO_ADDRESS);
+
+        await expect(resolveNames(['checkpoint.stark'])).resolves.toEqual({});
+      });
+    });
+
+    describe('when the contract returns a value that is not an address', () => {
+      it.each([
+        ['non hex characters', '0xzz'],
+        ['more than 64 hex digits', `0x1${'f'.repeat(64)}`],
+        ['a felt above the address bound', `0x${'f'.repeat(64)}`]
+      ])('rejects on %s, leaving the report to addressResolvers/index', async (_, value) => {
+        mockGetAddressFromStarkName.mockResolvedValueOnce(value);
+
+        await expect(resolveNames(['checkpoint.stark'])).rejects.toThrow();
+      });
+    });
+
+    it('ignores non-stark handles', async () => {
+      await expect(resolveNames(['domain.eth', 'domain.crypto'])).resolves.toEqual({});
+      expect(mockGetAddressFromStarkName).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('lookupAddresses()', () => {
+    it('drops addresses without a name, and keeps the others', async () => {
+      mockGetStarkName.mockResolvedValueOnce('checkpoint.stark');
+      mockGetStarkName.mockRejectedValueOnce(new Error('Starkname not found'));
+
+      await expect(lookupAddresses([PADDED, ZERO_ADDRESS])).resolves.toEqual({
+        [PADDED]: 'checkpoint.stark'
+      });
+    });
+
+    it('rejects with any other error, leaving the report to addressResolvers/index', async () => {
+      const error = new Error('Could not get stark name');
+      mockGetStarkName.mockRejectedValueOnce(error);
+
+      await expect(lookupAddresses([PADDED])).rejects.toBe(error);
+    });
+
+    it('ignores non-starknet addresses', async () => {
+      await expect(lookupAddresses([EVM_ADDRESS])).resolves.toEqual({});
+      expect(mockGetStarkName).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -32,7 +32,7 @@ const MIXED_CASE = '0x7FF6b17F07c4d83236e3FC5f94259a19D1ed41BBcf1822397ea17882e9
 const ZERO_ADDRESS = `0x${'0'.repeat(64)}`;
 const EVM_ADDRESS = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
 // The same 64 hex-digit shape as an address, but past the felt bound: a transaction hash or a
-// proposal id looks exactly like this, and about 97% of them land here.
+// proposal id looks exactly like this.
 const OUT_OF_RANGE = '0x07ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00';
 const OUT_OF_RANGE_FELT =
   '3618502788666131106986593281521497120414687020801267626233049500247285300992';
@@ -196,9 +196,8 @@ describe('Starknet address resolver', () => {
         expect(mockCallContract).not.toHaveBeenCalled();
       });
 
-      // The felt check would reject this too, but only after paying the encoder, whose BigInt
-      // loop is worse than quadratic. `OVER_PRIME_49` above does not pin that: it is short
-      // enough to be cheap either way.
+      // `OVER_PRIME_49` above does not pin this: it is short enough that the felt check rejects
+      // it cheaply either way. Here, reaching the encoder at all is the failure.
       it('drops an oversized label without encoding it', async () => {
         await expect(resolveNames([`${'a'.repeat(100_000)}.stark`])).resolves.toEqual({});
 
@@ -279,9 +278,8 @@ describe('Starknet address resolver', () => {
       expect(mockCallContract).not.toHaveBeenCalled();
     });
 
-    // `addressResolvers/index` filters this out upstream too, but the resolver is exported: a
-    // direct caller passing one poisons the single atomic multicall with a `-32602` that
-    // `isSilencedError` does not silence, losing every address batched alongside it.
+    // The hub guard drops this upstream as well, so only a direct caller of the export reaches
+    // it -- which is exactly the regression starknet-batch-guard.test.ts cannot catch.
     it('ignores a 64 hex-digit value past the felt range', async () => {
       mockDomains([CHECKPOINT_FELT]);
 

--- a/test/unit/addressResolvers/starknet.test.ts
+++ b/test/unit/addressResolvers/starknet.test.ts
@@ -110,5 +110,10 @@ describe('Starknet address resolver', () => {
       await expect(lookupAddresses([EVM_ADDRESS])).resolves.toEqual({});
       expect(mockGetStarkName).not.toHaveBeenCalled();
     });
+
+    it('ignores a 64 hex-digit value above the felt address bound', async () => {
+      await expect(lookupAddresses([`0x${'f'.repeat(64)}`])).resolves.toEqual({});
+      expect(mockGetStarkName).not.toHaveBeenCalled();
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,10 +2870,10 @@
   dependencies:
     "@sentry/node" "^10.52.0"
 
-"@snapshot-labs/snapshot.js@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.15.1.tgz#2da7e4d5f75d9c9ad476c8b1acb7251cd7bd9f53"
-  integrity sha512-VICLBMgbz5w70w/81SOVEK+R8GbPAEQfWU3nyoquvRTyp6vQlaJ3+MijHJ5nFg40u8H21OltpBuIaE5H9q1gtw==
+"@snapshot-labs/snapshot.js@^0.15.2":
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.15.2.tgz#6452f3de47ad18c40d25904667cdaad8556599f6"
+  integrity sha512-ZmcOVGKny1gq90u0XxdYQDZBM1ah+4T3d8K/jK0MR1EYyGT+OAqegY7MVzt5WoojYVALybmSRRemh+S3+mMfLw==
   dependencies:
     "@ethersproject/abi" "^5.6.4"
     "@ethersproject/address" "^5.6.1"
@@ -2890,7 +2890,7 @@
     cross-fetch "^3.1.6"
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
-    starknet "^6.11.0"
+    starknet "^6.21.0"
     viem "^2.55.11"
 
 "@stablelib/binary@^1.0.1":
@@ -7245,7 +7245,7 @@ stack-utils@^2.0.3, stack-utils@^2.0.6:
   resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.10.tgz#d21dc973d0cd04d7b6293ce461f2f06a5873c760"
   integrity sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==
 
-"starknet@>=6.21.0 <6.21.2", starknet@^6.11.0:
+"starknet@>=6.21.0 <6.21.2", starknet@^6.21.0:
   version "6.21.1"
   resolved "https://registry.yarnpkg.com/starknet/-/starknet-6.21.1.tgz#2cfd9a0e6cfba0a90687d3bf4c30555d3c0b0a0b"
   integrity sha512-bmhGGsF8rAZWzWzkQAtkzHfmzy4Nc9pFRKVQo/i+sd2TQqRiOnVM5kK9suEbpveTGd/Ko9zGHmrjofE49hZOng==


### PR DESCRIPTION
Fixes #503.

<!-- Merge-order declarations, read by the PR dashboard. Syntax is documented on the dashboard. -->
Depends on #504 — #491 drops its own range check in favour of the shared one #504 adds to `normalizeAddresses`, and the batch-guard test here stays red until #504 lands.
Depends on release of snapshot-labs/snapshot.js#1225 — merging #1225 is not enough; the `@snapshot-labs/snapshot.js` floor in `package.json` has to be raised to a published release that carries `baseFetch`.

### What was broken

The Starknet address resolver read `https://api.starknet.id`, and that host stopped accepting connections. `.stark` names quietly stopped resolving in production as a result: `lookup_addresses` on a named address returned the Snapshot profile-name fallback instead of the handle.

Nothing reported it. `apiCall` fanned out with `Promise.allSettled` and read a value only from fulfilled responses, so a total outage produced `{}` — indistinguishable from "no such name". Nothing ever threw, so the `capture()` in `index.ts` never fired and no Sentry event was raised. A red `Test` workflow is what surfaced it.

This is not a stale fixture like #482. The name the test asserts is still registered and still maps to the address it expects; the API was down for every name, so no fixture swap could have fixed it.

### The fix

Resolve on-chain instead, reading the StarknetID naming contract through the brovider we control. Not a new dependency or a new pattern — the avatar resolver in `src/resolvers/starknet.ts` already reads that contract through the same `snapshot.utils.getProvider` — and it drops a third-party HTTP single point of failure that [StarknetID's own docs](https://docs.starknet.id/devs/starknetid-api) advise against depending on.

Both directions go through one `snapshot.utils.multicall`, so a batch is a single round trip rather than a call per name. The `@snapshot-labs/snapshot.js` bump is what makes that possible, and it is load-bearing rather than incidental: the reverse lookup returns a `Span::<felt252>`, which the older `parseStarknetResult` has no case for — it hands back the span's length felt and the resolver returns `{}` for every address, which is the same silent failure this PR exists to remove. If the bump is ever lost to a dedup or a downgrade, the bug comes back.

A miss is a value now rather than a throw — an empty span one way, the zero address the other — so no error-message matching is left in the resolver. Anything that does throw out of the multicall is a real RPC or network fault, and it propagates to `index.ts` rather than being flattened into an empty result. An outage of this kind is loud now instead of silent.

### Handle validation (#503)

Resolving on-chain also brings StarknetID's encoder into `resolveNames`, and that encoder *skips* characters outside its alphabet rather than rejecting them, without advancing the multiplier. So `a!b` encodes identically to `ab`, and `!!!` encodes to felt 0, which maps to a real account. Checking the `.stark` suffix is not a sufficient gate: a garbage handle comes back carrying somebody else's address. The avatar resolver had the same gap, where `ab.stark`, `a!b.stark` and `a!!b.stark` all resolved to a byte-identical image.

`isStarkDomain` now gates on the encoder's own alphabet, subdomains included, and both call sites share the one helper so they cannot drift. Parts of that gate look wrong at a glance:

- The class is starknet.js's `basicAlphabet` **plus** its `bigAlphabet` (`这来`), not just `[a-z0-9-]`. Those glyphs are safe to admit: unlike a skipped character, the encoder consumes them and advances the multiplier, so they round-trip and cannot collide with a shorter handle. They are also in live use, so rejecting them would have dropped an already-registered name to the blockie fallback.
- The felt bound is guarded directly rather than through upstream's character cap. A label whose encoded felt reaches the field prime is rejected by the node, and because resolution is one atomic multicall, that failure takes down every name batched alongside it — as an error `isSilencedError` does not silence. Character length is the wrong proxy for that bound; the felt is the actual invariant.


