### PR TITLE
feat(utils): validate the GraphQL response envelope in graphQlCall

### DIFF
--- a/src/lookupDomains/ens.ts
+++ b/src/lookupDomains/ens.ts
@@ -28,7 +28,12 @@ async function fetchDomainData(domain: Domain, chainId: string): Promise<Domain>
     }`,
     { id: `0x${hash}` }
   );
-  const labelName = data?.registration?.domain?.labelName;
+  // `data?.` used to swallow a missing envelope here and return the raw
+  // `[hash]` label as if the subgraph had simply not known it. graphQlCall now
+  // throws on that, so a subgraph failure is reported rather than served as an
+  // undecoded name. A registration that genuinely has no labelName still falls
+  // through to the unchanged name.
+  const labelName = data.registration?.domain?.labelName;
 
   return {
     ...domain,

--- a/src/lookupDomains/ens.ts
+++ b/src/lookupDomains/ens.ts
@@ -28,9 +28,8 @@ async function fetchDomainData(domain: Domain, chainId: string): Promise<Domain>
     }`,
     { id: `0x${hash}` }
   );
-  // Not `data?.`: a missing envelope must not fall through to the raw `[hash]`
-  // label and make a subgraph outage look like an unindexed name. A `registration`
-  // that is genuinely null still does fall through, to the unchanged name.
+  // Not `data?.`: swallowing a missing envelope here serves the raw `[hash]`
+  // label as though the subgraph had simply not indexed it.
   const labelName = data.registration?.domain?.labelName;
 
   return {

--- a/src/lookupDomains/ens.ts
+++ b/src/lookupDomains/ens.ts
@@ -28,11 +28,9 @@ async function fetchDomainData(domain: Domain, chainId: string): Promise<Domain>
     }`,
     { id: `0x${hash}` }
   );
-  // `data?.` used to swallow a missing envelope here and return the raw
-  // `[hash]` label as if the subgraph had simply not known it. graphQlCall now
-  // throws on that, so a subgraph failure is reported rather than served as an
-  // undecoded name. A registration that genuinely has no labelName still falls
-  // through to the unchanged name.
+  // Not `data?.`: a missing envelope must not fall through to the raw `[hash]`
+  // label and make a subgraph outage look like an unindexed name. A `registration`
+  // that is genuinely null still does fall through, to the unchanged name.
   const labelName = data.registration?.domain?.labelName;
 
   return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -188,44 +188,22 @@ export type GraphQlResponse<T = any> = {
   errors?: { message?: string }[];
 };
 
-/**
- * Builds the error a failed GraphQL envelope describes.
- *
- * The HTTP status goes *on* the error, at both `status` and `response.status`,
- * because those are the two places isSilencedError() reads. A status
- * interpolated into the message string is unreachable to it, so a rate limit or
- * a gateway timeout would stay noisy where the equivalent axios error is
- * silenced (STAMP-6X).
- */
 function graphQlEnvelopeError(url: string, status: number, message: string) {
   let source = url;
   try {
     source = new URL(url).host;
   } catch {
-    // A non-absolute url is unexpected; naming it in full still beats no source.
+    // Not an absolute url; keep the whole string as the source.
   }
 
+  // Both locations are load-bearing: isSilencedError reads `status` and
+  // `response.status`, and a status only in the message string is unreachable to it.
   return Object.assign(new Error(`[${source}] ${message}`), {
     status,
     response: { status }
   });
 }
 
-/**
- * POSTs a GraphQL query and validates the response envelope.
- *
- * A GraphQL upstream reports its own failures inside an HTTP 200 body, so axios
- * does not throw. Unchecked, the caller's `data.data.X` destructure then raises
- * a TypeError that names the field we wanted and carries none of the upstream's
- * evidence — STAMP-6W (`data: {users: null}`), STAMP-49 (no `data` key at all)
- * and STAMP-19 are all that same failure.
- *
- * Throws when the body carries `errors`, or when the `data` envelope is absent,
- * so every caller can destructure `data.data.X` on the strength of this check.
- * Note that a *field* resolving to null (`data.account === null`) is a
- * legitimate "no record" answer, not an envelope failure, and is left to the
- * caller to handle.
- */
 export async function graphQlCall<T = any>(
   url: string,
   query: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import snapshot from '@snapshot-labs/snapshot.js';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { Response } from 'express';
 import sharp from 'sharp';
 import chains from './chains.json';
@@ -183,20 +183,63 @@ export const getBaseAssetIconUrl = (chainId: string) => {
   return 'https://static.cdnlogo.com/logos/e/81/ethereum-eth.svg';
 };
 
-export function graphQlCall(
+export type GraphQlResponse<T = any> = {
+  data: T;
+  errors?: { message?: string }[];
+};
+
+/**
+ * Builds the error a failed GraphQL envelope describes.
+ *
+ * The HTTP status goes *on* the error, at both `status` and `response.status`,
+ * because those are the two places isSilencedError() reads. A status
+ * interpolated into the message string is unreachable to it, so a rate limit or
+ * a gateway timeout would stay noisy where the equivalent axios error is
+ * silenced (STAMP-6X).
+ */
+function graphQlEnvelopeError(url: string, status: number, message: string) {
+  let source = url;
+  try {
+    source = new URL(url).host;
+  } catch {
+    // A non-absolute url is unexpected; naming it in full still beats no source.
+  }
+
+  return Object.assign(new Error(`[${source}] ${message}`), {
+    status,
+    response: { status }
+  });
+}
+
+/**
+ * POSTs a GraphQL query and validates the response envelope.
+ *
+ * A GraphQL upstream reports its own failures inside an HTTP 200 body, so axios
+ * does not throw. Unchecked, the caller's `data.data.X` destructure then raises
+ * a TypeError that names the field we wanted and carries none of the upstream's
+ * evidence — STAMP-6W (`data: {users: null}`), STAMP-49 (no `data` key at all)
+ * and STAMP-19 are all that same failure.
+ *
+ * Throws when the body carries `errors`, or when the `data` envelope is absent,
+ * so every caller can destructure `data.data.X` on the strength of this check.
+ * Note that a *field* resolving to null (`data.account === null`) is a
+ * legitimate "no record" answer, not an envelope failure, and is left to the
+ * caller to handle.
+ */
+export async function graphQlCall<T = any>(
   url: string,
   query: string,
   variables?: Record<string, any>,
   options: any = {
     headers: {}
   }
-) {
+): Promise<AxiosResponse<GraphQlResponse<T>>> {
   const data: { query: string; variables?: Record<string, any> } = { query };
   if (variables) {
     data.variables = variables;
   }
 
-  return axios({
+  const response: AxiosResponse<GraphQlResponse<T>> = await axios({
     url: url,
     method: 'post',
     headers: {
@@ -208,6 +251,22 @@ export function graphQlCall(
     timeout: 5e3,
     data
   });
+
+  const body = response.data;
+
+  if (body?.errors?.length) {
+    throw graphQlEnvelopeError(
+      url,
+      response.status,
+      body.errors[0]?.message || 'GraphQL request failed'
+    );
+  }
+
+  if (!body?.data) {
+    throw graphQlEnvelopeError(url, response.status, 'GraphQL response has no data envelope');
+  }
+
+  return response;
 }
 
 /**

--- a/test/unit/addressResolvers/ens.test.ts
+++ b/test/unit/addressResolvers/ens.test.ts
@@ -1,0 +1,57 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import axios from 'axios';
+import { resolveNames } from '../../../src/addressResolvers/ens';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+jest.mock('axios', () => {
+  const mock: any = jest.fn();
+  mock.get = jest.fn();
+  mock.post = jest.fn();
+  return { __esModule: true, default: mock };
+});
+
+// resolveNames falls back to the provider for anything the subgraph did not
+// answer. Stub it so the test never leaves the process.
+jest.mock('../../../src/addressResolvers/utils', () => ({
+  ...jest.requireActual('../../../src/addressResolvers/utils'),
+  provider: jest.fn(() => ({
+    resolveName: jest.fn().mockResolvedValue(null),
+    lookupAddress: jest.fn().mockResolvedValue(null)
+  }))
+}));
+
+const mockedAxios = axios as unknown as jest.Mock;
+
+const HANDLE = 'test.eth';
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+
+describe('addressResolvers/ens - resolveNames', () => {
+  it('reports the subgraph failure instead of a TypeError naming our own field', async () => {
+    mockedAxios.mockResolvedValue({
+      status: 200,
+      data: { errors: [{ message: 'bad indexers' }], data: null }
+    });
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({ message: '[subgrapher.snapshot.org] bad indexers' }),
+      { input: { handles: [HANDLE] } }
+    );
+  });
+
+  it('resolves from the subgraph and reports nothing when it answers', async () => {
+    mockedAxios.mockResolvedValue({
+      status: 200,
+      data: {
+        data: { domains: [{ name: HANDLE, resolvedAddress: { id: ADDRESS.toLowerCase() } }] }
+      }
+    });
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({ [HANDLE]: ADDRESS });
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/addressResolvers/ens.test.ts
+++ b/test/unit/addressResolvers/ens.test.ts
@@ -13,8 +13,6 @@ jest.mock('axios', () => {
   return { __esModule: true, default: mock };
 });
 
-// resolveNames falls back to the provider for anything the subgraph did not
-// answer. Stub it so the test never leaves the process.
 jest.mock('../../../src/addressResolvers/utils', () => ({
   ...jest.requireActual('../../../src/addressResolvers/utils'),
   provider: jest.fn(() => ({

--- a/test/unit/graphQlCall.test.ts
+++ b/test/unit/graphQlCall.test.ts
@@ -41,8 +41,6 @@ describe('graphQlCall', () => {
     });
 
     it('does not throw on a field that resolved to null', async () => {
-      // A null field is the upstream saying "no record", not "I failed". It is
-      // the caller's to handle, and must not be turned into an error here.
       respondWith({ data: { account: null } });
 
       const { data } = await graphQlCall(URL, QUERY);
@@ -53,7 +51,6 @@ describe('graphQlCall', () => {
 
   describe('when the body carries errors', () => {
     it('throws the upstream message, attributed to the upstream', async () => {
-      // The exact STAMP-6W body: HTTP 200, so axios does not throw.
       const err = await errorFrom({
         errors: [{ message: 'Invalid addresses in id' }],
         data: { users: null }

--- a/test/unit/graphQlCall.test.ts
+++ b/test/unit/graphQlCall.test.ts
@@ -1,0 +1,128 @@
+import axios from 'axios';
+import { isSilencedError } from '../../src/addressResolvers/utils';
+import { graphQlCall } from '../../src/utils';
+
+jest.mock('axios', () => {
+  const mock: any = jest.fn();
+  mock.get = jest.fn();
+  mock.post = jest.fn();
+  return { __esModule: true, default: mock };
+});
+
+const mockedAxios = axios as unknown as jest.Mock;
+
+const URL = 'https://hub.snapshot.org/graphql';
+const QUERY = 'query users { users { id } }';
+
+function respondWith(body: any, status = 200) {
+  mockedAxios.mockResolvedValue({ status, data: body });
+}
+
+async function errorFrom(body: any, status = 200) {
+  respondWith(body, status);
+
+  try {
+    await graphQlCall(URL, QUERY);
+  } catch (err: any) {
+    return err;
+  }
+
+  throw new Error('graphQlCall resolved, expected it to throw');
+}
+
+describe('graphQlCall', () => {
+  describe('when the envelope is intact', () => {
+    it('returns the response', async () => {
+      respondWith({ data: { users: [{ id: '0x1' }] } });
+
+      const { data } = await graphQlCall(URL, QUERY);
+
+      expect(data.data.users).toEqual([{ id: '0x1' }]);
+    });
+
+    it('does not throw on a field that resolved to null', async () => {
+      // A null field is the upstream saying "no record", not "I failed". It is
+      // the caller's to handle, and must not be turned into an error here.
+      respondWith({ data: { account: null } });
+
+      const { data } = await graphQlCall(URL, QUERY);
+
+      expect(data.data.account).toBeNull();
+    });
+  });
+
+  describe('when the body carries errors', () => {
+    it('throws the upstream message, attributed to the upstream', async () => {
+      // The exact STAMP-6W body: HTTP 200, so axios does not throw.
+      const err = await errorFrom({
+        errors: [{ message: 'Invalid addresses in id' }],
+        data: { users: null }
+      });
+
+      expect(err.message).toBe('[hub.snapshot.org] Invalid addresses in id');
+    });
+
+    it('falls back to a generic message when the upstream gives none', async () => {
+      const err = await errorFrom({ errors: [{}], data: null });
+
+      expect(err.message).toBe('[hub.snapshot.org] GraphQL request failed');
+    });
+
+    it('does not throw on an empty errors array', async () => {
+      respondWith({ errors: [], data: { users: [] } });
+
+      await expect(graphQlCall(URL, QUERY)).resolves.toBeDefined();
+    });
+  });
+
+  describe('when the data envelope is absent', () => {
+    it.each<[string, any]>([
+      ['no data key at all', { errors: [{ message: 'boom' }] }],
+      ['a null data envelope', { data: null }],
+      ['an empty body', {}],
+      ['a body that is not a GraphQL response', 'Bad Gateway']
+    ])('throws on %s', async (_, body) => {
+      const err = await errorFrom(body);
+
+      expect(err.message).toMatch(/^\[hub\.snapshot\.org\] /);
+    });
+
+    it('names the failure when there is no upstream message to quote', async () => {
+      const err = await errorFrom({});
+
+      expect(err.message).toBe('[hub.snapshot.org] GraphQL response has no data envelope');
+    });
+
+    it('names the upstream by host, not by caller', async () => {
+      respondWith({});
+
+      await expect(
+        graphQlCall('https://subgrapher.snapshot.org/subgraph/arbitrum/abc', QUERY)
+      ).rejects.toThrow('[subgrapher.snapshot.org]');
+    });
+  });
+
+  describe('the thrown error', () => {
+    // isSilencedError reads error.status and error.response.status. A status
+    // that lives only in the message string is unreachable to it, which is why
+    // it goes on the object (STAMP-6X).
+    it('carries the http status in both places isSilencedError reads', async () => {
+      const err = await errorFrom({ errors: [{ message: 'boom' }], data: null }, 429);
+
+      expect(err.status).toBe(429);
+      expect(err.response.status).toBe(429);
+    });
+
+    it.each([429, 504])('is silenced on a %i', async status => {
+      const err = await errorFrom({ errors: [{ message: 'boom' }], data: null }, status);
+
+      expect(isSilencedError(err)).toBe(true);
+    });
+
+    it('is not silenced on a status that is not transient', async () => {
+      const err = await errorFrom({ errors: [{ message: 'boom' }], data: null }, 500);
+
+      expect(isSilencedError(err)).toBe(false);
+    });
+  });
+});

--- a/test/unit/graphQlCall.test.ts
+++ b/test/unit/graphQlCall.test.ts
@@ -103,9 +103,6 @@ describe('graphQlCall', () => {
   });
 
   describe('the thrown error', () => {
-    // isSilencedError reads error.status and error.response.status. A status
-    // that lives only in the message string is unreachable to it, which is why
-    // it goes on the object (STAMP-6X).
     it('carries the http status in both places isSilencedError reads', async () => {
       const err = await errorFrom({ errors: [{ message: 'boom' }], data: null }, 429);
 

--- a/test/unit/graphQlEnvelope.test.ts
+++ b/test/unit/graphQlEnvelope.test.ts
@@ -29,15 +29,10 @@ function respondWith(body: any, status = 200) {
   mockedAxios.mockResolvedValue({ status, data: body });
 }
 
-// `errors` is checked before the envelope is, so `data` never decides the outcome
-// here: pass a payload for the STAMP-6W shape, where the upstream flags an error and
-// still sends something that looks usable.
 function upstreamFailure(message: string, data: any = null) {
   return { errors: [{ message }], data };
 }
 
-// Each case is written so that removing the envelope check in graphQlCall changes
-// the outcome, not just the wording.
 describe('graphQlCall callers surface an envelope failure', () => {
   describe('src/addressResolvers/lens.ts - accountsBulk', () => {
     it('rejects with the upstream message', async () => {
@@ -64,8 +59,6 @@ describe('graphQlCall callers surface an envelope failure', () => {
   });
 
   describe('src/lookupDomains/ens.ts - registration', () => {
-    // A domain whose label the subgraph has not indexed comes back hashed, and
-    // a second query decodes it.
     const hashedDomain = {
       data: {
         account: { domains: [{ name: '[7f3a].eth' }], wrappedDomains: [] }

--- a/test/unit/graphQlEnvelope.test.ts
+++ b/test/unit/graphQlEnvelope.test.ts
@@ -29,16 +29,15 @@ function respondWith(body: any, status = 200) {
   mockedAxios.mockResolvedValue({ status, data: body });
 }
 
-// An upstream failure served as HTTP 200, so axios resolves and the caller
-// walks straight into it. `data` defaults to null (the STAMP-49 shape); pass a
-// payload to get the STAMP-6W shape, where the upstream reports an error and
+// `errors` is checked before the envelope is, so `data` never decides the outcome
+// here: pass a payload for the STAMP-6W shape, where the upstream flags an error and
 // still sends something that looks usable.
 function upstreamFailure(message: string, data: any = null) {
   return { errors: [{ message }], data };
 }
 
-// One case per graphQlCall caller. Each is written so that removing the
-// envelope check in graphQlCall changes the outcome, not just the wording.
+// Each case is written so that removing the envelope check in graphQlCall changes
+// the outcome, not just the wording.
 describe('graphQlCall callers surface an envelope failure', () => {
   describe('src/addressResolvers/lens.ts - accountsBulk', () => {
     it('rejects with the upstream message', async () => {
@@ -91,9 +90,6 @@ describe('graphQlCall callers surface an envelope failure', () => {
       await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['[7f3a].eth']);
     });
 
-    // Behaviour change: this used to fall through `data?.` and hand back the
-    // undecoded `[7f3a].eth` as though the label were simply unknown, making a
-    // subgraph outage indistinguishable from a missing label.
     it('rejects rather than returning the undecoded name when the subgraph fails', async () => {
       answerWith(upstreamFailure('bad indexers'));
 

--- a/test/unit/graphQlEnvelope.test.ts
+++ b/test/unit/graphQlEnvelope.test.ts
@@ -1,0 +1,145 @@
+import axios from 'axios';
+import { lookupAddresses as lensLookupAddresses } from '../../src/addressResolvers/lens';
+import ensLookupDomains from '../../src/lookupDomains/ens';
+import lensResolve from '../../src/resolvers/lens';
+import { resolveSpaceAvatar, resolveUserAvatar } from '../../src/resolvers/snapshot';
+import { resolveAvatar as resolveSxSpaceAvatar } from '../../src/resolvers/space-sx';
+import { fetchHttpImage } from '../../src/resolvers/utils';
+
+jest.mock('axios', () => {
+  const mock: any = jest.fn();
+  mock.get = jest.fn();
+  mock.post = jest.fn();
+  return { __esModule: true, default: mock };
+});
+
+jest.mock('../../src/resolvers/utils', () => ({
+  ...jest.requireActual('../../src/resolvers/utils'),
+  fetchHttpImage: jest.fn()
+}));
+
+const mockedAxios = axios as unknown as jest.Mock;
+
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const IMAGE_URL = 'https://example.com/avatar.png';
+
+const ENS_SUBGRAPH = '[subgrapher.snapshot.org]';
+
+function respondWith(body: any, status = 200) {
+  mockedAxios.mockResolvedValue({ status, data: body });
+}
+
+// An upstream failure served as HTTP 200, so axios resolves and the caller
+// walks straight into it. `data` defaults to null (the STAMP-49 shape); pass a
+// payload to get the STAMP-6W shape, where the upstream reports an error and
+// still sends something that looks usable.
+function upstreamFailure(message: string, data: any = null) {
+  return { errors: [{ message }], data };
+}
+
+// One case per graphQlCall caller. Each is written so that removing the
+// envelope check in graphQlCall changes the outcome, not just the wording.
+describe('graphQlCall callers surface an envelope failure', () => {
+  describe('src/addressResolvers/lens.ts - accountsBulk', () => {
+    it('rejects with the upstream message', async () => {
+      respondWith(upstreamFailure('Rate limit exceeded'));
+
+      await expect(lensLookupAddresses([ADDRESS])).rejects.toThrow(
+        '[api.lens.xyz] Rate limit exceeded'
+      );
+    });
+  });
+
+  describe('src/lookupDomains/ens.ts - account', () => {
+    it('rejects with the upstream message', async () => {
+      respondWith(upstreamFailure('bad indexers'));
+
+      await expect(ensLookupDomains(ADDRESS)).rejects.toThrow(`${ENS_SUBGRAPH} bad indexers`);
+    });
+
+    it('still returns empty for an address the subgraph has no account for', async () => {
+      respondWith({ data: { account: null } });
+
+      await expect(ensLookupDomains(ADDRESS)).resolves.toEqual([]);
+    });
+  });
+
+  describe('src/lookupDomains/ens.ts - registration', () => {
+    // A domain whose label the subgraph has not indexed comes back hashed, and
+    // a second query decodes it.
+    const hashedDomain = {
+      data: {
+        account: { domains: [{ name: '[7f3a].eth' }], wrappedDomains: [] }
+      }
+    };
+
+    function answerWith(second: any) {
+      mockedAxios
+        .mockResolvedValueOnce({ status: 200, data: hashedDomain })
+        .mockResolvedValueOnce({ status: 200, data: second });
+    }
+
+    it('decodes the label when the subgraph answers', async () => {
+      answerWith({ data: { registration: { domain: { labelName: 'vitalik' } } } });
+
+      await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['vitalik.eth']);
+    });
+
+    it('keeps the hashed name when the label is genuinely unknown', async () => {
+      answerWith({ data: { registration: null } });
+
+      await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['[7f3a].eth']);
+    });
+
+    // Behaviour change: this used to fall through `data?.` and hand back the
+    // undecoded `[7f3a].eth` as though the label were simply unknown, making a
+    // subgraph outage indistinguishable from a missing label.
+    it('rejects rather than returning the undecoded name when the subgraph fails', async () => {
+      answerWith(upstreamFailure('bad indexers'));
+
+      await expect(ensLookupDomains(ADDRESS)).rejects.toThrow(`${ENS_SUBGRAPH} bad indexers`);
+    });
+  });
+
+  describe('src/resolvers/snapshot.ts - entry', () => {
+    it('does not use a payload the upstream flagged as an error', async () => {
+      respondWith(upstreamFailure('hub is down', { entry: { avatar: IMAGE_URL } }));
+
+      await expect(resolveUserAvatar(ADDRESS)).resolves.toBe(false);
+      expect(fetchHttpImage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('src/resolvers/snapshot.ts - spaces', () => {
+    it('does not use a payload the upstream flagged as an error', async () => {
+      respondWith(
+        upstreamFailure('subgraph is down', { spaces: [{ metadata: { avatar: IMAGE_URL } }] })
+      );
+
+      await expect(resolveSpaceAvatar(ADDRESS, 1, 'eth')).resolves.toBe(false);
+      expect(fetchHttpImage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('src/resolvers/space-sx.ts - spaces', () => {
+    it('does not use a payload the upstream flagged as an error', async () => {
+      respondWith(
+        upstreamFailure('subgraph is down', { spaces: [{ metadata: { avatar: IMAGE_URL } }] })
+      );
+
+      await expect(resolveSxSpaceAvatar(ADDRESS)).resolves.toBe(false);
+      expect(fetchHttpImage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('src/resolvers/lens.ts - account', () => {
+    it('does not use a payload the upstream flagged as an error', async () => {
+      respondWith(
+        upstreamFailure('Rate limit exceeded', { account: { metadata: { picture: IMAGE_URL } } })
+      );
+
+      await expect(lensResolve(ADDRESS)).resolves.toBe(false);
+      expect(fetchHttpImage).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #272.

Every GraphQL call site destructured `data.data.X` straight off the response with no check that the envelope was there. A GraphQL upstream reports its own failures inside an HTTP **200** body, so axios does not throw, and the destructure raised a TypeError naming the field *we* wanted while carrying none of the upstream's evidence. STAMP-6W, STAMP-49 and STAMP-19 are all that one failure.

Those sites all go through `graphQlCall`, and they are its only callers, so the check goes there once. It throws when the body carries `errors`, or when the `data` envelope is absent.

Three things worth pointing at:

**The status goes on the error object, not into the message.** `isSilencedError` reads `error.status` and `error.response.status`. A status that exists only in prose is unreachable to it, so a 429 or 504 from a GraphQL upstream would stay noisy where the identical axios error is silenced. In practice axios rejects anything outside 2xx before this check runs, so the status carried here will be 200. It goes on the object anyway, because that is the only place downstream can read it and because the alternative, a status in the message string, is the exact mistake STAMP-6X was about.

**`source` is the upstream host, not a resolver name.** Most of the call sites have no name to give. The host is uniform across all of them, it names the upstream that actually failed rather than the caller that noticed, and it groups stably in Sentry.

**A null field is not an envelope failure.** `data.account === null` is the upstream saying "no record", it is legitimate, and it still passes straight through to the caller's existing `account?.` reads. Only a missing envelope, or an explicit `errors[]`, throws. Optional chaining was deliberately not used as the fix: returning empty on a missing envelope converts an upstream outage into a silent empty result, every user quietly loses their ENS name, and `cache.ts` then stores that emptiness.

## Behaviour change in `lookupDomains/ens.ts`

Everywhere else this is pure hardening. A TypeError becomes a meaningful error, on the same path, with the same outcome.

`src/lookupDomains/ens.ts` was the wrong version of this fix already. It destructured the envelope and then read it back with `?.`, so a subgraph failure silently returned the raw `[7f3a].eth` label, indistinguishable from a label the subgraph genuinely has not indexed. It now throws like the rest, which means a subgraph outage during label decoding drops that chain's ENS domains instead of serving an undecoded name. Those failures are reported through `lookupDomains/index.ts`, where every resolver failure is already caught and captured. The second query hits the same subgraph as the first, so if it fails the answer we were about to serve was not trustworthy anyway.

A `registration` that is genuinely `null` still falls through to the unchanged name, so the two cases stay separated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
