### PR TITLE
refactor(resolvers): capture resolver errors in index.ts

### DIFF
--- a/src/resolvers/basename.ts
+++ b/src/resolvers/basename.ts
@@ -4,12 +4,8 @@ import { resize } from '../utils';
 import { fetchHttpImage } from './utils';
 
 export default async function resolve(nameOrAddress: string) {
-  try {
-    const url = await getAvatar(nameOrAddress);
-    if (!url) return false;
+  const url = await getAvatar(nameOrAddress);
+  if (!url) return false;
 
-    return await resize(await fetchHttpImage(url), max, max);
-  } catch {
-    return false;
-  }
+  return await resize(await fetchHttpImage(url), max, max);
 }

--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -1,7 +1,6 @@
-import { getAddress } from '@ethersproject/address';
 import { max } from '../constants.json';
 import { resize } from '../utils';
-import { fetchHttpImage } from './utils';
+import { fetchHttpImage, toChecksumAddress } from './utils';
 
 const API_KEY = process.env.COINGECKO_API_KEY;
 
@@ -17,20 +16,31 @@ const COINGECKO_ASSET_PLATFORMS = {
 export default async function resolve(address: string, chainId: string) {
   if (!API_KEY) return false;
 
-  try {
-    const assetPlatformId = COINGECKO_ASSET_PLATFORMS[chainId];
+  const assetPlatformId = COINGECKO_ASSET_PLATFORMS[chainId];
 
-    if (!assetPlatformId) return false;
+  if (!assetPlatformId) return false;
 
-    const checksum = getAddress(address);
-    const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
+  const checksum = toChecksumAddress(address);
 
-    const data = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } }).then(res =>
-      res.json()
-    );
-    const input = await fetchHttpImage(data?.image?.large);
-    return await resize(input, max, max);
-  } catch {
-    return false;
+  if (!checksum) return false;
+
+  const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
+  const response = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } });
+
+  // CoinGecko knows no coin for this contract ({"error":"coin not found"}):
+  // no data. Any other non-2xx is a real failure (a rejected API key answers
+  // 401) and must be reported rather than read as an empty result.
+  if (response.status === 404) return false;
+  if (!response.ok) {
+    throw new Error(`Invalid network response (${url} ${response.status})`);
   }
+
+  const data = await response.json();
+
+  // A coin with no image: no data, and fetchHttpImage(undefined) would throw
+  // "Provided config url is not valid" as if the request had failed.
+  if (!data?.image?.large) return false;
+
+  const input = await fetchHttpImage(data.image.large);
+  return await resize(input, max, max);
 }

--- a/src/resolvers/ens.ts
+++ b/src/resolvers/ens.ts
@@ -1,8 +1,12 @@
 import { isAddress } from '@ethersproject/address';
 import { max } from '../constants.json';
 import { getProvider, resize } from '../utils';
-import { fetchHttpImage } from './utils';
+import { fetchHttpImage, HTTP_404_ERROR } from './utils';
 import { lookupAddresses } from '../addressResolvers';
+
+// A name with no avatar record falls through to the ENS metadata service, which
+// answers 404. That is the normal no-avatar path, not a failure.
+export const MUTED_ERRORS = [HTTP_404_ERROR];
 
 async function castToEnsName(nameOrAddress: string): Promise<string | undefined> {
   if (isAddress(nameOrAddress)) {
@@ -13,25 +17,21 @@ async function castToEnsName(nameOrAddress: string): Promise<string | undefined>
 }
 
 export default async function resolve(nameOrAddress: string) {
-  try {
-    const provider = getProvider(1);
-    const ensName = await castToEnsName(nameOrAddress);
+  const provider = getProvider(1);
+  const ensName = await castToEnsName(nameOrAddress);
 
-    if (!ensName) return false;
+  if (!ensName) return false;
 
-    const ensResolver = await provider.getResolver(ensName);
+  const ensResolver = await provider.getResolver(ensName);
 
-    if (!ensResolver) {
-      return false;
-    }
-
-    let url = await ensResolver.getText('avatar');
-    url = url?.startsWith('http') ? url : `https://metadata.ens.domains/mainnet/avatar/${ensName}`;
-
-    const input = await fetchHttpImage(url);
-
-    return await resize(input, max, max);
-  } catch {
+  if (!ensResolver) {
     return false;
   }
+
+  let url = await ensResolver.getText('avatar');
+  url = url?.startsWith('http') ? url : `https://metadata.ens.domains/mainnet/avatar/${ensName}`;
+
+  const input = await fetchHttpImage(url);
+
+  return await resize(input, max, max);
 }

--- a/src/resolvers/farcaster.ts
+++ b/src/resolvers/farcaster.ts
@@ -26,21 +26,18 @@ function normalizeAddress(address: Address): Address | null {
 }
 
 async function fetchAddressImageUrl(normalizedAddress: string): Promise<string | null> {
-  try {
-    const response = await fetch(`${NEYNAR_API_URL}?addresses=${normalizedAddress}`, {
-      headers: { Accept: 'application/json', api_key: API_KEY }
-    });
+  const response = await fetch(`${NEYNAR_API_URL}?addresses=${normalizedAddress}`, {
+    headers: { Accept: 'application/json', api_key: API_KEY }
+  });
 
-    if (!response.ok) {
-      throw new Error(`Invalid network response (${response.url} ${response.status})`);
-    }
-
-    const data: Record<Address, UserDetails[]> = await response.json();
-
-    return data[normalizedAddress.toLowerCase()]?.[0].pfp_url;
-  } catch {
-    return null;
+  if (!response.ok) {
+    throw new Error(`Invalid network response (${response.url} ${response.status})`);
   }
+
+  const data: Record<Address, UserDetails[]> = await response.json();
+
+  // No account for this address: no data.
+  return data[normalizedAddress.toLowerCase()]?.[0]?.pfp_url ?? null;
 }
 
 export default async function resolve(address: string): Promise<Buffer | false> {
@@ -50,11 +47,7 @@ export default async function resolve(address: string): Promise<Buffer | false> 
   const url = await fetchAddressImageUrl(normalizedAddress);
   if (!url) return false;
 
-  try {
-    const imageUrl = withCache(url);
-    const input = await fetchHttpImage(imageUrl);
-    return await resize(input, max, max);
-  } catch {
-    return false;
-  }
+  const imageUrl = withCache(url);
+  const input = await fetchHttpImage(imageUrl);
+  return await resize(input, max, max);
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,7 +1,8 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import basename from './basename';
 import blockie from './blockie';
 import coingecko from './coingecko';
-import ens from './ens';
+import ens, { MUTED_ERRORS as ENS_MUTED_ERRORS } from './ens';
 import farcaster from './farcaster';
 import jazzicon from './jazzicon';
 import lens from './lens';
@@ -15,26 +16,57 @@ import {
 } from './snapshot';
 import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from './space-sx';
 import starknet from './starknet';
-import trustwallet from './trustwallet';
+import trustwallet, { MUTED_ERRORS as TRUSTWALLET_MUTED_ERRORS } from './trustwallet';
 import zapper from './zapper';
+import { isSilencedError } from '../addressResolvers/utils';
 
-export default {
-  blockie,
-  jazzicon,
-  ens,
-  basename,
-  trustwallet,
-  coingecko,
-  snapshot: sResolveUserAvatar,
-  'user-cover': sResolveUserCover,
-  space: sResolveSpaceAvatar,
-  'space-cover': sResolveSpaceCover,
-  'space-logo': sResolveSpaceLogo,
-  'space-sx': sxResolveAvatar,
-  'space-cover-sx': sxResolveCover,
-  selfid,
-  lens,
-  zapper,
-  starknet,
-  farcaster
+type ResolverFn = (...args: any[]) => Promise<Buffer | false>;
+
+// A resolver returns false when it has no image for the input, and throws when
+// it failed to find out. mutedErrors lists the extra error messages this
+// resolver never wants reported (e.g. an asset CDN's 404 for a token it does
+// not have); the always-silenced ones live in isSilencedError.
+type Resolver = {
+  name: string;
+  fn: ResolverFn;
+  mutedErrors?: string[];
 };
+
+const RESOLVERS: Resolver[] = [
+  { name: 'blockie', fn: blockie },
+  { name: 'jazzicon', fn: jazzicon },
+  { name: 'ens', fn: ens, mutedErrors: ENS_MUTED_ERRORS },
+  { name: 'basename', fn: basename },
+  { name: 'trustwallet', fn: trustwallet, mutedErrors: TRUSTWALLET_MUTED_ERRORS },
+  { name: 'coingecko', fn: coingecko },
+  { name: 'snapshot', fn: sResolveUserAvatar },
+  { name: 'user-cover', fn: sResolveUserCover },
+  { name: 'space', fn: sResolveSpaceAvatar },
+  { name: 'space-cover', fn: sResolveSpaceCover },
+  { name: 'space-logo', fn: sResolveSpaceLogo },
+  { name: 'space-sx', fn: sxResolveAvatar },
+  { name: 'space-cover-sx', fn: sxResolveCover },
+  { name: 'selfid', fn: selfid },
+  { name: 'lens', fn: lens },
+  { name: 'zapper', fn: zapper },
+  { name: 'starknet', fn: starknet },
+  { name: 'farcaster', fn: farcaster }
+];
+
+function withCapture({ name, fn, mutedErrors }: Resolver): ResolverFn {
+  return async (...args) => {
+    try {
+      return await fn(...args);
+    } catch (err) {
+      if (!isSilencedError(err, mutedErrors)) {
+        capture(err, { input: { resolver: name, args } });
+      }
+
+      return false;
+    }
+  };
+}
+
+export default Object.fromEntries(
+  RESOLVERS.map(resolver => [resolver.name, withCapture(resolver)])
+) as Record<string, ResolverFn>;

--- a/src/resolvers/lens.ts
+++ b/src/resolvers/lens.ts
@@ -32,29 +32,25 @@ export default async function resolve(domainOrAddress: string) {
     return false;
   }
 
-  try {
-    const {
-      data: {
-        data: { account }
-      }
-    } = await graphQlCall(
-      `${API_URL}/graphql`,
-      `query Account($request: AccountRequest!) {
-        account(request: $request) {
-          metadata {
-            picture
-          }
+  const {
+    data: {
+      data: { account }
+    }
+  } = await graphQlCall(
+    `${API_URL}/graphql`,
+    `query Account($request: AccountRequest!) {
+      account(request: $request) {
+        metadata {
+          picture
         }
-      }`,
-      { request }
-    );
+      }
+    }`,
+    { request }
+  );
 
-    const img_url = normalizeImageUrl(account?.metadata?.picture);
-    if (!img_url) return false;
+  const img_url = normalizeImageUrl(account?.metadata?.picture);
+  if (!img_url) return false;
 
-    const input = await fetchHttpImage(img_url);
-    return await resize(input, max, max);
-  } catch {
-    return false;
-  }
+  const input = await fetchHttpImage(img_url);
+  return await resize(input, max, max);
 }

--- a/src/resolvers/selfid.ts
+++ b/src/resolvers/selfid.ts
@@ -1,23 +1,21 @@
-import { getAddress } from '@ethersproject/address';
 import { Core } from '@self.id/core';
 import { max } from '../constants.json';
 import { getUrl, resize } from '../utils';
-import { fetchHttpImage } from './utils';
+import { fetchHttpImage, toChecksumAddress } from './utils';
 
 const core = new Core({ ceramic: 'https://gateway.ceramic.network' });
 
 export default async function resolve(address: string) {
-  try {
-    const did = await core.getAccountDID(`${getAddress(address)}@eip155:1`);
-    const result = await core.get('basicProfile', did);
+  const checksum = toChecksumAddress(address);
+  if (!checksum) return false;
 
-    const { src } = result?.image?.original || {};
-    if (!src) return false;
+  const did = await core.getAccountDID(`${checksum}@eip155:1`);
+  const result = await core.get('basicProfile', did);
 
-    const url = getUrl(src);
-    const input = await fetchHttpImage(url);
-    return await resize(input, max, max);
-  } catch {
-    return false;
-  }
+  const { src } = result?.image?.original || {};
+  if (!src) return false;
+
+  const url = getUrl(src);
+  const input = await fetchHttpImage(url);
+  return await resize(input, max, max);
 }

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -1,8 +1,7 @@
 import { getAddress } from '@ethersproject/address';
 import { defaultOffchainNetwork, max, offchainNetworks } from '../constants.json';
 import { getUrl, graphQlCall, resize } from '../utils';
-import { fetchHttpImage } from './utils';
-import { isStarknetAddress } from '../addressResolvers/utils';
+import { fetchHttpImage, spaceIds } from './utils';
 
 const UNIFIED_API_URL = 'https://api.snapshot.box';
 const UNIFIED_API_TESTNET_URL = 'https://testnet-api.snapshot.box';
@@ -76,10 +75,13 @@ async function getOnchainProperty(
   entity: Entity,
   property: Property
 ) {
-  const ids = [id];
-  if (!isStarknetAddress(id)) {
-    ids.push(getAddress(id));
-  }
+  // The logo lives in the offchain skin settings; SpaceMetadataItem has no logo
+  // field, so asking the onchain API for one is a GraphQL validation error
+  // rather than a missing logo. There is nothing to query.
+  if (property === 'logo') return null;
+
+  const ids = spaceIds(id);
+  if (!ids) return null;
 
   const {
     data: {
@@ -97,7 +99,7 @@ async function getOnchainProperty(
     { ids }
   );
 
-  return spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0];
+  return spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0] ?? null;
 }
 
 function normalizeEvmAddress(value: string) {
@@ -115,29 +117,25 @@ function createPropertyResolver(entity: Entity, property: Property) {
 
     if (!Object.keys(API_URLS).includes(networkId)) return false;
 
-    try {
-      if (offchainNetworks.includes(networkId) || entity === 'user') {
-        value = await getOffchainProperty(
-          offchainNetworks.includes(networkId) ? networkId : defaultOffchainNetwork,
-          normalizeEvmAddress(address),
-          entity,
-          property
-        );
-      } else {
-        value = await getOnchainProperty(networkId, address, entity, property);
-      }
-
-      if (!value) return false;
-
-      const url = getUrl(value);
-      const input = await fetchHttpImage(url);
-
-      if (['cover', 'logo'].includes(property)) return input;
-
-      return await resize(input, max, max);
-    } catch {
-      return false;
+    if (offchainNetworks.includes(networkId) || entity === 'user') {
+      value = await getOffchainProperty(
+        offchainNetworks.includes(networkId) ? networkId : defaultOffchainNetwork,
+        normalizeEvmAddress(address),
+        entity,
+        property
+      );
+    } else {
+      value = await getOnchainProperty(networkId, address, entity, property);
     }
+
+    if (!value) return false;
+
+    const url = getUrl(value);
+    const input = await fetchHttpImage(url);
+
+    if (['cover', 'logo'].includes(property)) return input;
+
+    return await resize(input, max, max);
   };
 }
 

--- a/src/resolvers/space-sx.ts
+++ b/src/resolvers/space-sx.ts
@@ -1,16 +1,16 @@
-import { getAddress } from '@ethersproject/address';
 import { max } from '../constants.json';
 import { getUrl, graphQlCall, resize } from '../utils';
-import { fetchHttpImage } from './utils';
-import { isStarknetAddress } from '../addressResolvers/utils';
+import { fetchHttpImage, spaceIds } from './utils';
 
 const SUBGRAPH_URLS = ['https://api.snapshot.box', 'https://testnet-api.snapshot.box'];
 
-async function getSpaceProperty(key: string, url: string, property: 'avatar' | 'cover') {
-  const ids = [key];
-  if (!isStarknetAddress(key)) {
-    ids.push(getAddress(key));
-  }
+async function getSpaceProperty(
+  key: string,
+  url: string,
+  property: 'avatar' | 'cover'
+): Promise<string | null> {
+  const ids = spaceIds(key);
+  if (!ids) return null;
 
   const {
     data: {
@@ -28,26 +28,37 @@ async function getSpaceProperty(key: string, url: string, property: 'avatar' | '
     { ids }
   );
 
-  const result = spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0];
-
-  return result || Promise.reject(false);
+  return spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0] ?? null;
 }
 
 function createPropertyResolver(property: 'avatar' | 'cover') {
   return async key => {
-    try {
-      const value = await Promise.any(
-        SUBGRAPH_URLS.map(url => getSpaceProperty(key, url, property))
+    // A space lives on one of the two APIs, so "not here" is the normal answer
+    // from the other one: a null, not a failure. A failure only costs us the
+    // value when no API answered with one, and only then is it rethrown for
+    // index.ts to report.
+    const results = await Promise.allSettled(
+      SUBGRAPH_URLS.map(url => getSpaceProperty(key, url, property))
+    );
+
+    const value = results
+      .map(result => (result.status === 'fulfilled' ? result.value : null))
+      .find(Boolean);
+
+    if (!value) {
+      const failure = results.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
       );
+      if (failure) throw failure.reason;
 
-      const url = getUrl(value);
-      const input = await fetchHttpImage(url);
-
-      if (property === 'cover') return input;
-      return await resize(input, max, max);
-    } catch {
       return false;
     }
+
+    const url = getUrl(value);
+    const input = await fetchHttpImage(url);
+
+    if (property === 'cover') return input;
+    return await resize(input, max, max);
   };
 }
 

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -11,10 +11,10 @@ function isStarknetDomain(domain: string): boolean {
   return domain.endsWith('.stark');
 }
 
-function normalizeAddress(address: string): string {
-  if (!address.match(/^(0x)?[0-9a-fA-F]{64}$/)) throw new Error('Invalid starknet address');
-
-  return address;
+// Not a felt252: not a Starknet address, so there is no profile to resolve.
+// That is no data (null), not an error.
+function normalizeAddress(address: string): string | null {
+  return address.match(/^(0x)?[0-9a-fA-F]{64}$/) ? address : null;
 }
 
 async function getStarknetAddress(domain: string): Promise<string | null> {
@@ -48,22 +48,18 @@ async function fetchImageOrMetadata(url: string): Promise<Buffer | { image?: str
 }
 
 export default async function resolve(domainOrAddress: string) {
-  try {
-    const img_url = await getImage(domainOrAddress);
+  const img_url = await getImage(domainOrAddress);
 
-    if (!img_url || img_url === DEFAULT_IMG_URL) return false;
+  if (!img_url || img_url === DEFAULT_IMG_URL) return false;
 
-    const fetched = await fetchImageOrMetadata(getUrl(img_url));
-    const buffer = Buffer.isBuffer(fetched)
-      ? fetched
-      : fetched.image
-        ? await fetchHttpImage(getUrl(fetched.image))
-        : null;
+  const fetched = await fetchImageOrMetadata(getUrl(img_url));
+  const buffer = Buffer.isBuffer(fetched)
+    ? fetched
+    : fetched.image
+      ? await fetchHttpImage(getUrl(fetched.image))
+      : null;
 
-    if (!buffer) return false;
+  if (!buffer) return false;
 
-    return await resize(buffer, max, max);
-  } catch {
-    return false;
-  }
+  return await resize(buffer, max, max);
 }

--- a/src/resolvers/trustwallet.ts
+++ b/src/resolvers/trustwallet.ts
@@ -1,24 +1,25 @@
-import { getAddress } from '@ethersproject/address';
 import { max } from '../constants.json';
 import { chainIdToName, getBaseAssetIconUrl, resize } from '../utils';
-import { fetchHttpImage } from './utils';
+import { fetchHttpImage, HTTP_404_ERROR, toChecksumAddress } from './utils';
 
 const ETH = [
   '0x0000000000000000000000000000000000000000',
   '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 ];
 
+// The assets repo answers 404 for every token it has no logo for, which is most
+// of them. That is the normal no-logo path, not a failure.
+export const MUTED_ERRORS = [HTTP_404_ERROR];
+
 export default async function resolve(address, chainId) {
-  try {
-    const networkName = chainIdToName(chainId) || 'ethereum';
-    const checksum = getAddress(address);
+  const networkName = chainIdToName(chainId) || 'ethereum';
+  const checksum = toChecksumAddress(address);
 
-    let url = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${networkName}/assets/${checksum}/logo.png`;
-    if (ETH.includes(checksum)) url = getBaseAssetIconUrl(chainId);
+  if (!checksum) return false;
 
-    const input = await fetchHttpImage(url);
-    return await resize(input, max, max);
-  } catch {
-    return false;
-  }
+  let url = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${networkName}/assets/${checksum}/logo.png`;
+  if (ETH.includes(checksum)) url = getBaseAssetIconUrl(chainId);
+
+  const input = await fetchHttpImage(url);
+  return await resize(input, max, max);
 }

--- a/src/resolvers/utils.ts
+++ b/src/resolvers/utils.ts
@@ -1,12 +1,18 @@
 import http from 'http';
 import https from 'https';
+import { getAddress } from '@ethersproject/address';
 import axios from 'axios';
+import { isStarknetAddress } from '../addressResolvers/utils';
 
 export const axiosDefaultParams = {
   httpAgent: new http.Agent({ keepAlive: true }),
   httpsAgent: new https.Agent({ keepAlive: true }),
   timeout: 5e3
 };
+
+// axios' message for an HTTP 404. Resolvers whose no-data answer IS a 404 pass
+// this to index.ts as a muted error.
+export const HTTP_404_ERROR = 'Request failed with status code 404';
 
 export async function fetchHttpImage(url: string): Promise<Buffer> {
   return (
@@ -18,4 +24,26 @@ export async function fetchHttpImage(url: string): Promise<Buffer> {
       }
     })
   ).data;
+}
+
+// An id that is not an EVM address is not an address the upstreams know about:
+// that is no data (null), not an error, so it must not reach index.ts as a
+// rejection.
+export function toChecksumAddress(address: string): string | null {
+  try {
+    return getAddress(address);
+  } catch {
+    return null;
+  }
+}
+
+// The ids to query an onchain space by. The id arrives lowercased from the
+// request while the API stores EVM ids checksummed, so both spellings are
+// queried.
+export function spaceIds(id: string): string[] | null {
+  if (isStarknetAddress(id)) return [id];
+
+  const checksum = toChecksumAddress(id);
+
+  return checksum ? [id, checksum] : null;
 }

--- a/src/resolvers/zapper.ts
+++ b/src/resolvers/zapper.ts
@@ -1,7 +1,6 @@
-import { getAddress } from '@ethersproject/address';
 import { max } from '../constants.json';
 import { chainIdToName, getBaseAssetIconUrl, resize } from '../utils';
-import { fetchHttpImage } from './utils';
+import { fetchHttpImage, toChecksumAddress } from './utils';
 
 const ETH = [
   '0x0000000000000000000000000000000000000000',
@@ -9,16 +8,14 @@ const ETH = [
 ];
 
 export default async function resolve(address, chainId) {
-  try {
-    const networkName = chainIdToName(chainId) || 'ethereum';
-    const checksum = getAddress(address);
+  const networkName = chainIdToName(chainId) || 'ethereum';
+  const checksum = toChecksumAddress(address);
 
-    let url = `https://storage.googleapis.com/zapper-fi-assets/tokens/${networkName}/${checksum.toLocaleLowerCase()}.png`;
-    if (ETH.includes(checksum)) url = getBaseAssetIconUrl(chainId);
+  if (!checksum) return false;
 
-    const input = await fetchHttpImage(url);
-    return await resize(input, max, max);
-  } catch {
-    return false;
-  }
+  let url = `https://storage.googleapis.com/zapper-fi-assets/tokens/${networkName}/${checksum.toLocaleLowerCase()}.png`;
+  if (ETH.includes(checksum)) url = getBaseAssetIconUrl(chainId);
+
+  const input = await fetchHttpImage(url);
+  return await resize(input, max, max);
 }

--- a/test/integration/resolvers/helper.ts
+++ b/test/integration/resolvers/helper.ts
@@ -1,6 +1,14 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import resolvers from '../../../src/resolvers';
 import { remoteSnapshotOptions } from '../../fixtures/image-snapshot-addresses';
 import { expectResolverImageSnapshot } from '../../helpers/imageSnapshot';
+
+// index.ts reports what a resolver throws, so the no-avatar cases below assert
+// that nothing was reported: "this address has no avatar" is an answer, not a
+// failure, and must not page anyone.
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
 
 type ResolverName = keyof typeof resolvers;
 
@@ -75,9 +83,10 @@ export default function testResolverImageSnapshots({
 
       withoutAvatar.forEach(input => {
         it(
-          'returns false when no avatar is set',
+          'returns false when no avatar is set, without reporting an error',
           async () => {
             expect(await call(resolver, input)).toBe(false);
+            expect(capture).not.toHaveBeenCalled();
           },
           TIMEOUT
         );

--- a/test/unit/resolvers.test.ts
+++ b/test/unit/resolvers.test.ts
@@ -1,0 +1,85 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import resolvers from '../../src/resolvers';
+import ens from '../../src/resolvers/ens';
+import trustwallet from '../../src/resolvers/trustwallet';
+import zapper from '../../src/resolvers/zapper';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+// Stub the resolver functions, keeping each module's real MUTED_ERRORS export:
+// what is under test is the wiring in index.ts, not the resolvers themselves.
+jest.mock('../../src/resolvers/ens', () => ({
+  ...jest.requireActual('../../src/resolvers/ens'),
+  __esModule: true,
+  default: jest.fn()
+}));
+jest.mock('../../src/resolvers/trustwallet', () => ({
+  ...jest.requireActual('../../src/resolvers/trustwallet'),
+  __esModule: true,
+  default: jest.fn()
+}));
+jest.mock('../../src/resolvers/zapper', () => ({
+  ...jest.requireActual('../../src/resolvers/zapper'),
+  __esModule: true,
+  default: jest.fn()
+}));
+
+const ensResolver = ens as jest.Mock;
+const trustwalletResolver = trustwallet as jest.Mock;
+const zapperResolver = zapper as jest.Mock;
+
+const ADDRESS = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+const IMAGE = Buffer.from('an image');
+
+describe('resolvers - resolver failures', () => {
+  it('returns what the resolver returned', async () => {
+    ensResolver.mockResolvedValue(IMAGE);
+
+    await expect(resolvers.ens(ADDRESS)).resolves.toBe(IMAGE);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not report a resolver that has no image', async () => {
+    ensResolver.mockResolvedValue(false);
+
+    await expect(resolvers.ens(ADDRESS)).resolves.toBe(false);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('captures a resolver error, with the resolver and its input as context', async () => {
+    const error = new Error('boom');
+    ensResolver.mockRejectedValue(error);
+
+    await expect(resolvers.ens(ADDRESS)).resolves.toBe(false);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith(error, {
+      input: { resolver: 'ens', args: [ADDRESS] }
+    });
+  });
+
+  it('does not capture a silenced error', async () => {
+    ensResolver.mockRejectedValue(new Error('Request failed with status=504, no body'));
+
+    await expect(resolvers.ens(ADDRESS)).resolves.toBe(false);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not capture an error listed in the resolver MUTED_ERRORS', async () => {
+    trustwalletResolver.mockRejectedValue(new Error('Request failed with status code 404'));
+
+    await expect(resolvers.trustwallet(ADDRESS, '1')).resolves.toBe(false);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('applies MUTED_ERRORS only to the resolver exporting it', async () => {
+    const error = new Error('Request failed with status code 404');
+    zapperResolver.mockRejectedValue(error);
+
+    await expect(resolvers.zapper(ADDRESS, '1')).resolves.toBe(false);
+    expect(capture).toHaveBeenCalledWith(error, {
+      input: { resolver: 'zapper', args: [ADDRESS, '1'] }
+    });
+  });
+});


### PR DESCRIPTION
Third leg of the resolver error-capture refactor tracked in #496. `addressResolvers` (#500) and `lookupDomains` (#501) are on master; #496 scoped itself to those two orchestrators and left the image resolvers in `src/resolvers/` out. This brings them under the same shape — without that history it reads as a duplicate of a change already merged.

### What was broken

Every image resolver ended in `catch { return false }`. A resolver dying and an address simply having no avatar were the same event: blockie fallback, nothing reported. A resolver could be dead upstream indefinitely and the only symptom would be that people get blockies.

### The fix

The resolvers throw, and the capture moves into `src/resolvers/index.ts`, which reports and then answers `false` on the resolver's behalf.

`src/resolvers/*` export bare default functions rather than modules with a `NAME`, so unlike `addressResolvers` there is nothing for index.ts to read a name off. It keeps a small `{ name, fn, mutedErrors }` registry instead and wraps each entry. The default export is still a name → callable map that answers `false` when a resolver cannot answer, so `api.ts` and its callers did not have to change, and a resolver still never throws into the unguarded image route (#495 is neither fixed nor made worse here).

The catches that answer "this input is not an address" stay where they are: that is no data, not a failure.

### "No data" that used to reach index.ts as a rejection

These had to be fixed first, or the wrapper would page someone on a perfectly normal request.

**space-sx** is the one to understand before judging the wrapper over-broad. `getSpaceProperty` rejected with a literal `false` to mean "not on this API", and the two APIs were aggregated with `Promise.any`, so under a plain wrapper every space without an avatar reports an `AggregateError` of `false` values. It returns `null` now, and the resolver takes the first non-null of an `allSettled` fan-out. A rejection is rethrown only when no API produced a value, so one API being down still cannot cost us an avatar the other one has: the resilience `Promise.any` gave us is kept.

The rest:

- **starknet** — `normalizeAddress` threw on anything that is not a felt252, i.e. on bad user input. Returns `null`.
- **coingecko** — fetching the image URL of a coin that has no image threw `Provided config url is not valid`, as if the request itself had failed. Guarded. A 404 is read as "no such coin" (the API's own `{"error":"coin not found"}`), while any other non-2xx is raised rather than read as an empty body — otherwise a rejected API key would be invisible.
- **onchain space ids** — `getAddress()` threw on any id that is not an address, so a junk id in the URL reported. A shared `spaceIds()` helper returns `null` instead.
- **space-logo on an onchain network** — `SpaceMetadataItem` has no `logo` field, so asking the onchain API for one is a GraphQL validation failure on every single request rather than a missing logo. There is nothing to ask for, so it no longer asks. Same `false` as before, minus the doomed round trip.

### Muting

Per resolver rather than global, through a `MUTED_ERRORS` the resolver exports and the registry reads:

- `trustwallet` — the assets repo 404s for every token it has no logo for, which is most of them.
- `ens` — a name with no avatar record falls through to `metadata.ens.domains`, which answers 404 as well.

Deliberately not muted: zapper's 403 and a rejected coingecko key. Those are a resolver being down, which is exactly what should be visible.

### Tests

A unit suite covers the wiring itself: pass-through, `false` not reported, an error captured with the resolver and its arguments as context, silenced and muted errors, and muting scoped to the resolver that exports it.

The shared integration helper's no-avatar cases now also assert that nothing was reported. That is the guarantee this PR exists for, and it is asserted against the live upstreams rather than a mock.

### CI is not green

`Test` is already red on master, on live-network suites this PR does not touch, and it is red here too. This branch does add a failure of its own, and I would rather not hide it: zapper's no-avatar case.

`storage.googleapis.com/zapper-fi-assets` answers `403 UserProjectAccountProblem` — the owning billing account is absent — for every token, so with zapper there is no longer any such thing as "no logo". Every request is a failure, and the stricter assertion now says so. The same 403 is why zapper's image-snapshot case is already red on master. If we want that suite green, the honest fix is to retire the resolver (or `skip` it the way selfid is), not to mute a 403.
