### PR TITLE
refactor(addressResolvers): capture resolver errors in index.ts

### DIFF
--- a/src/addressResolvers/basename.ts
+++ b/src/addressResolvers/basename.ts
@@ -1,9 +1,8 @@
 import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { namehash } from '@ethersproject/hash';
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
-import { FetchError, provider as getProvider, isEvmAddress, isSilencedError } from './utils';
+import { provider as getProvider, isEvmAddress } from './utils';
 import { Address, EMPTY_ADDRESS, getUrl, Handle } from '../utils';
 
 export const NAME = 'Basename';
@@ -44,13 +43,8 @@ async function collect(
   items: string[],
   query: (item: string) => Promise<[string, string]>
 ): Promise<Record<string, string>> {
-  try {
-    const entries = await Promise.all(items.map(query));
-    return Object.fromEntries(entries.filter(([, value]) => value));
-  } catch (err) {
-    if (!isSilencedError(err)) capture(err, { input: items });
-    throw new FetchError();
-  }
+  const entries = await Promise.all(items.map(query));
+  return Object.fromEntries(entries.filter(([, value]) => value));
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {

--- a/src/addressResolvers/ens.ts
+++ b/src/addressResolvers/ens.ts
@@ -2,7 +2,7 @@ import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
-import { FetchError, provider as getProvider, isEvmAddress, isSilencedError } from './utils';
+import { provider as getProvider, isEvmAddress, isSilencedError } from './utils';
 import constants from '../constants.json';
 import { Address, graphQlCall, Handle } from '../utils';
 
@@ -34,45 +34,36 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
+  let reverseRecords: string[] = [];
   try {
-    let reverseRecords: string[] = [];
-    try {
-      reverseRecords = await snapshot.utils.call(
-        provider,
-        abi,
-        ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [normalizedAddresses]],
-        { blockTag: 'latest' }
-      );
-    } catch (err: any) {
-      if (err?.code !== 'CALL_EXCEPTION') throw err;
-    }
-    const validNames = normalizeEns(reverseRecords);
-
-    // The batch contract only reads on-chain reverse records. Names served by
-    // off-chain resolvers (CCIP-Read) need provider.lookupAddress, which follows
-    // the OffchainLookup flow via the ENS UniversalResolver.
-    const missing = normalizedAddresses.map((_, i) => i).filter(i => !validNames[i]);
-    const lookups = await Promise.allSettled(
-      missing.map(idx => provider.lookupAddress(normalizedAddresses[idx]))
+    reverseRecords = await snapshot.utils.call(
+      provider,
+      abi,
+      ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [normalizedAddresses]],
+      { blockTag: 'latest' }
     );
-    const fallbackNames = normalizeEns(
-      lookups.map(r => (r.status === 'fulfilled' && r.value) || '')
-    );
-    missing.forEach((idx, j) => {
-      if (fallbackNames[j]) validNames[idx] = fallbackNames[j];
-    });
-
-    return Object.fromEntries(
-      normalizedAddresses
-        .map((address, index) => [address, validNames[index]])
-        .filter((_, index) => !!validNames[index])
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { addresses: normalizedAddresses } });
-    }
-    throw new FetchError();
+  } catch (err: any) {
+    if (err?.code !== 'CALL_EXCEPTION') throw err;
   }
+  const validNames = normalizeEns(reverseRecords);
+
+  // The batch contract only reads on-chain reverse records. Names served by
+  // off-chain resolvers (CCIP-Read) need provider.lookupAddress, which follows
+  // the OffchainLookup flow via the ENS UniversalResolver.
+  const missing = normalizedAddresses.map((_, i) => i).filter(i => !validNames[i]);
+  const lookups = await Promise.allSettled(
+    missing.map(idx => provider.lookupAddress(normalizedAddresses[idx]))
+  );
+  const fallbackNames = normalizeEns(lookups.map(r => (r.status === 'fulfilled' && r.value) || ''));
+  missing.forEach((idx, j) => {
+    if (fallbackNames[j]) validNames[idx] = fallbackNames[j];
+  });
+
+  return Object.fromEntries(
+    normalizedAddresses
+      .map((address, index) => [address, validNames[index]])
+      .filter((_, index) => !!validNames[index])
+  );
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {

--- a/src/addressResolvers/gwei.ts
+++ b/src/addressResolvers/gwei.ts
@@ -2,9 +2,8 @@ import { getAddress } from '@ethersproject/address';
 import { concat } from '@ethersproject/bytes';
 import { keccak256 } from '@ethersproject/keccak256';
 import { toUtf8Bytes } from '@ethersproject/strings';
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import { Address, batchContractCalls, EMPTY_ADDRESS, Handle } from '../utils';
-import { FetchError, provider as getProvider, isEvmAddress, isSilencedError } from './utils';
+import { provider as getProvider, isEvmAddress } from './utils';
 
 // Gwei Name Service: an ENS-compatible .gwei namespace on Ethereum. https://gwei.domains
 export const NAME = 'Gwei Name Service';
@@ -55,27 +54,22 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (pairs.length === 0) return {};
 
-  try {
-    const addresses: Record<string, Address> = await batchContractCalls(
-      NETWORK,
-      provider,
-      ABI,
-      pairs.map(([, id]) => id),
-      new Array(pairs.length).fill(CONTRACT),
-      'resolve'
-    );
+  const addresses: Record<string, Address> = await batchContractCalls(
+    NETWORK,
+    provider,
+    ABI,
+    pairs.map(([, id]) => id),
+    new Array(pairs.length).fill(CONTRACT),
+    'resolve'
+  );
 
-    const results: Record<Handle, Address> = {};
-    pairs.forEach(([handle, id]) => {
-      const address = addresses[id];
-      if (address && address !== EMPTY_ADDRESS) results[handle] = getAddress(address);
-    });
+  const results: Record<Handle, Address> = {};
+  pairs.forEach(([handle, id]) => {
+    const address = addresses[id];
+    if (address && address !== EMPTY_ADDRESS) results[handle] = getAddress(address);
+  });
 
-    return results;
-  } catch (err) {
-    if (!isSilencedError(err)) capture(err, { input: { handles } });
-    throw new FetchError();
-  }
+  return results;
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
@@ -83,26 +77,21 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  try {
-    // reverseResolve() is forward-confirmed on-chain, so it's spoofing-safe.
-    const names: Record<string, Handle> = await batchContractCalls(
-      NETWORK,
-      provider,
-      ABI,
-      normalizedAddresses,
-      new Array(normalizedAddresses.length).fill(CONTRACT),
-      'reverseResolve'
-    );
+  // reverseResolve() is forward-confirmed on-chain, so it's spoofing-safe.
+  const names: Record<string, Handle> = await batchContractCalls(
+    NETWORK,
+    provider,
+    ABI,
+    normalizedAddresses,
+    new Array(normalizedAddresses.length).fill(CONTRACT),
+    'reverseResolve'
+  );
 
-    const results: Record<Address, Handle> = {};
-    normalizedAddresses.forEach(address => {
-      const name = names[address];
-      if (name && name.endsWith(TLD)) results[address] = name;
-    });
+  const results: Record<Address, Handle> = {};
+  normalizedAddresses.forEach(address => {
+    const name = names[address];
+    if (name && name.endsWith(TLD)) results[address] = name;
+  });
 
-    return results;
-  } catch (err) {
-    if (!isSilencedError(err)) capture(err, { input: { addresses: normalizedAddresses } });
-    throw new FetchError();
-  }
+  return results;
 }

--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -1,3 +1,4 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import * as basenameResolver from './basename';
 import cache, { clear } from './cache';
 import * as ensResolver from './ens';
@@ -9,6 +10,7 @@ import * as spaceIdResolver from './spaceId';
 import * as starknetResolver from './starknet';
 import * as unstoppableDomainResolver from './unstoppableDomains';
 import {
+  isSilencedError,
   mapOriginalInput,
   normalizeAddresses,
   normalizeHandles,
@@ -18,7 +20,16 @@ import {
 import { timeAddressResolverResponse as timeResponse } from '../helpers/metrics';
 import { Address, Handle } from '../utils';
 
-const RESOLVERS = [
+// A resolver may export MUTED_ERRORS, a list of extra error messages this
+// resolver never wants reported (e.g. a flaky public API's own 5xx).
+type Resolver = {
+  NAME: string;
+  MUTED_ERRORS?: string[];
+  lookupAddresses: (addresses: Address[]) => Promise<Record<Address, Handle>>;
+  resolveNames: (handles: Handle[]) => Promise<Record<Handle, Address>>;
+};
+
+const RESOLVERS: Resolver[] = [
   snapshotResolver,
   ensResolver,
   basenameResolver,
@@ -57,7 +68,11 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
             try {
               result = await r[fnName](_input);
               status = 1;
-            } catch {}
+            } catch (err) {
+              if (!isSilencedError(err, r.MUTED_ERRORS)) {
+                capture(err, { input: { [fnName]: _input } });
+              }
+            }
             end({ status });
 
             return result;

--- a/src/addressResolvers/lens.ts
+++ b/src/addressResolvers/lens.ts
@@ -1,11 +1,10 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
-import { FetchError, isEvmAddress, isSilencedError } from './utils';
+import { isEvmAddress } from './utils';
 import { Address, graphQlCall, Handle } from '../utils';
 
 export const NAME = 'Lens';
 const API_URL = 'https://api.lens.xyz/graphql';
-// mute not fixable errors, since it's a public API
-const MUTED_ERRORS = ['status code 503', 'status code 429'];
+// mute not fixable errors, since it's a public API. Read by addressResolvers/index.ts.
+export const MUTED_ERRORS = ['status code 503', 'status code 429'];
 
 async function apiCall(filterName: string, filters: string[]) {
   const filterValue =
@@ -44,23 +43,15 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  try {
-    const accounts = await apiCall('addresses', normalizedAddresses);
+  const accounts = await apiCall('addresses', normalizedAddresses);
 
-    return (
-      Object.fromEntries(
-        accounts
-          .filter(i => i.username)
-          .map(i => [i.username.ownedBy, `${i.username.localName}.lens`])
-      ) || {}
-    );
-  } catch (err) {
-    if (!isSilencedError(err, MUTED_ERRORS)) {
-      capture(err, { input: { addresses: normalizedAddresses } });
-    }
-
-    throw new FetchError();
-  }
+  return (
+    Object.fromEntries(
+      accounts
+        .filter(i => i.username)
+        .map(i => [i.username.ownedBy, `${i.username.localName}.lens`])
+    ) || {}
+  );
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
@@ -68,17 +59,10 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  try {
-    const accounts = await apiCall('usernames', normalizedHandles);
+  const accounts = await apiCall('usernames', normalizedHandles);
 
-    return (
-      Object.fromEntries(accounts.map(i => [`${i.username.localName}.lens`, i.username.ownedBy])) ||
-      {}
-    );
-  } catch (err) {
-    if (!isSilencedError(err, MUTED_ERRORS)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-    throw new FetchError();
-  }
+  return (
+    Object.fromEntries(accounts.map(i => [`${i.username.localName}.lens`, i.username.ownedBy])) ||
+    {}
+  );
 }

--- a/src/addressResolvers/shibarium.ts
+++ b/src/addressResolvers/shibarium.ts
@@ -1,7 +1,6 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import { DNSConnect } from '@webinterop/dns-connect';
 import { Address, Handle } from '../utils';
-import { FetchError, isEvmAddress, isSilencedError, withoutEmptyValues } from './utils';
+import { isEvmAddress, withoutEmptyValues } from './utils';
 import constants from '../constants.json';
 
 export const NAME = 'Shibarium';
@@ -24,47 +23,33 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  try {
-    const dnsConnect = new DNSConnect({
-      dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
-    });
+  const dnsConnect = new DNSConnect({
+    dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
+  });
 
-    const results = await Promise.all(
-      normalizedAddresses.map(async address => dnsConnect.reverseResolve(address, NETWORK))
-    );
+  const results = await Promise.all(
+    normalizedAddresses.map(async address => dnsConnect.reverseResolve(address, NETWORK))
+  );
 
-    return withoutEmptyValues(
-      Object.fromEntries(normalizedAddresses.map((address, index) => [address, results[index]]))
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { addresses } });
-    }
-    throw new FetchError();
-  }
+  return withoutEmptyValues(
+    Object.fromEntries(normalizedAddresses.map((address, index) => [address, results[index]]))
+  );
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
-  try {
-    const normalizedHandles = normalizeHandles(handles);
+  const normalizedHandles = normalizeHandles(handles);
 
-    if (normalizedHandles.length === 0) return {};
+  if (normalizedHandles.length === 0) return {};
 
-    const dnsConnect = new DNSConnect({
-      dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
-    });
+  const dnsConnect = new DNSConnect({
+    dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
+  });
 
-    const results = await Promise.all(
-      normalizedHandles.map(async handle => dnsConnect.resolve(handle, NETWORK))
-    );
+  const results = await Promise.all(
+    normalizedHandles.map(async handle => dnsConnect.resolve(handle, NETWORK))
+  );
 
-    return withoutEmptyValues(
-      Object.fromEntries(normalizedHandles.map((handle, index) => [handle, results[index]]))
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles } });
-    }
-    throw new FetchError();
-  }
+  return withoutEmptyValues(
+    Object.fromEntries(normalizedHandles.map((handle, index) => [handle, results[index]]))
+  );
 }

--- a/src/addressResolvers/snapshot.ts
+++ b/src/addressResolvers/snapshot.ts
@@ -1,39 +1,30 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import { Address, graphQlCall, Handle } from '../utils';
-import { FetchError, isSilencedError } from './utils';
 
 const HUB_URL = process.env.HUB_URL ?? 'https://hub.snapshot.org';
 export const NAME = 'Snapshot';
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
-  try {
-    const {
-      data: {
-        data: { users }
-      }
-    } = await graphQlCall(
-      `${HUB_URL}/graphql`,
-      `query users($addresses: [String!]!) {
-        users(where: {id_in: $addresses}) {
-          id
-          name
-        }
-      }`,
-      { addresses },
-      {
-        headers: { 'x-api-key': process.env.HUB_API_KEY }
-      }
-    );
-
-    return Object.fromEntries(
-      users.filter((user: any) => user.name).map((user: any) => [user.id, user.name])
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { addresses } });
+  const {
+    data: {
+      data: { users }
     }
-    throw new FetchError();
-  }
+  } = await graphQlCall(
+    `${HUB_URL}/graphql`,
+    `query users($addresses: [String!]!) {
+      users(where: {id_in: $addresses}) {
+        id
+        name
+      }
+    }`,
+    { addresses },
+    {
+      headers: { 'x-api-key': process.env.HUB_API_KEY }
+    }
+  );
+
+  return Object.fromEntries(
+    users.filter((user: any) => user.name).map((user: any) => [user.id, user.name])
+  );
 }
 
 export async function resolveNames(): Promise<Record<Handle, Address>> {

--- a/src/addressResolvers/spaceId.ts
+++ b/src/addressResolvers/spaceId.ts
@@ -1,7 +1,6 @@
 import { namehash } from '@ethersproject/hash';
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import { Address, batchContractCalls, EMPTY_ADDRESS, Handle } from '../utils';
-import { FetchError, provider as getProvider, isEvmAddress, isSilencedError } from './utils';
+import { provider as getProvider, isEvmAddress } from './utils';
 
 // NOTE: Space ID supports multiple networks and TLDs, this file only implements BNB with .bnb TLD
 // https://www.space.id/
@@ -35,38 +34,31 @@ async function resolveNameHashes(
   hashes: string[],
   fnName: string
 ): Promise<Record<string, Address | Handle>> {
-  try {
-    // Fetch the mapping of namehash -> resolver address
-    const resolvers: Record<string, Address> = await batchContractCalls(
-      NETWORK,
-      provider,
-      REGISTRY_ABI,
-      hashes,
-      new Array(hashes.length).fill(BNB_REGISTRY_CONTRACT),
-      'resolver'
-    );
+  // Fetch the mapping of namehash -> resolver address
+  const resolvers: Record<string, Address> = await batchContractCalls(
+    NETWORK,
+    provider,
+    REGISTRY_ABI,
+    hashes,
+    new Array(hashes.length).fill(BNB_REGISTRY_CONTRACT),
+    'resolver'
+  );
 
-    Object.keys(resolvers).forEach(hash => {
-      if (resolvers[hash] === EMPTY_ADDRESS) delete resolvers[hash];
-    });
+  Object.keys(resolvers).forEach(hash => {
+    if (resolvers[hash] === EMPTY_ADDRESS) delete resolvers[hash];
+  });
 
-    if (Object.keys(resolvers).length === 0) return {};
+  if (Object.keys(resolvers).length === 0) return {};
 
-    // Fetch the mapping of namehash -> address/handle
-    return await batchContractCalls(
-      NETWORK,
-      provider,
-      RESOLVER_ABI,
-      Object.keys(resolvers),
-      Object.values(resolvers),
-      fnName
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { hashes, fnName } });
-    }
-    throw new FetchError();
-  }
+  // Fetch the mapping of namehash -> address/handle
+  return await batchContractCalls(
+    NETWORK,
+    provider,
+    RESOLVER_ABI,
+    Object.keys(resolvers),
+    Object.values(resolvers),
+    fnName
+  );
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {

--- a/src/addressResolvers/starknet.ts
+++ b/src/addressResolvers/starknet.ts
@@ -1,6 +1,5 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import axios from 'axios';
-import { FetchError, isSilencedError, isStarknetAddress, withoutEmptyValues } from './utils';
+import { isStarknetAddress, withoutEmptyValues } from './utils';
 import { Address, Handle } from '../utils';
 
 export const NAME = 'Starknet';
@@ -52,14 +51,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  try {
-    return await apiCall('addr_to_domain', normalizedAddresses);
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { addresses: normalizedAddresses } });
-    }
-    throw new FetchError();
-  }
+  return await apiCall('addr_to_domain', normalizedAddresses);
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
@@ -67,12 +59,5 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  try {
-    return await apiCall('domain_to_addr', normalizedHandles);
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-    throw new FetchError();
-  }
+  return await apiCall('domain_to_addr', normalizedHandles);
 }

--- a/src/addressResolvers/unstoppableDomains.ts
+++ b/src/addressResolvers/unstoppableDomains.ts
@@ -2,7 +2,6 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import Resolution, { NamingServiceName } from '@unstoppabledomains/resolution';
 import {
-  FetchError,
   provider as getProvider,
   isEvmAddress,
   isSilencedError,
@@ -32,23 +31,16 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  try {
-    const names: Record<Address, Handle> = await batchContractCalls(
-      NETWORK,
-      provider,
-      ABI,
-      normalizedAddresses,
-      new Array(normalizedAddresses.length).fill(CONTRACT_ADDRESS),
-      'reverseNameOf'
-    );
+  const names: Record<Address, Handle> = await batchContractCalls(
+    NETWORK,
+    provider,
+    ABI,
+    normalizedAddresses,
+    new Array(normalizedAddresses.length).fill(CONTRACT_ADDRESS),
+    'reverseNameOf'
+  );
 
-    return withoutEmptyValues(names);
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { addresses, normalizedAddresses } });
-    }
-    throw new FetchError();
-  }
+  return withoutEmptyValues(names);
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
@@ -56,33 +48,26 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  try {
-    const results = await Promise.all(
-      normalizedHandles.map(async handle => {
-        try {
-          const tokenId = new Resolution().namehash(handle, NamingServiceName.UNS);
-          return await snapshot.utils.call(
-            provider,
-            ABI,
-            [CONTRACT_ADDRESS, 'ownerOf', [tokenId]],
-            { blockTag: 'latest' }
-          );
-        } catch (err) {
-          if (!isSilencedError(err)) {
-            capture(err, { input: { handles: normalizedHandles } });
-          }
-          return;
+  // Kept: this is per-handle partial-failure handling, not the resolver-level
+  // "give up" catch. One unresolvable handle must not drop the whole batch, and
+  // index.ts never sees the error, so it has to be reported from here.
+  const results = await Promise.all(
+    normalizedHandles.map(async handle => {
+      try {
+        const tokenId = new Resolution().namehash(handle, NamingServiceName.UNS);
+        return await snapshot.utils.call(provider, ABI, [CONTRACT_ADDRESS, 'ownerOf', [tokenId]], {
+          blockTag: 'latest'
+        });
+      } catch (err) {
+        if (!isSilencedError(err)) {
+          capture(err, { input: { handles: normalizedHandles } });
         }
-      })
-    );
+        return;
+      }
+    })
+  );
 
-    return withoutEmptyValues(
-      Object.fromEntries(normalizedHandles.map((handle, index) => [handle, results[index]]))
-    );
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-    throw new FetchError();
-  }
+  return withoutEmptyValues(
+    Object.fromEntries(normalizedHandles.map((handle, index) => [handle, results[index]]))
+  );
 }

--- a/test/integration/addressResolvers/ens.test.ts
+++ b/test/integration/addressResolvers/ens.test.ts
@@ -2,7 +2,6 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import testAddressResolver from './helper';
 import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/ens';
-import { FetchError } from '../../../src/addressResolvers/utils';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({
   capture: jest.fn()
@@ -47,8 +46,10 @@ describe('ENS address resolver: CCIP-Read fallback', () => {
     const address = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
 
     try {
-      await expect(lookupAddresses([address])).rejects.toBeInstanceOf(FetchError);
-      expect(capture).toHaveBeenCalledWith(error, { input: { addresses: [address] } });
+      // The resolver rethrows the original error untouched. Reporting it is
+      // addressResolvers/index.ts' job now, so nothing is captured here.
+      await expect(lookupAddresses([address])).rejects.toBe(error);
+      expect(capture).not.toHaveBeenCalled();
     } finally {
       callSpy.mockRestore();
     }

--- a/test/unit/addressResolvers.test.ts
+++ b/test/unit/addressResolvers.test.ts
@@ -1,0 +1,90 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { lookupAddresses } from '../../src/addressResolvers';
+import * as basename from '../../src/addressResolvers/basename';
+import * as ens from '../../src/addressResolvers/ens';
+import * as gwei from '../../src/addressResolvers/gwei';
+import * as lens from '../../src/addressResolvers/lens';
+import * as shibarium from '../../src/addressResolvers/shibarium';
+import * as snapshotResolver from '../../src/addressResolvers/snapshot';
+import * as spaceId from '../../src/addressResolvers/spaceId';
+import * as starknet from '../../src/addressResolvers/starknet';
+import * as unstoppableDomains from '../../src/addressResolvers/unstoppableDomains';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+// Run the resolver fan-out on every call, without a redis round trip.
+jest.mock('../../src/addressResolvers/cache', () => ({
+  __esModule: true,
+  default: (input: string[], callback: (input: string[]) => any) => callback(input),
+  clear: jest.fn()
+}));
+
+const RESOLVERS = [
+  snapshotResolver,
+  ens,
+  basename,
+  unstoppableDomains,
+  lens,
+  starknet,
+  shibarium,
+  spaceId,
+  gwei
+];
+
+const ADDRESS = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+
+beforeEach(() => {
+  RESOLVERS.forEach(resolver => {
+    jest.spyOn(resolver, 'lookupAddresses').mockResolvedValue({});
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('addressResolvers - resolver failures', () => {
+  it('captures a resolver error, with the input as context', async () => {
+    const error = new Error('boom');
+    jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith(error, { input: { lookupAddresses: [ADDRESS] } });
+  });
+
+  it('does not capture a silenced error', async () => {
+    jest
+      .spyOn(ens, 'lookupAddresses')
+      .mockRejectedValue(new Error('Request failed with status=504, no body'));
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not capture an error listed in the resolver MUTED_ERRORS', async () => {
+    jest
+      .spyOn(lens, 'lookupAddresses')
+      .mockRejectedValue(new Error('Request failed with status code 503'));
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('applies MUTED_ERRORS only to the resolver exporting it', async () => {
+    const error = new Error('Request failed with status code 503');
+    jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(error, { input: { lookupAddresses: [ADDRESS] } });
+  });
+
+  it('keeps the other resolvers results when one fails', async () => {
+    jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(new Error('boom'));
+    jest.spyOn(shibarium, 'lookupAddresses').mockResolvedValue({ [ADDRESS]: 'boorger.shib' });
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({ [ADDRESS]: 'boorger.shib' });
+  });
+});

--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -35,7 +35,7 @@ describe('POST /', () => {
 
         const response = await lookupDomains();
 
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(200);
         expect(capture).toHaveBeenCalledTimes(1);
         expect(capture).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Request failed with status code 500' }),
@@ -52,7 +52,7 @@ describe('POST /', () => {
 
         const response = await lookupDomains();
 
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(200);
         expect(capture).not.toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
First half of #496. No behaviour change on the JSON-RPC path, and independent of #448 as the issue says.

Every resolver repeated the same block: catch, decide whether to report, then throw a `FetchError` purely so the failure could cross the `index.ts` boundary without being reported twice. `_call` already swallows those rejections with a bare `catch {}`, so the sentinel carried an "already handled" flag the orchestrator never read.

The capture moves into `_call`'s catch and the resolvers throw their original errors. 14 catch blocks go, and with them 14 of the 16 `throw new FetchError()` sites. Silence policy stays with the resolver: `lens.ts` exports `MUTED_ERRORS` and `index.ts` passes it to `isSilencedError`. `RESOLVERS` picks up an explicit `Resolver` type so `MUTED_ERRORS` is a real optional field rather than an untyped lookup.

### Three catch blocks stay

They are partial-failure handling, not the sentinel pattern. They capture and continue instead of giving up, so `index.ts` never sees the error and could not report it:

- `ens.ts` `resolveNames`, subgraph path and provider path — either can fail without losing the other's results
- `unstoppableDomains.ts` `resolveNames`, per handle — one unresolvable handle must not drop the batch

Same reasoning the issue already applies to `lookupDomains/shibarium.ts`'s inner capture.

### One behaviour change, worth a look

`basename.ts` `getAvatar` reaches `collect()` from outside the orchestrator, and its only caller `resolvers/basename.ts` swallows with a bare `catch {}`. So Basename avatar failures stop being reported. The sibling `call('text', ...)` on that same path already reported nothing, and every other `src/resolvers/*` swallows the same way, so this makes Basename consistent rather than odd. Say the word if you would rather keep a capture there.

### FetchError

Still needed by `lookupDomains`' 2 remaining sites, so the class stays here. It goes in the follow-up.

### Tests

One new file, `test/unit/addressResolvers.test.ts`, on the one concern this PR moves: who reports a resolver failure. Five cases — captured once with the input as context, silenced errors not captured, `MUTED_ERRORS` honoured, `MUTED_ERRORS` scoped to the resolver that exports it, and one failing resolver not taking the others down. Both halves are mutation-checked: reverting the capture fails 2 of them, dropping `r.MUTED_ERRORS` from the `isSilencedError` call fails a third.

`test/integration/addressResolvers/ens.test.ts` had one case asserting the old contract (`rejects.toBeInstanceOf(FetchError)` plus a resolver-level capture). It now asserts the raw error is rethrown untouched and nothing is captured at the resolver. That is the only edit to that file — its unrelated live-network failure is untouched.

### Gate

- `yarn typecheck` clean
- `yarn lint` clean
- `yarn jest test/unit` — 10/10, 3 suites
- `test/integration/addressResolvers/utils.test.ts` green

CI will still show `addressResolvers/ens`, `addressResolvers/starknet` and `resolvers/zapper` red. Those are the live-network suites that have been failing since 2026-07-07, untouched here.

### Base

Stacked on #499 so this PR's CI is not red for a reason that has nothing to do with it — master's `test/unit/api.test.ts` is currently broken by the #448 merge and #499 is the two-line fix. Retarget to master once #499 lands. Nothing in this diff depends on it otherwise.

Refs #496