### PR TITLE
fix(api): stop re-capturing resolver errors already reported at source

### DIFF
--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -4,7 +4,12 @@ import { Address, EMPTY_ADDRESS, Handle } from '../utils';
 
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
-export class FetchError extends Error {}
+export class FetchError extends Error {
+  constructor(message = 'Resolver request failed, original error reported at its source') {
+    super(message);
+    this.name = 'FetchError';
+  }
+}
 
 export function isEvmAddress(address: Address): boolean {
   return /^0x[a-fA-F0-9]{40}$/.test(address);

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,6 +2,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import express from 'express';
 import { z } from 'zod';
 import { clearCache, lookupAddresses, resolveNames } from './addressResolvers';
+import { FetchError } from './addressResolvers/utils';
 import { clear, get, set, streamToBuffer } from './aws';
 import constants from './constants.json';
 import getOwner from './getOwner';
@@ -40,7 +41,7 @@ router.post('/', async (req, res) => {
     return rpcSuccess(res, result, id);
   } catch (err) {
     const error = err as any;
-    if (error.code !== 400) {
+    if (!(error instanceof FetchError) && error.code !== 400) {
       capture(error.error ? new Error(error.error) : error);
     }
     return rpcError(res, 500, err, id);

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -1,0 +1,74 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import request from 'supertest';
+import getOwner from '../../src/getOwner';
+import { graphQlCall } from '../../src/utils';
+import { createTestApp } from '../helpers/testServer';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+jest.mock('../../src/utils', () => ({
+  ...jest.requireActual('../../src/utils'),
+  graphQlCall: jest.fn()
+}));
+
+jest.mock('../../src/getOwner', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+const ADDRESS = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+const app = createTestApp();
+
+function lookupDomains() {
+  return request(app).post('/').send({ method: 'lookup_domains', params: ADDRESS, network: '1' });
+}
+
+describe('POST /', () => {
+  describe('on lookup_domains', () => {
+    describe('when a resolver reports its own error', () => {
+      it('captures the resolver error only once', async () => {
+        (graphQlCall as jest.Mock).mockRejectedValue(
+          new Error('Request failed with status code 500')
+        );
+
+        const response = await lookupDomains();
+
+        expect(response.status).toBe(500);
+        expect(capture).toHaveBeenCalledTimes(1);
+        expect(capture).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'Request failed with status code 500' }),
+          expect.anything()
+        );
+      });
+    });
+
+    describe('when a resolver silences its own error', () => {
+      it('does not capture anything', async () => {
+        (graphQlCall as jest.Mock).mockRejectedValue(
+          new Error('Request failed with status=504, no body')
+        );
+
+        const response = await lookupDomains();
+
+        expect(response.status).toBe(500);
+        expect(capture).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when an unexpected error is thrown', () => {
+    it('captures it', async () => {
+      (getOwner as jest.Mock).mockRejectedValue(new Error('unexpected'));
+
+      const response = await request(app)
+        .post('/')
+        .send({ method: 'get_owner', params: 'test.shib' });
+
+      expect(response.status).toBe(500);
+      expect(capture).toHaveBeenCalledTimes(1);
+      expect(capture).toHaveBeenCalledWith(expect.objectContaining({ message: 'unexpected' }));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #488.

There are **16** `throw new FetchError()` sites in the resolvers, not 15 as this description previously said. `git grep -c "throw new FetchError" -- src/` gives the same 16 on this branch and on `master@4edd613`, split 14 in `addressResolvers/` and 2 in `lookupDomains/`.

I checked all 16, and the invariant holds. Its precise form is **"already captured, or deliberately silenced"**, not simply "already captured". Every one of the 16 is the same shape:

```ts
} catch (err) {
  if (!isSilencedError(err)) capture(err, { input });
  throw new FetchError();
}
```

No site captures unconditionally and none skips unconditionally. (The only variation is cosmetic: some spell the `if` with braces, and `lens.ts` passes an extra `MUTED_ERRORS` list to `isSilencedError`.) So `FetchError` is a *"handled, give up on this resolver"* sentinel, not a new failure.

It nevertheless rejects the `lookupDomains` `Promise.all` and lands in the `api.ts` catch-all, which has no way to tell it apart from an unexpected error and captures it a second time. Since `FetchError extends Error {}` set neither `name` nor `message`, that duplicate reached Sentry titled just `Error`, with no message and no context.

Of the 16, only the **2** in `lookupDomains/` can actually reach that catch-all. The 14 in `addressResolvers/` cannot: `addressResolvers/index.ts:57-60` wraps each resolver call in a bare `catch {}`, so their `FetchError` is swallowed before `lookupAddresses` / `resolveNames` ever return. `lookupDomains/index.ts:33` has no such guard, being a plain `await Promise.all(promises)`, which is why that path escapes. `api.ts` is still the right place for the fix, since that boundary is where the double-capture happens, but the live blast radius is the two `lookupDomains` resolvers.

The issue's stated root cause reproduced exactly, including the detail that on **silenced** errors the resolver skips its own capture, so the blank duplicate is the *only* event Sentry ever sees — which is what makes STAMP-35's 1614 events largely originless.

## Reproduction

New test at `test/unit/api.test.ts` mounts the real router and mocks only the network (`graphQlCall`) and Sentry, so the real `lookupDomains/ens.ts` catch, the real `lookupDomains` fan-out and the real `api.ts` catch all run. Instrumenting each `capture` call on `master`:

```
POST / {method: lookup_domains, params: <address>, network: "1"}

  graphQlCall rejects with Error('Request failed with status code 500')
  capture called 2 time(s)
    #1 instanceof FetchError=false name="Error" message="Request failed with status code 500" sentryTitle="Error: Request failed with status code 500"
    #2 instanceof FetchError=true  name="Error" message=""                                    sentryTitle="Error"

  graphQlCall rejects with Error('Request failed with status=504')   <- isSilencedError
  capture called 1 time(s)
    #1 instanceof FetchError=true  name="Error" message=""
```

`#2` is STAMP-6V / STAMP-35.

## Changes

- **`src/api.ts`** — skip the catch-all capture for `err instanceof FetchError`. Everything else still reaches Sentry, so the catch-all remains a genuine safety net for unexpected failures (e.g. `getOwner`, which throws real errors and is unaffected).
- **`src/addressResolvers/utils.ts`** — give `FetchError` a `name` and a default message, so it stays identifiable if it ever surfaces through another boundary or a `console.log`.

### What this does to Sentry volume, stated plainly

Because the invariant is *"already captured, **or deliberately silenced**"*, the effect is not uniform across error classes:

| resolver error | Sentry events before | after |
| --- | --- | --- |
| not silenced | 2: the real error, plus a blank `Error` | 1: the real error |
| silenced (`status=504`, `ETIMEDOUT`, `execution reverted`, …) | 1: a blank `Error` | **0** |

Measured with one probe against the real router on both sides:

```
master@4edd613  NON-SILENCED        capture called 2 time(s)
                  #1 ctor=Error       name="Error" message="Request failed with status code 500"
                  #2 ctor=FetchError  name="Error" message=""
                SILENCED-504        capture called 1 time(s)
                  #1 ctor=FetchError  name="Error" message=""
                SILENCED-REVERTED   capture called 1 time(s)
                SILENCED-ETIMEDOUT  capture called 1 time(s)

branch          NON-SILENCED        capture called 1 time(s)
                  #1 ctor=Error       name="Error" message="Request failed with status code 500"
                SILENCED-504        capture called 0 time(s)
                SILENCED-REVERTED   capture called 0 time(s)
                SILENCED-ETIMEDOUT  capture called 0 time(s)
```

The second row is the part worth saying out loud rather than letting a reviewer discover it later: **on a silenced error Sentry now sees zero events for that request, where before it saw one.** That is the intended outcome, since the blank `Error` was exactly the noise #488 reported and with no message, no context and no stack of its own it was never actionable. But it is a genuine reduction in signal, not merely deduplication. If we later decide some silenced class deserves a breadcrumb rather than silence, that is a change to `isSilencedError`'s policy at the resolver, not to this catch-all.

### HTTP response

The **status** is unchanged: a failing resolver still produces a 500. The response **body** does change, which this description previously got wrong. `api.ts` hands the raw error to `rpcError(res, 500, err, id)`, which places it at `error.data`, and `this.name = 'FetchError'` is an own *enumerable* property, so it now survives `JSON.stringify` where the old `class FetchError extends Error {}` serialised to nothing:

```
before: {"jsonrpc":"2.0","error":{"code":500,"message":"unauthorized","data":{}},"id":null}
after : {"jsonrpc":"2.0","error":{"code":500,"message":"unauthorized","data":{"name":"FetchError"}},"id":null}
```

Verified live against the real router on both commits. (`message` stays out of the body either way, since `super(message)` sets it non-enumerable.) Arguably an improvement, in that the body now says *what* failed instead of `{}`, but it is a change and anything parsing `error.data` should know.

Whether a failing resolver *should* answer 500 at all, i.e. absorbing per-resolver failures into a partial 200, is the separate question tracked in #448, which this deliberately does not touch. The two are complementary and independent: #448 stops `FetchError` escaping the `lookupDomains` fan-out; this stops any escaped `FetchError` being re-reported, from any path.

## Test plan

`test/unit/api.test.ts` (first `test/unit/` file; picked up by `yarn test:coverage`, which CI runs).

Before, on `4edd613` with no source change:

```
  POST /
    on lookup_domains
      when a resolver reports its own error
        ✕ captures the resolver error only once
          Expected number of calls: 1
          Received number of calls: 2
      when a resolver silences its own error
        ✕ does not capture anything
          Expected number of calls: 0
          Received number of calls: 1
          1: [Error]
    when an unexpected error is thrown
      ✓ captures it

Tests:       2 failed, 1 passed, 3 total
```

After:

```
  POST /
    on lookup_domains
      when a resolver reports its own error
        ✓ captures the resolver error only once (127 ms)
      when a resolver silences its own error
        ✓ does not capture anything (25 ms)
    when an unexpected error is thrown
      ✓ captures it (11 ms)

Tests:       3 passed, 3 total
```

The third case passes on both sides on purpose — it guards against over-suppressing, proving the catch-all still captures non-`FetchError` errors.

Gates:

```
$ yarn lint
$ eslint src/ test/
Done in 13.34s.

$ yarn typecheck
$ tsc --noEmit
Done in 21.12s.
```

Full suite, run twice concurrently under identical conditions — this branch and `master` at `4edd613`:

```
master  Test Suites: 4 failed, 1 skipped, 23 passed, 27 of 28 total
        Tests:       12 failed, 4 skipped, 14 todo, 172 passed, 202 total

branch  Test Suites: 4 failed, 1 skipped, 24 passed, 28 of 29 total
        Tests:       12 failed, 4 skipped, 14 todo, 175 passed, 205 total
```

Byte-identical failure sets — the 12 are pre-existing, hit live third-party APIs, and are unrelated to this change:

- 4 `addressResolvers/starknet` — `api.starknet.id` is decommissioned; `curl` to it returns HTTP `000` (connection failure).
- 3 `resolvers/starknet` image snapshots — this resolver goes through brovider, and `rpc.snapshot.org/sn` is currently returning `429: Monthly capacity limit exceeded` (Alchemy account quota):
  ```
  provider ctor: RpcProvider2
  nodeUrl: https://rpc.snapshot.org/sn
  ERR: RPC: starknet_chainId with params undefined
       429: Monthly capacity limit exceeded. Visit https://dashboard.alchemy.com/settings/billing ...
  ```
- 5 shibarium / unstoppable domains (`getOwner`, `lookupDomains`) — `D3_API_KEY_MAINNET` and `UNSTOPPABLE_DOMAINS_API_KEY` are CI secrets not present locally, so those resolvers correctly short-circuit to `[]` / `EMPTY_ADDRESS`. They do pass on CI.

The delta is exactly `+3 passed`: the new tests.

## CI on this PR

CI is red, and none of it is this change. `PASS test/unit/api.test.ts`; the failures are `7 failed, 180 passed, 205 total`, all starknet.

`master` at `4edd613` — the commit this branch is based on — is itself red, with `4 failed, 180 passed, 202 total` (run [30753408965](https://github.com/snapshot-labs/stamp/actions/runs/30753408965), the 4 `addressResolvers/starknet` tests). That run is from 2026-08-02 15:01; the 3 extra `resolvers/starknet` image-snapshot failures appeared afterwards, when the `/sn` 429 above started. The local run of unmodified `master` in the table above reproduces all 3, so they are not from this branch.

## Noted, not fixed here

- `addressResolvers/_call` rejects with `{ error, code: 400 }` for over-length input, but `api.ts` answers `rpcError(res, 500, …)` regardless — a 400 condition reported as a 500. Pre-existing and out of scope, and currently unreachable over HTTP since the zod schemas already `.max()` the arrays.
- `lookupDomains/shibarium.ts` captures without an `isSilencedError` filter, so timeouts/aborts are reported there where every other resolver silences them (@wa0x6e's STAMP-6S note on the issue). Separate change.
- **After this PR the tree holds two distinct classes both named `FetchError`, both with `.name === 'FetchError'`.** `src/lookupDomains/shibarium.ts:2` and `src/resolvers/farcaster.ts:2` `import fetch from 'node-fetch'` (v2.7.0), which ships its own `FetchError`; `node_modules/node-fetch/lib/index.js:159` sets `FetchError.prototype.name = 'FetchError'`. So neither the class name nor the `.name` value distinguishes the two any more. Only `instanceof` does, and it points the safe way: node-fetch's is **not** `instanceof` the local class, so `api.ts:44` still captures it. No hole.

  ```
  local.constructor.name               = FetchError
  local.name                           = "FetchError"
  nodefetch.constructor.name           = FetchError
  nodefetch.name                       = "FetchError"
  nodefetch instanceof LocalFetchError = false
  nodefetch.code                       = "ECONNRESET"  (a string, never numeric 400, so the `code !== 400` arm is safe too)

  thrown into POST / :  node-fetch FetchError -> capture called 1 time(s)
                        local     FetchError -> capture called 0 time(s)
  ```

  In practice neither can reach the catch-all today: `lookupDomains/shibarium.ts` catches and captures its own errors at both levels, and `resolvers/farcaster.ts` swallows into `return null`. Recorded here so that a future reader debugging a `FetchError` in Sentry does not infer the class from the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

