### PR TITLE
refactor(lookupDomains): register each provider in one place

### DIFF
--- a/src/lookupDomains/ens.ts
+++ b/src/lookupDomains/ens.ts
@@ -2,6 +2,7 @@ import constants from '../constants.json';
 import { Address, graphQlCall, Handle } from '../utils';
 
 export const DEFAULT_CHAIN_ID = '1';
+export const CHAIN_IDS = Object.keys(constants.ensSubgraph);
 
 type Domain = {
   name: string;

--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -2,16 +2,24 @@ import { isAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { isSilencedError } from '../addressResolvers/utils';
 import { Address, Handle } from '../utils';
-import ens, { DEFAULT_CHAIN_ID as ENS_DEFAULT_CHAIN_ID } from './ens';
-import shibarium, { DEFAULT_CHAIN_ID as SHIBARIUM_DEFAULT_CHAIN_ID } from './shibarium';
+import ens, { CHAIN_IDS as ENS_CHAIN_IDS, DEFAULT_CHAIN_ID as ENS_DEFAULT_CHAIN_ID } from './ens';
+import shibarium, {
+  CHAIN_IDS as SHIBARIUM_CHAIN_IDS,
+  DEFAULT_CHAIN_ID as SHIBARIUM_DEFAULT_CHAIN_ID
+} from './shibarium';
 import unstoppableDomains, {
+  CHAIN_IDS as UNSTOPPABLE_DOMAINS_CHAIN_IDS,
   DEFAULT_CHAIN_ID as UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID
 } from './unstoppableDomains';
 
 const PROVIDERS = [
-  { lookup: ens, defaultChainId: ENS_DEFAULT_CHAIN_ID },
-  { lookup: shibarium, defaultChainId: SHIBARIUM_DEFAULT_CHAIN_ID },
-  { lookup: unstoppableDomains, defaultChainId: UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID }
+  { lookup: ens, defaultChainId: ENS_DEFAULT_CHAIN_ID, chainIds: ENS_CHAIN_IDS },
+  { lookup: shibarium, defaultChainId: SHIBARIUM_DEFAULT_CHAIN_ID, chainIds: SHIBARIUM_CHAIN_IDS },
+  {
+    lookup: unstoppableDomains,
+    defaultChainId: UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID,
+    chainIds: UNSTOPPABLE_DOMAINS_CHAIN_IDS
+  }
 ];
 
 const DEFAULT_CHAIN_IDS = PROVIDERS.map(provider => provider.defaultChainId);
@@ -26,15 +34,17 @@ export default async function lookupDomains(
 
   if (!isAddress(address)) return [];
 
-  PROVIDERS.forEach(({ lookup }) => {
-    chainIds.forEach(chainId => {
-      promises.push(
-        lookup(address, chainId).catch(err => {
-          if (!isSilencedError(err)) capture(err, { input: { address, chainId } });
-          return [];
-        })
-      );
-    });
+  PROVIDERS.forEach(({ lookup, chainIds: supportedChainIds }) => {
+    chainIds
+      .filter(chainId => supportedChainIds.includes(chainId))
+      .forEach(chainId => {
+        promises.push(
+          lookup(address, chainId).catch(err => {
+            if (!isSilencedError(err)) capture(err, { input: { address, chainId } });
+            return [];
+          })
+        );
+      });
   });
 
   const domains = await Promise.all(promises);

--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -8,13 +8,13 @@ import unstoppableDomains, {
   DEFAULT_CHAIN_ID as UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID
 } from './unstoppableDomains';
 
-const RESOLVERS = [ens, shibarium, unstoppableDomains];
-
-const DEFAULT_CHAIN_IDS = [
-  ENS_DEFAULT_CHAIN_ID,
-  SHIBARIUM_DEFAULT_CHAIN_ID,
-  UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID
+const PROVIDERS = [
+  { lookup: ens, defaultChainId: ENS_DEFAULT_CHAIN_ID },
+  { lookup: shibarium, defaultChainId: SHIBARIUM_DEFAULT_CHAIN_ID },
+  { lookup: unstoppableDomains, defaultChainId: UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID }
 ];
+
+const DEFAULT_CHAIN_IDS = PROVIDERS.map(provider => provider.defaultChainId);
 
 export default async function lookupDomains(
   address: Address,
@@ -26,10 +26,10 @@ export default async function lookupDomains(
 
   if (!isAddress(address)) return [];
 
-  RESOLVERS.forEach(resolver => {
+  PROVIDERS.forEach(({ lookup }) => {
     chainIds.forEach(chainId => {
       promises.push(
-        resolver(address, chainId).catch(err => {
+        lookup(address, chainId).catch(err => {
           if (!isSilencedError(err)) capture(err, { input: { address, chainId } });
           return [];
         })

--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -15,6 +15,7 @@ const API_KEYS = {
 };
 
 export const DEFAULT_CHAIN_ID = MAINNET;
+export const CHAIN_IDS = Object.keys(constants.d3);
 
 export default async function lookupDomains(
   address: Address,

--- a/src/lookupDomains/unstoppableDomains.ts
+++ b/src/lookupDomains/unstoppableDomains.ts
@@ -1,6 +1,7 @@
 import { Address, Handle } from '../utils';
 
 export const DEFAULT_CHAIN_ID = '146';
+export const CHAIN_IDS = [DEFAULT_CHAIN_ID];
 
 const SUPPORTED_TLDS = ['sonic'];
 

--- a/test/unit/lookupDomains.test.ts
+++ b/test/unit/lookupDomains.test.ts
@@ -11,21 +11,25 @@ jest.mock('@snapshot-labs/snapshot-sentry', () => ({
 jest.mock('../../src/lookupDomains/ens', () => ({
   __esModule: true,
   DEFAULT_CHAIN_ID: '1',
+  CHAIN_IDS: ['1', '11155111'],
   default: jest.fn()
 }));
 jest.mock('../../src/lookupDomains/shibarium', () => ({
   __esModule: true,
   DEFAULT_CHAIN_ID: '109',
+  CHAIN_IDS: ['109', '157'],
   default: jest.fn()
 }));
 jest.mock('../../src/lookupDomains/unstoppableDomains', () => ({
   __esModule: true,
   DEFAULT_CHAIN_ID: '146',
+  CHAIN_IDS: ['146'],
   default: jest.fn()
 }));
 
 const VALID_ADDRESS = '0x24F15402C6Bb870554489b2fd2049A85d75B982f';
 const CHAINS = ['1', '109', '146'];
+const ENS_CHAINS = ['1', '11155111'];
 
 describe('lookupDomains - default chains', () => {
   it('calls every provider on its own default chain when no chain is given', async () => {
@@ -38,6 +42,33 @@ describe('lookupDomains - default chains', () => {
     expect(ens).toHaveBeenCalledWith(VALID_ADDRESS, '1');
     expect(shibarium).toHaveBeenCalledWith(VALID_ADDRESS, '109');
     expect(unstoppableDomains).toHaveBeenCalledWith(VALID_ADDRESS, '146');
+  });
+});
+
+describe('lookupDomains - chain routing', () => {
+  beforeEach(() => {
+    (ens as jest.Mock).mockResolvedValue([]);
+    (shibarium as jest.Mock).mockResolvedValue([]);
+    (unstoppableDomains as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('does not call a provider for a chain it does not declare', async () => {
+    await lookupDomains(VALID_ADDRESS, CHAINS);
+
+    expect(ens).toHaveBeenCalledTimes(1);
+    expect(ens).toHaveBeenCalledWith(VALID_ADDRESS, '1');
+    expect(shibarium).toHaveBeenCalledTimes(1);
+    expect(shibarium).toHaveBeenCalledWith(VALID_ADDRESS, '109');
+    expect(unstoppableDomains).toHaveBeenCalledTimes(1);
+    expect(unstoppableDomains).toHaveBeenCalledWith(VALID_ADDRESS, '146');
+  });
+
+  it('calls a provider for each declared chain, in the requested order', async () => {
+    await lookupDomains(VALID_ADDRESS, ['11155111', '1']);
+
+    expect((ens as jest.Mock).mock.calls.map(call => call[1])).toEqual(['11155111', '1']);
+    expect(shibarium).not.toHaveBeenCalled();
+    expect(unstoppableDomains).not.toHaveBeenCalled();
   });
 });
 
@@ -90,9 +121,9 @@ describe('lookupDomains - error reporting', () => {
   it('captures one event per failing chain', async () => {
     (ens as jest.Mock).mockRejectedValue(new Error('boom'));
 
-    await expect(lookupDomains(VALID_ADDRESS, CHAINS)).resolves.toEqual([]);
-    expect(capture).toHaveBeenCalledTimes(CHAINS.length);
-    CHAINS.forEach(chainId => {
+    await expect(lookupDomains(VALID_ADDRESS, ENS_CHAINS)).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledTimes(ENS_CHAINS.length);
+    ENS_CHAINS.forEach(chainId => {
       expect(capture).toHaveBeenCalledWith(expect.any(Error), {
         input: { address: VALID_ADDRESS, chainId }
       });

--- a/test/unit/lookupDomains.test.ts
+++ b/test/unit/lookupDomains.test.ts
@@ -27,6 +27,20 @@ jest.mock('../../src/lookupDomains/unstoppableDomains', () => ({
 const VALID_ADDRESS = '0x24F15402C6Bb870554489b2fd2049A85d75B982f';
 const CHAINS = ['1', '109', '146'];
 
+describe('lookupDomains - default chains', () => {
+  it('calls every provider on its own default chain when no chain is given', async () => {
+    (ens as jest.Mock).mockResolvedValue([]);
+    (shibarium as jest.Mock).mockResolvedValue([]);
+    (unstoppableDomains as jest.Mock).mockResolvedValue([]);
+
+    await lookupDomains(VALID_ADDRESS);
+
+    expect(ens).toHaveBeenCalledWith(VALID_ADDRESS, '1');
+    expect(shibarium).toHaveBeenCalledWith(VALID_ADDRESS, '109');
+    expect(unstoppableDomains).toHaveBeenCalledWith(VALID_ADDRESS, '146');
+  });
+});
+
 describe('lookupDomains - resolver failures', () => {
   it('does not propagate a resolver failure and returns the other resolvers results', async () => {
     (ens as jest.Mock).mockRejectedValue(new Error('boom'));


### PR DESCRIPTION
Two commits, and they are worth reading separately. The first is provably inert, the second is the behavioural one.

**1. `refactor(lookupDomains): register each provider in one place`**

`src/lookupDomains/index.ts` registered each provider twice: `RESOLVERS` for the lookup function and `DEFAULT_CHAIN_IDS` for the chain it serves by default. Add a provider to the first and miss the second and it compiles, passes review, and is then never called on the default path, because the default `chains` argument is built from the second list. Nothing fails, so nothing tells you.

That collapses into one `PROVIDERS` array with the chain ids derived from it by mapping in place, so a provider cannot be half registered. Order is preserved because the result is flattened and deduplicated provider by provider and chain by chain. The existing unit suite passes with no edits at that commit, which is what shows the behaviour is identical.

**2. `refactor(lookupDomains): declare each provider's chains in the registry`**

The fan-out asked every provider about every requested chain and let each one decide for itself. On the default path that was nine calls, six of which returned empty from a guard before making any request. The explicit path did the same: `lookupDomains(address, ['1'])` asked all three providers and two returned empty.

Each provider now exports the chain ids it serves, derived from the same constant its own guard already reads, so there is still one declaration per provider. The registry entry carries that list and `index.ts` calls a provider only for the requested chains it declares, in the requested order.

Two things worth pointing at:

**The guards stay in the providers.** They are not dead code: each provider is imported and called directly, and both `lookupDomains/shibarium` and `lookupDomains/unstoppableDomains` have a test asserting they do not call their API on an unsupported chain. The registry is the routing policy, the guard is the provider's own precondition, and both read the same declaration.

**The shibarium API key check stays inside the provider.** Its guard is not purely a chain list, it also requires `D3_API_KEY_*` to be present. A static list says which chains the provider can serve; whether the key is configured is a runtime question the registry cannot answer, and hoisting it would freeze the answer at import time.

Results are unchanged on both paths. Two tests were added for the routing, and one existing test, `captures one event per failing chain`, now asks ENS about the two chains ENS declares rather than about three chains only one of which it ever served. Its assertion is otherwise unchanged.

Closes #521, including the "declare each provider's chains in the registry" step from its follow-on list.
