### PR TITLE
fix(lookupDomains): stop reporting Shibarium rate limits

### DIFF
--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -1,5 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import fetch from 'node-fetch';
+import { isSilencedError } from '../addressResolvers/utils';
 import constants from '../constants.json';
 import { Address, Handle } from '../utils';
 
@@ -44,7 +45,9 @@ export default async function lookupDomains(
         }
 
         if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+          throw Object.assign(new Error(`HTTP ${response.status}: ${response.statusText}`), {
+            status: response.status
+          });
         }
 
         let data: { pageItems?: Array<{ sld: string; tld: string }> };
@@ -60,7 +63,9 @@ export default async function lookupDomains(
         hasMore = domains.length === PAGE_SIZE;
         skip += PAGE_SIZE;
       } catch (err) {
-        capture(err, { input: { address, chainId, skip } });
+        if (!isSilencedError(err)) {
+          capture(err, { input: { address, chainId, skip } });
+        }
         break;
       } finally {
         clearTimeout(timeoutId);
@@ -69,7 +74,9 @@ export default async function lookupDomains(
 
     return allDomains;
   } catch (err) {
-    capture(err);
+    if (!isSilencedError(err)) {
+      capture(err);
+    }
     return allDomains;
   }
 }

--- a/test/integration/lookupDomains/shibarium.test.ts
+++ b/test/integration/lookupDomains/shibarium.test.ts
@@ -1,0 +1,121 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import fetch from 'node-fetch';
+import { Address, Handle } from '../../../src/utils';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+jest.mock('node-fetch', () => jest.fn());
+
+const ADDRESS = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
+const CHAIN_ID = '109';
+const PAGE_SIZE = 25;
+
+const mockedFetch = fetch as unknown as jest.Mock;
+
+let lookupDomains: (address: Address, chainId?: string) => Promise<Handle[]>;
+
+function httpResponse(status: number, statusText: string, body: any = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: async () => body
+  };
+}
+
+function page(count: number) {
+  return {
+    pageItems: Array.from({ length: count }, (_, i) => ({ sld: `domain${i}`, tld: 'shib' }))
+  };
+}
+
+describe('lookupDomains/shibarium', () => {
+  const apiKey = process.env.D3_API_KEY_MAINNET;
+
+  beforeAll(async () => {
+    process.env.D3_API_KEY_MAINNET = 'test-key';
+    lookupDomains = (await import('../../../src/lookupDomains/shibarium')).default;
+  });
+
+  afterAll(() => {
+    if (apiKey === undefined) {
+      delete process.env.D3_API_KEY_MAINNET;
+    } else {
+      process.env.D3_API_KEY_MAINNET = apiKey;
+    }
+  });
+
+  it('does not report a rate limit to Sentry', async () => {
+    mockedFetch.mockResolvedValue(httpResponse(429, 'Too Many Requests'));
+
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not report a gateway timeout to Sentry', async () => {
+    mockedFetch.mockResolvedValue(httpResponse(504, 'Gateway Timeout'));
+
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('reports the HTTP status when the API rejects the credentials', async () => {
+    mockedFetch.mockResolvedValue(httpResponse(401, 'Unauthorized'));
+
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'HTTP 401: Unauthorized', status: 401 }),
+      { input: { address: ADDRESS, chainId: CHAIN_ID, skip: 0 } }
+    );
+  });
+
+  it('reports a server error to Sentry', async () => {
+    mockedFetch.mockResolvedValue(httpResponse(500, 'Internal Server Error'));
+
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'HTTP 500: Internal Server Error', status: 500 }),
+      { input: { address: ADDRESS, chainId: CHAIN_ID, skip: 0 } }
+    );
+  });
+
+  it('reports a failure that carries no HTTP status', async () => {
+    mockedFetch.mockRejectedValue(
+      Object.assign(new Error('getaddrinfo ENOTFOUND api-public.interstellar.xyz'), {
+        code: 'ENOTFOUND'
+      })
+    );
+
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'getaddrinfo ENOTFOUND api-public.interstellar.xyz' }),
+      { input: { address: ADDRESS, chainId: CHAIN_ID, skip: 0 } }
+    );
+  });
+
+  it('keeps the domains collected before a rate limit interrupts pagination', async () => {
+    mockedFetch
+      .mockResolvedValueOnce(httpResponse(200, 'OK', page(PAGE_SIZE)))
+      .mockResolvedValueOnce(httpResponse(429, 'Too Many Requests'));
+
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toHaveLength(PAGE_SIZE);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('returns the domains on a successful response', async () => {
+    mockedFetch.mockResolvedValue(
+      httpResponse(200, 'OK', { pageItems: [{ sld: 'boorger', tld: 'shib' }] })
+    );
+
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual(['boorger.shib']);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not call the API on an unsupported chain', async () => {
+    await expect(lookupDomains(ADDRESS, '1')).resolves.toEqual([]);
+    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`src/lookupDomains/shibarium.ts` captured every pagination failure with no `isSilencedError` filter, so a D3 rate limit or gateway timeout floods Sentry exactly like STAMP-6X did for Unstoppable Domains.

## Root cause

Two halves, and only both together fix it. The guard was missing, and the thrown error carried its status only inside the message text, so `error.status` was undefined and `HTTP 504: Gateway Timeout` never matched the existing `status=504` message. Adding the guard on its own changes nothing:

```
guard only, no status attached
mode=mock429  requests=50  Sentry captures: 50 / 50
mode=mock504  requests=10  Sentry captures: 10 / 10
```

## Verification

Real resolver, D3 endpoint mocked, counting `capture()` calls.

Before:

```
mode=mock429    requests=50   Sentry captures: 50 / 50
mode=mock504    requests=10   Sentry captures: 10 / 10
mode=mock401    requests=5    Sentry captures: 5 / 5
mode=mockdns    requests=5    Sentry captures: 5 / 5
mode=live401    requests=5    Sentry captures: 5 / 5
```

After:

```
mode=mock429    requests=50   Sentry captures: 0 / 50
mode=mock504    requests=10   Sentry captures: 0 / 10
mode=mock401    requests=5    Sentry captures: 5 / 5
mode=mock500    requests=5    Sentry captures: 5 / 5
mode=mockdns    requests=5    Sentry captures: 5 / 5
mode=live401    requests=5    Sentry captures: 5 / 5
```

`live401` is a real request to `api-public.interstellar.xyz` with an invalid key, `mockdns` an `ENOTFOUND` with no HTTP status. Both stay visible, so this does not over-silence.

## The outer catch

It gets the same guard. It is near dead today, only the `AbortController` and the `setTimeout` sit outside the inner `try`, but it is one line, it changes nothing for a genuine error, and leaving one guarded and one unguarded `capture` in the same file is how this flood comes back the moment anything moves above the inner `try`.

## Depends on #497

Stacked on `fix/494-silence-unstoppable-domains-rate-limit`. The guard only works because #497 makes `isSilencedError` read `error.status` and treat 429 as transient. `utils.ts` is untouched here. Merge #497 first.

## Scope

Behaviour fix only. Shibarium still swallows and returns partial results instead of rethrowing (#448), and nothing is centralised (#496).

## Tests

8 new tests in `test/integration/lookupDomains/shibarium.test.ts`, 5 of which fail without the `src` change. CI is unchanged against the base branch: the same 5 pre-existing failures (4 starknet, 1 ENS CCIP-Read), 188 -> 196 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
