### PR TITLE
test(ens): point the CCIP-Read case at a live off-chain gateway

### DIFF
--- a/test/integration/addressResolvers/ens.test.ts
+++ b/test/integration/addressResolvers/ens.test.ts
@@ -18,13 +18,13 @@ testAddressResolver({
 });
 
 describe('ENS address resolver: CCIP-Read fallback', () => {
-  // avsa.eth's primary name is set via an off-chain resolver that the batch
+  // jesse.base.eth's primary name is set via an off-chain resolver that the batch
   // getNames contract doesn't follow, so the fallback to provider.lookupAddress
   // is required.
   it('resolves names that the batch contract misses', async () => {
-    const address = '0x809FA673fe2ab515FaA168259cB14E2BeDeBF68e';
+    const address = '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9';
     await expect(lookupAddresses([address])).resolves.toEqual({
-      [address]: 'avsa.eth'
+      [address]: 'jesse.base.eth'
     });
   }, 15e3);
 


### PR DESCRIPTION
The CCIP-Read fallback case in `test/integration/addressResolvers/ens.test.ts` asserts that `avsa.eth` resolves, and it cannot pass any more. That name's forward resolver returns an empty address on chain and serves the real record off chain, and the gateway it points ethers at, `gateway.namestone.xyz`, answers `503 Service Suspended`. The resolver contract is alive, the gateway behind it is gone, and while it stays gone the name is unresolvable by any route. It is the name owner's to fix, not ours.

This keeps the case and swaps the fixture to `jesse.base.eth`. Same shape as the one it replaces: ReverseRecords returns an empty string for that address, so the batch still misses and the per-address `provider.lookupAddress` fallback still has to complete a real CCIP-Read round trip before the case can pass. Nothing else in the case changes.

The argument for this gateway is what sits behind it. `api.coinbase.com` serves L1 resolution for every name under `base.eth` rather than for one name, so it cannot be switched off without taking the whole namespace with it. That is exactly what one owner was able to do to `gateway.namestone.xyz`.

This does not remove the dependency, it moves it somewhere heavier. The case still asserts against someone else's live service, so the risk in #519 stands: it can go red because the name owner re-points their primary name, or because Coinbase changes the gateway.

Ref #518
