### PR TITLE
test(api): name the lookup_domains cases after what they now assert

### DIFF
--- a/test/unit/api.test.ts
+++ b/test/unit/api.test.ts
@@ -27,7 +27,7 @@ function lookupDomains() {
 
 describe('POST /', () => {
   describe('on lookup_domains', () => {
-    describe('when a resolver reports its own error', () => {
+    describe('when a resolver fails', () => {
       it('captures the resolver error only once', async () => {
         (graphQlCall as jest.Mock).mockRejectedValue(
           new Error('Request failed with status code 500')
@@ -44,7 +44,7 @@ describe('POST /', () => {
       });
     });
 
-    describe('when a resolver silences its own error', () => {
+    describe('when a resolver fails with a silenced error', () => {
       it('does not capture anything', async () => {
         (graphQlCall as jest.Mock).mockRejectedValue(
           new Error('Request failed with status=504, no body')


### PR DESCRIPTION
Follow-up to #501, from Wan's question on #500.

Those two `describe` blocks say the resolver reports and silences its own error. #501 moved both into `lookupDomains/index.ts`, so neither is true any more. The assertions are untouched.

They are worth keeping as they are: with capture in `index.ts`, removing it, doubling it, dropping the `isSilencedError` guard, or letting the rejection reach `api.ts` each fail at least one of these two cases. The 200 status is the one thing they assert that `test/unit/lookupDomains.test.ts` does not.

### Gate

- `yarn typecheck` clean
- `yarn lint` clean
- `yarn jest test/unit` 13/13, 3 suites

`addressResolvers/ens`, `addressResolvers/starknet` and `resolvers/zapper` stay red in CI, as on master since 2026-07-07.