### PR TITLE
refactor(resolvers): build the map from one registry array

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "sharp": "^0.34.5",
     "starknet": ">=6.21.0 <6.21.2",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.3",
+    "typescript": "^4.9.5",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -20,14 +20,20 @@ import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from
 import starknet from './starknet';
 import trustwallet from './trustwallet';
 
+type ResolverFn = (...args: any[]) => Promise<Buffer | false>;
+
+type Resolver = {
+  name: string;
+  fn: ResolverFn;
+  resize: boolean;
+};
+
 // The catch keeps what each resolver had around its own resize call: bytes
 // sharp refuses answer false rather than throwing into the image route, which
-// has no guard of its own (#495). The unwrapped entries below hand their bytes
+// has no guard of its own (#495). Entries with resize: false hand their bytes
 // to the bare resize() in api.ts and stay exposed to that gap.
-function withResize<T extends unknown[]>(
-  resolve: (...args: T) => Promise<Buffer | false>
-): (...args: T) => Promise<Buffer | false> {
-  return async (...args: T) => {
+function withResize(resolve: ResolverFn): ResolverFn {
+  return async (...args) => {
     const input = await resolve(...args);
     if (!input) return false;
 
@@ -40,28 +46,38 @@ function withResize<T extends unknown[]>(
   };
 }
 
-// Covers and logos opt out so the base cache keeps its upstream aspect ratio:
-// resize() passes no fit option, so sharp center-crops, and a banner cached as
-// a square can never be served wide again (api.ts resizes every response to the
-// requested w x h regardless).
-// blockie and jazzicon opt out because api.ts feeds their result straight into
-// resize(): they resize themselves and must never answer false.
-export default {
-  blockie,
-  jazzicon,
-  ens: withResize(ens),
-  basename: withResize(basename),
-  trustwallet: withResize(trustwallet),
-  coingecko: withResize(coingecko),
-  snapshot: withResize(sResolveUserAvatar),
-  'user-cover': sResolveUserCover,
-  space: withResize(sResolveSpaceAvatar),
-  'space-cover': sResolveSpaceCover,
-  'space-logo': sResolveSpaceLogo,
-  'space-sx': withResize(sxResolveAvatar),
-  'space-cover-sx': sxResolveCover,
-  selfid: withResize(selfid),
-  lens: withResize(lens),
-  starknet: withResize(starknet),
-  farcaster: withResize(farcaster)
-};
+// Covers and logos take resize: false so the base cache keeps its upstream
+// aspect ratio: resize() passes no fit option, so sharp center-crops, and a
+// banner cached as a square can never be served wide again (api.ts resizes
+// every response to the requested w x h regardless).
+// blockie and jazzicon take it for a different reason: api.ts feeds their
+// result straight into resize(), so they resize themselves and must never
+// answer false.
+const RESOLVERS = [
+  { name: 'blockie', fn: blockie, resize: false },
+  { name: 'jazzicon', fn: jazzicon, resize: false },
+  { name: 'ens', fn: ens, resize: true },
+  { name: 'basename', fn: basename, resize: true },
+  { name: 'trustwallet', fn: trustwallet, resize: true },
+  { name: 'coingecko', fn: coingecko, resize: true },
+  { name: 'snapshot', fn: sResolveUserAvatar, resize: true },
+  { name: 'user-cover', fn: sResolveUserCover, resize: false },
+  { name: 'space', fn: sResolveSpaceAvatar, resize: true },
+  { name: 'space-cover', fn: sResolveSpaceCover, resize: false },
+  { name: 'space-logo', fn: sResolveSpaceLogo, resize: false },
+  { name: 'space-sx', fn: sxResolveAvatar, resize: true },
+  { name: 'space-cover-sx', fn: sxResolveCover, resize: false },
+  { name: 'selfid', fn: selfid, resize: true },
+  { name: 'lens', fn: lens, resize: true },
+  { name: 'starknet', fn: starknet, resize: true },
+  { name: 'farcaster', fn: farcaster, resize: true }
+] as const satisfies readonly Resolver[];
+
+type ResolverName = (typeof RESOLVERS)[number]['name'];
+
+// Object.fromEntries types its result as Record<string, ...>, which compiles
+// everywhere and silently drops the name check that api.ts and the integration
+// helper rely on. The cast is what keeps the keys a literal union.
+export default Object.fromEntries(
+  RESOLVERS.map(entry => [entry.name, entry.resize ? withResize(entry.fn) : entry.fn])
+) as Record<ResolverName, ResolverFn>;

--- a/test/unit/resolvers.test.ts
+++ b/test/unit/resolvers.test.ts
@@ -1,0 +1,39 @@
+import resolvers from '../../src/resolvers';
+
+const NAMES = [
+  'blockie',
+  'jazzicon',
+  'ens',
+  'basename',
+  'trustwallet',
+  'coingecko',
+  'snapshot',
+  'user-cover',
+  'space',
+  'space-cover',
+  'space-logo',
+  'space-sx',
+  'space-cover-sx',
+  'selfid',
+  'lens',
+  'starknet',
+  'farcaster'
+] as const;
+
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+// The map is built from the registry with Object.fromEntries, which types its
+// keys as string on its own. api.ts and the integration helper both index it by
+// name, so the keys have to stay a literal union: this annotation stops
+// compiling if it widens, which is the failure that would otherwise be silent.
+const keysAreALiteralUnion: Exact<keyof typeof resolvers, (typeof NAMES)[number]> = true;
+
+describe('resolvers', () => {
+  it('keeps the resolver names a literal union', () => {
+    expect(keysAreALiteralUnion).toBe(true);
+  });
+
+  it('exposes every registered resolver, in order', () => {
+    expect(Object.keys(resolvers)).toEqual([...NAMES]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,7 +7578,7 @@ typescript-memoize@^1.0.0-alpha.4:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.1.1.tgz#02737495d5df6ebf72c07ba0d002e8f4cf5ccfa0"
   integrity sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==
 
-typescript@^4.7.3:
+typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
One commit, and it is inert. There is no behavioural half to separate out: the exported map ends up the same object it is today, so splitting it the way #523 was split would give a second commit with nothing in it.

`src/resolvers/index.ts` exported a hand-written literal where every entry carried a decision made at the call site, wrapped in `withResize()` or passed through bare. Which entries were bare, and why, lived in a comment above the literal rather than in the entry. The two reasons are not even the same reason: covers and logos opt out to keep their upstream aspect ratio, blockie and jazzicon opt out because `api.ts` hands their result straight to `resize()` and they must never answer `false`.

That collapses into one `RESOLVERS` array carrying the name, the function and whether the entry resizes, with the map derived from it. It follows the shape #523 settled on for `lookupDomains`: object literal entries with camelCase fields, module constants mapped in.

Two things worth pointing at:

**The literal key union is the whole risk.** `Object.fromEntries` types its result as `Record<string, ...>`, and `keyof` that is `string | number`, not the seventeen names. Nothing fails to compile at the point where it widens. `api.ts` indexes the map by name and `test/integration/resolvers/helper.ts` types its `resolver` field as `keyof typeof resolvers`, so the widening quietly stops checking every resolver name that `snapshot.test.ts` passes. The entries are therefore `as const` and the map is cast back to `Record<ResolverName, ResolverFn>`. `test/unit/resolvers.test.ts` carries an annotation that stops compiling if the union widens, which is the one failure that would otherwise be silent.

**The catches stay where they are.** Nothing outside `index.ts` is touched. Moving each resolver's `catch { return false }` into the wrapper is the next step, not this one, and it cannot be done in the same pass: `snapshot.ts` supplies five entries and `space-sx.ts` supplies two from shared factories, so removing the catch for the wrapped entries removes it for the bare ones in the same edit, and the bare ones would then throw into the image route, which has no guard of its own (#495).

`withResize` loses its generic and takes `ResolverFn` instead. Inferring a single type parameter across seventeen different resolver signatures does not work, and the map's values are all `ResolverFn` after the cast anyway, so nothing is lost.

Splitting the `resize` flag into the two properties it conflates is also left for later. One flag reproduces today exactly.

Closes #522.
