### PR TITLE
refactor(resolvers): resize in the resolver map instead of each resolver

### DIFF
--- a/src/resolvers/basename.ts
+++ b/src/resolvers/basename.ts
@@ -1,14 +1,12 @@
-import { getAvatar } from '../addressResolvers/basename';
-import { max } from '../constants.json';
-import { resize } from '../utils';
 import { fetchHttpImage } from './utils';
+import { getAvatar } from '../addressResolvers/basename';
 
 export default async function resolve(nameOrAddress: string) {
   try {
     const url = await getAvatar(nameOrAddress);
     if (!url) return false;
 
-    return await resize(await fetchHttpImage(url), max, max);
+    return await fetchHttpImage(url);
   } catch {
     return false;
   }

--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -1,6 +1,4 @@
 import { getAddress } from '@ethersproject/address';
-import { max } from '../constants.json';
-import { resize } from '../utils';
 import { fetchHttpImage } from './utils';
 
 const API_KEY = process.env.COINGECKO_API_KEY;
@@ -28,8 +26,7 @@ export default async function resolve(address: string, chainId: string) {
     const data = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } }).then(res =>
       res.json()
     );
-    const input = await fetchHttpImage(data?.image?.large);
-    return await resize(input, max, max);
+    return await fetchHttpImage(data?.image?.large);
   } catch {
     return false;
   }

--- a/src/resolvers/ens.ts
+++ b/src/resolvers/ens.ts
@@ -1,6 +1,5 @@
 import { isAddress } from '@ethersproject/address';
-import { max } from '../constants.json';
-import { getProvider, resize } from '../utils';
+import { getProvider } from '../utils';
 import { fetchHttpImage } from './utils';
 import { lookupAddresses } from '../addressResolvers';
 
@@ -28,9 +27,7 @@ export default async function resolve(nameOrAddress: string) {
     let url = await ensResolver.getText('avatar');
     url = url?.startsWith('http') ? url : `https://metadata.ens.domains/mainnet/avatar/${ensName}`;
 
-    const input = await fetchHttpImage(url);
-
-    return await resize(input, max, max);
+    return await fetchHttpImage(url);
   } catch {
     return false;
   }

--- a/src/resolvers/farcaster.ts
+++ b/src/resolvers/farcaster.ts
@@ -1,7 +1,7 @@
 import { getAddress } from '@ethersproject/address';
 import fetch from 'node-fetch';
 import { max } from '../constants.json';
-import { Address, resize } from '../utils';
+import { Address } from '../utils';
 import { fetchHttpImage } from './utils';
 
 const NEYNAR_API_URL = 'https://api.neynar.com/v2/farcaster/user/bulk-by-address';
@@ -52,8 +52,7 @@ export default async function resolve(address: string): Promise<Buffer | false> 
 
   try {
     const imageUrl = withCache(url);
-    const input = await fetchHttpImage(imageUrl);
-    return await resize(input, max, max);
+    return await fetchHttpImage(imageUrl);
   } catch {
     return false;
   }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -20,12 +20,10 @@ import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from
 import starknet from './starknet';
 import trustwallet from './trustwallet';
 
-// Normalizing to a max x max webp is pipeline work, not resolver work: a
-// resolver finds the bytes, the map normalizes them. The resize keeps the catch
-// it had inside each wrapped resolver, so hostile bytes from those entries
-// answer false rather than throwing into the unguarded image route in api.ts.
-// The cover/logo entries below skip this wrapper and remain exposed to that
-// same gap (pre-existing, tracked in #495).
+// The catch keeps what each resolver had around its own resize call: bytes
+// sharp refuses answer false rather than throwing into the image route, which
+// has no guard of its own (#495). The unwrapped entries below hand their bytes
+// to the bare resize() in api.ts and stay exposed to that gap.
 function withResize<T extends unknown[]>(
   resolve: (...args: T) => Promise<Buffer | false>
 ): (...args: T) => Promise<Buffer | false> {
@@ -42,19 +40,12 @@ function withResize<T extends unknown[]>(
   };
 }
 
-// Two groups of entries deliberately opt out of the resize:
-//   - covers and logos ('user-cover', 'space-cover', 'space-logo',
-//     'space-cover-sx') skip the shared resize so the base cache keeps its
-//     upstream aspect ratio; api.ts still resizes every response to the
-//     request's w x h (default 64x64) before serving it. resize() passes
-//     no options, so sharp falls back to fit: 'cover', which would center-crop a
-//     1500x500 banner into a 500x500 square; parseQuery gives the '-cover'
-//     types (user-cover, space-cover, space-cover-sx) their own, larger
-//     ceiling (constants.maxCover) for the same reason. space-logo keeps the
-//     default constants.max ceiling but is still excluded here so its aspect
-//     ratio isn't force-cropped to a square.
-//   - blockie and jazzicon are the fallbacks api.ts feeds straight into resize(),
-//     so they stay out of the false-on-failure contract and resize themselves.
+// Covers and logos opt out so the base cache keeps its upstream aspect ratio:
+// resize() passes no fit option, so sharp center-crops, and a banner cached as
+// a square can never be served wide again (api.ts resizes every response to the
+// requested w x h regardless).
+// blockie and jazzicon opt out because api.ts feeds their result straight into
+// resize(): they resize themselves and must never answer false.
 export default {
   blockie,
   jazzicon,

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,3 +1,4 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import { max } from '../constants.json';
 import { resize } from '../utils';
 import basename from './basename';
@@ -21,8 +22,10 @@ import trustwallet from './trustwallet';
 
 // Normalizing to a max x max webp is pipeline work, not resolver work: a
 // resolver finds the bytes, the map normalizes them. The resize keeps the catch
-// it had inside each resolver, so hostile bytes still answer false rather than
-// throwing into the unguarded image route in api.ts.
+// it had inside each wrapped resolver, so hostile bytes from those entries
+// answer false rather than throwing into the unguarded image route in api.ts.
+// The cover/logo entries below skip this wrapper and remain exposed to that
+// same gap (pre-existing, tracked in #495).
 function withResize<T extends unknown[]>(
   resolve: (...args: T) => Promise<Buffer | false>
 ): (...args: T) => Promise<Buffer | false> {
@@ -32,7 +35,8 @@ function withResize<T extends unknown[]>(
 
     try {
       return await resize(input, max, max);
-    } catch {
+    } catch (err) {
+      capture(err);
       return false;
     }
   };
@@ -40,10 +44,15 @@ function withResize<T extends unknown[]>(
 
 // Two groups of entries deliberately opt out of the resize:
 //   - covers and logos ('user-cover', 'space-cover', 'space-logo',
-//     'space-cover-sx') are served at their upstream dimensions. resize() passes
+//     'space-cover-sx') skip the shared resize so the base cache keeps its
+//     upstream aspect ratio; api.ts still resizes every response to the
+//     request's w x h (default 64x64) before serving it. resize() passes
 //     no options, so sharp falls back to fit: 'cover', which would center-crop a
-//     1500x500 banner into a 500x500 square; parseQuery gives those types their
-//     own, larger ceiling (constants.maxCover) for the same reason.
+//     1500x500 banner into a 500x500 square; parseQuery gives the '-cover'
+//     types (user-cover, space-cover, space-cover-sx) their own, larger
+//     ceiling (constants.maxCover) for the same reason. space-logo keeps the
+//     default constants.max ceiling but is still excluded here so its aspect
+//     ratio isn't force-cropped to a square.
 //   - blockie and jazzicon are the fallbacks api.ts feeds straight into resize(),
 //     so they stay out of the false-on-failure contract and resize themselves.
 export default {

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,3 +1,5 @@
+import { max } from '../constants.json';
+import { resize } from '../utils';
 import basename from './basename';
 import blockie from './blockie';
 import coingecko from './coingecko';
@@ -17,22 +19,49 @@ import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from
 import starknet from './starknet';
 import trustwallet from './trustwallet';
 
+// Normalizing to a max x max webp is pipeline work, not resolver work: a
+// resolver finds the bytes, the map normalizes them. The resize keeps the catch
+// it had inside each resolver, so hostile bytes still answer false rather than
+// throwing into the unguarded image route in api.ts.
+function withResize<T extends unknown[]>(
+  resolve: (...args: T) => Promise<Buffer | false>
+): (...args: T) => Promise<Buffer | false> {
+  return async (...args: T) => {
+    const input = await resolve(...args);
+    if (!input) return false;
+
+    try {
+      return await resize(input, max, max);
+    } catch {
+      return false;
+    }
+  };
+}
+
+// Two groups of entries deliberately opt out of the resize:
+//   - covers and logos ('user-cover', 'space-cover', 'space-logo',
+//     'space-cover-sx') are served at their upstream dimensions. resize() passes
+//     no options, so sharp falls back to fit: 'cover', which would center-crop a
+//     1500x500 banner into a 500x500 square; parseQuery gives those types their
+//     own, larger ceiling (constants.maxCover) for the same reason.
+//   - blockie and jazzicon are the fallbacks api.ts feeds straight into resize(),
+//     so they stay out of the false-on-failure contract and resize themselves.
 export default {
   blockie,
   jazzicon,
-  ens,
-  basename,
-  trustwallet,
-  coingecko,
-  snapshot: sResolveUserAvatar,
+  ens: withResize(ens),
+  basename: withResize(basename),
+  trustwallet: withResize(trustwallet),
+  coingecko: withResize(coingecko),
+  snapshot: withResize(sResolveUserAvatar),
   'user-cover': sResolveUserCover,
-  space: sResolveSpaceAvatar,
+  space: withResize(sResolveSpaceAvatar),
   'space-cover': sResolveSpaceCover,
   'space-logo': sResolveSpaceLogo,
-  'space-sx': sxResolveAvatar,
+  'space-sx': withResize(sxResolveAvatar),
   'space-cover-sx': sxResolveCover,
-  selfid,
-  lens,
-  starknet,
-  farcaster
+  selfid: withResize(selfid),
+  lens: withResize(lens),
+  starknet: withResize(starknet),
+  farcaster: withResize(farcaster)
 };

--- a/src/resolvers/lens.ts
+++ b/src/resolvers/lens.ts
@@ -1,6 +1,5 @@
 import { getAddress, isAddress } from '@ethersproject/address';
-import { max } from '../constants.json';
-import { graphQlCall, resize } from '../utils';
+import { graphQlCall } from '../utils';
 import { fetchHttpImage } from './utils';
 
 const API_URL = 'https://api.lens.xyz';
@@ -52,8 +51,7 @@ export default async function resolve(domainOrAddress: string) {
     const img_url = normalizeImageUrl(account?.metadata?.picture);
     if (!img_url) return false;
 
-    const input = await fetchHttpImage(img_url);
-    return await resize(input, max, max);
+    return await fetchHttpImage(img_url);
   } catch {
     return false;
   }

--- a/src/resolvers/selfid.ts
+++ b/src/resolvers/selfid.ts
@@ -1,7 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import { Core } from '@self.id/core';
-import { max } from '../constants.json';
-import { getUrl, resize } from '../utils';
+import { getUrl } from '../utils';
 import { fetchHttpImage } from './utils';
 
 const core = new Core({ ceramic: 'https://gateway.ceramic.network' });
@@ -15,8 +14,7 @@ export default async function resolve(address: string) {
     if (!src) return false;
 
     const url = getUrl(src);
-    const input = await fetchHttpImage(url);
-    return await resize(input, max, max);
+    return await fetchHttpImage(url);
   } catch {
     return false;
   }

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -1,6 +1,6 @@
 import { getAddress } from '@ethersproject/address';
-import { defaultOffchainNetwork, max, offchainNetworks } from '../constants.json';
-import { getUrl, graphQlCall, resize } from '../utils';
+import { defaultOffchainNetwork, offchainNetworks } from '../constants.json';
+import { getUrl, graphQlCall } from '../utils';
 import { fetchHttpImage } from './utils';
 import { isStarknetAddress } from '../addressResolvers/utils';
 
@@ -130,11 +130,8 @@ function createPropertyResolver(entity: Entity, property: Property) {
       if (!value) return false;
 
       const url = getUrl(value);
-      const input = await fetchHttpImage(url);
 
-      if (['cover', 'logo'].includes(property)) return input;
-
-      return await resize(input, max, max);
+      return await fetchHttpImage(url);
     } catch {
       return false;
     }

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -130,7 +130,6 @@ function createPropertyResolver(entity: Entity, property: Property) {
       if (!value) return false;
 
       const url = getUrl(value);
-
       return await fetchHttpImage(url);
     } catch {
       return false;

--- a/src/resolvers/space-sx.ts
+++ b/src/resolvers/space-sx.ts
@@ -40,7 +40,6 @@ function createPropertyResolver(property: 'avatar' | 'cover') {
       );
 
       const url = getUrl(value);
-
       return await fetchHttpImage(url);
     } catch {
       return false;

--- a/src/resolvers/space-sx.ts
+++ b/src/resolvers/space-sx.ts
@@ -1,6 +1,5 @@
 import { getAddress } from '@ethersproject/address';
-import { max } from '../constants.json';
-import { getUrl, graphQlCall, resize } from '../utils';
+import { getUrl, graphQlCall } from '../utils';
 import { fetchHttpImage } from './utils';
 import { isStarknetAddress } from '../addressResolvers/utils';
 
@@ -41,10 +40,8 @@ function createPropertyResolver(property: 'avatar' | 'cover') {
       );
 
       const url = getUrl(value);
-      const input = await fetchHttpImage(url);
 
-      if (property === 'cover') return input;
-      return await resize(input, max, max);
+      return await fetchHttpImage(url);
     } catch {
       return false;
     }

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { provider as getProvider, isStarkDomain } from '../addressResolvers/utils';
-import { max } from '../constants.json';
-import { getUrl, resize } from '../utils';
+import { getUrl } from '../utils';
 import { axiosDefaultParams, fetchHttpImage } from './utils';
 
 const DEFAULT_IMG_URL = 'https://starknet.id/api/identicons/0';
@@ -56,9 +55,7 @@ export default async function resolve(domainOrAddress: string) {
         ? await fetchHttpImage(getUrl(fetched.image))
         : null;
 
-    if (!buffer) return false;
-
-    return await resize(buffer, max, max);
+    return buffer ?? false;
   } catch {
     return false;
   }

--- a/src/resolvers/trustwallet.ts
+++ b/src/resolvers/trustwallet.ts
@@ -1,6 +1,5 @@
 import { getAddress } from '@ethersproject/address';
-import { max } from '../constants.json';
-import { chainIdToName, getBaseAssetIconUrl, resize } from '../utils';
+import { chainIdToName, getBaseAssetIconUrl } from '../utils';
 import { fetchHttpImage } from './utils';
 
 const ETH = [
@@ -16,8 +15,7 @@ export default async function resolve(address, chainId) {
     let url = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${networkName}/assets/${checksum}/logo.png`;
     if (ETH.includes(checksum)) url = getBaseAssetIconUrl(chainId);
 
-    const input = await fetchHttpImage(url);
-    return await resize(input, max, max);
+    return await fetchHttpImage(url);
   } catch {
     return false;
   }


### PR DESCRIPTION
Every image resolver ends with the same `return await resize(input, max, max)`, so the max by max webp normalization is copied across the resolver files along with its `resize` and `max` imports. That is pipeline work rather than resolver work: a resolver's job is to find the bytes, and normalizing them belongs to the layer that assembles the map.

This adds a `withResize()` wrapper in `src/resolvers/index.ts` and applies it to the avatar entries, dropping the resize call and its imports from those resolvers. Their contract is unchanged: a Buffer or `false`, never a throw.

The cover and logo entries (`user-cover`, `space-cover`, `space-logo`, `space-cover-sx`) are deliberately left unwrapped, and that is the part worth a second look. The shared `resize(input, max, max)` passes no fit option, so sharp falls back to `fit: 'cover'` and center-crops to a square instead of fitting inside one. Banners are wide, so wrapping those entries would bake a square crop into the base cache, and a base cached as a square can never serve a wide banner again. `api.ts` resizes every response to the requested `w`x`h` regardless, so this is about what the cache holds rather than the dimensions we serve. `blockie` and `jazzicon` stay unwrapped too, since `api.ts` feeds their result into `resize()` itself and they sit outside the false-on-failure contract.

A design note on the `catch` in the wrapper: today `resize` runs inside each resolver's own catch, so bytes sharp refuses (an ENS avatar record can point at anything) answer `false`. Keeping a catch preserves that. Without it those failures would throw into the unguarded `Promise.all` in `api.ts` and turn a per-resolver no-data answer into a failed request. It now captures as well, since one wrapper swallowing every resolver's sharp failures hides more than each resolver swallowing its own.

Part of #511, the resize extraction step of that plan.
