### PR TITLE
test(api): expect 200 for lookup_domains partial results

### DIFF
--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -35,7 +35,7 @@ describe('POST /', () => {
 
         const response = await lookupDomains();
 
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(200);
         expect(capture).toHaveBeenCalledTimes(1);
         expect(capture).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Request failed with status code 500' }),
@@ -52,7 +52,7 @@ describe('POST /', () => {
 
         const response = await lookupDomains();
 
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(200);
         expect(capture).not.toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
Master's unit suite has been red since #448 merged (273c3b2).

`test/unit/api.test.ts` landed with #492, whose branch was cut before #448's. #448 makes `lookupDomains` absorb per-resolver failures and return `[]` for the failing chain, so a resolver error is now a partial 200 instead of a 500. There was no textual conflict, so the merge went through clean and left both `lookup_domains` cases asserting 500.

CI confirms it is attributable to the merge and nothing else:

- 64a29ad (before #448): `Test Suites: 3 failed` — `addressResolvers/ens`, `addressResolvers/starknet`, `resolvers/zapper`, the live-network suites that have been red since 2026-07-07
- 273c3b2 (the #448 merge): `Test Suites: 4 failed` — the same three, plus `test/unit/api.test.ts`

This flips both `lookup_domains` assertions to 200 and nothing else. The `capture` assertions are unchanged and still hold — what those two cases are actually about is how many times the error gets reported, not the status. The `get_owner` case keeps its 500, since an unexpected error outside `lookupDomains` still rejects the request.

Local gate on this branch:

- `yarn jest test/unit` — 5/5 pass, 2 suites
- `yarn typecheck` — clean
- `yarn lint` — clean

CI here will still show the three live-network suites red. That is the pre-existing failure, untouched.