### PR TITLE
refactor(lookupDomains): name each provider and put the name in the error context

### DIFF
--- a/src/lookupDomains/ens.ts
+++ b/src/lookupDomains/ens.ts
@@ -1,6 +1,7 @@
 import constants from '../constants.json';
 import { Address, graphQlCall, Handle } from '../utils';
 
+export const NAME = 'Ens';
 export const DEFAULT_CHAIN_ID = '1';
 export const CHAIN_IDS = Object.keys(constants.ensSubgraph);
 

--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -2,21 +2,45 @@ import { isAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { isSilencedError } from '../addressResolvers/utils';
 import { Address, Handle } from '../utils';
-import ens, { CHAIN_IDS as ENS_CHAIN_IDS, DEFAULT_CHAIN_ID as ENS_DEFAULT_CHAIN_ID } from './ens';
+import ens, {
+  CHAIN_IDS as ENS_CHAIN_IDS,
+  DEFAULT_CHAIN_ID as ENS_DEFAULT_CHAIN_ID,
+  NAME as ENS_NAME
+} from './ens';
 import shibarium, {
   CHAIN_IDS as SHIBARIUM_CHAIN_IDS,
-  DEFAULT_CHAIN_ID as SHIBARIUM_DEFAULT_CHAIN_ID
+  DEFAULT_CHAIN_ID as SHIBARIUM_DEFAULT_CHAIN_ID,
+  NAME as SHIBARIUM_NAME
 } from './shibarium';
 import unstoppableDomains, {
   CHAIN_IDS as UNSTOPPABLE_DOMAINS_CHAIN_IDS,
-  DEFAULT_CHAIN_ID as UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID
+  DEFAULT_CHAIN_ID as UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID,
+  NAME as UNSTOPPABLE_DOMAINS_NAME
 } from './unstoppableDomains';
 
-const PROVIDERS = [
-  { lookup: ens, defaultChainId: ENS_DEFAULT_CHAIN_ID, chainIds: ENS_CHAIN_IDS },
-  { lookup: shibarium, defaultChainId: SHIBARIUM_DEFAULT_CHAIN_ID, chainIds: SHIBARIUM_CHAIN_IDS },
+type Provider = {
+  name: string;
+  fn: (address: Address, chainId: string) => Promise<Handle[]>;
+  defaultChainId: string;
+  chainIds: string[];
+};
+
+const PROVIDERS: Provider[] = [
   {
-    lookup: unstoppableDomains,
+    name: ENS_NAME,
+    fn: ens,
+    defaultChainId: ENS_DEFAULT_CHAIN_ID,
+    chainIds: ENS_CHAIN_IDS
+  },
+  {
+    name: SHIBARIUM_NAME,
+    fn: shibarium,
+    defaultChainId: SHIBARIUM_DEFAULT_CHAIN_ID,
+    chainIds: SHIBARIUM_CHAIN_IDS
+  },
+  {
+    name: UNSTOPPABLE_DOMAINS_NAME,
+    fn: unstoppableDomains,
     defaultChainId: UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID,
     chainIds: UNSTOPPABLE_DOMAINS_CHAIN_IDS
   }
@@ -34,13 +58,18 @@ export default async function lookupDomains(
 
   if (!isAddress(address)) return [];
 
-  PROVIDERS.forEach(({ lookup, chainIds: supportedChainIds }) => {
+  PROVIDERS.forEach(({ name, fn, chainIds: supportedChainIds }) => {
     chainIds
       .filter(chainId => supportedChainIds.includes(chainId))
       .forEach(chainId => {
         promises.push(
-          lookup(address, chainId).catch(err => {
-            if (!isSilencedError(err)) capture(err, { input: { address, chainId } });
+          fn(address, chainId).catch(err => {
+            if (!isSilencedError(err)) {
+              capture(err, {
+                tags: { provider: name },
+                contexts: { input: { address, chainId } }
+              });
+            }
             return [];
           })
         );

--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -14,6 +14,7 @@ const API_KEYS = {
   [TESTNET]: process.env.D3_API_KEY_TESTNET
 };
 
+export const NAME = 'Shibarium';
 export const DEFAULT_CHAIN_ID = MAINNET;
 export const CHAIN_IDS = Object.keys(constants.d3);
 

--- a/src/lookupDomains/unstoppableDomains.ts
+++ b/src/lookupDomains/unstoppableDomains.ts
@@ -1,5 +1,6 @@
 import { Address, Handle } from '../utils';
 
+export const NAME = 'Unstoppable Domains';
 export const DEFAULT_CHAIN_ID = '146';
 export const CHAIN_IDS = [DEFAULT_CHAIN_ID];
 

--- a/test/unit/lookupDomains.test.ts
+++ b/test/unit/lookupDomains.test.ts
@@ -10,18 +10,21 @@ jest.mock('@snapshot-labs/snapshot-sentry', () => ({
 
 jest.mock('../../src/lookupDomains/ens', () => ({
   __esModule: true,
+  NAME: 'Ens',
   DEFAULT_CHAIN_ID: '1',
   CHAIN_IDS: ['1', '11155111'],
   default: jest.fn()
 }));
 jest.mock('../../src/lookupDomains/shibarium', () => ({
   __esModule: true,
+  NAME: 'Shibarium',
   DEFAULT_CHAIN_ID: '109',
   CHAIN_IDS: ['109', '157'],
   default: jest.fn()
 }));
 jest.mock('../../src/lookupDomains/unstoppableDomains', () => ({
   __esModule: true,
+  NAME: 'Unstoppable Domains',
   DEFAULT_CHAIN_ID: '146',
   CHAIN_IDS: ['146'],
   default: jest.fn()
@@ -103,7 +106,8 @@ describe('lookupDomains - error reporting', () => {
     await expect(lookupDomains(VALID_ADDRESS, '1')).resolves.toEqual([]);
     expect(capture).toHaveBeenCalledTimes(1);
     expect(capture).toHaveBeenCalledWith(error, {
-      input: { address: VALID_ADDRESS, chainId: '1' }
+      tags: { provider: 'Ens' },
+      contexts: { input: { address: VALID_ADDRESS, chainId: '1' } }
     });
   });
 
@@ -118,6 +122,27 @@ describe('lookupDomains - error reporting', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it('names the failing provider, each with its own name', async () => {
+    (ens as jest.Mock).mockRejectedValue(new Error('boom'));
+    (shibarium as jest.Mock).mockRejectedValue(new Error('boom'));
+    (unstoppableDomains as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    await expect(lookupDomains(VALID_ADDRESS)).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledTimes(3);
+    expect(capture).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { provider: 'Ens' },
+      contexts: { input: { address: VALID_ADDRESS, chainId: '1' } }
+    });
+    expect(capture).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { provider: 'Shibarium' },
+      contexts: { input: { address: VALID_ADDRESS, chainId: '109' } }
+    });
+    expect(capture).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { provider: 'Unstoppable Domains' },
+      contexts: { input: { address: VALID_ADDRESS, chainId: '146' } }
+    });
+  });
+
   it('captures one event per failing chain', async () => {
     (ens as jest.Mock).mockRejectedValue(new Error('boom'));
 
@@ -125,7 +150,8 @@ describe('lookupDomains - error reporting', () => {
     expect(capture).toHaveBeenCalledTimes(ENS_CHAINS.length);
     ENS_CHAINS.forEach(chainId => {
       expect(capture).toHaveBeenCalledWith(expect.any(Error), {
-        input: { address: VALID_ADDRESS, chainId }
+        tags: { provider: 'Ens' },
+        contexts: { input: { address: VALID_ADDRESS, chainId } }
       });
     });
   });


### PR DESCRIPTION
The capture in the `lookupDomains` fan-out carried the address and the chain id but not which provider failed. A report could say a lookup broke on chain 1 without saying whether that was ENS or something else, and with three providers on the default path that is the first thing you want to know.

Each provider now exports a `NAME` and the registry entry carries it as `name`, which the fan-out puts into the captured context. The names come from the provider modules rather than from literals in `index.ts`, so they cannot drift from the module, and they reuse the spelling `src/addressResolvers` already uses for the same three upstreams.

The function field is `fn`, following the rule that an entry with one function calls it `fn` and an entry with several suffixes each one. That is why it is not `lookup`.

Two things worth pointing at.

**The name goes inside `input`, not in a tag.** `snapshot-sentry` only wraps the context object into `contexts` when none of its top level keys are Sentry's own (`tags`, `extra`, `contexts`, `user`, `level`, `fingerprint`). A top level `tags: { provider }` would stop that wrap and silently drop the address and chain id the report carries today. That is invisible at the call site, so it is the one comment in the diff.

**Shibarium will still be missing from these reports, and now visibly so.** It catches, classifies and reports inside itself and returns partial results, so its failures never reach this capture and never get a name. Naming the others does not fix that, it makes the asymmetry legible in Sentry: two providers that report with a name and one that reports without one from somewhere else. That is the argument for doing the Shibarium reporting step next rather than later.

Scope is the name and its use in the capture. The chain routing, the mute lists and the Shibarium reporting are untouched and keep their places in #511.

On the tests: the mocked provider modules gain `NAME`, and the two assertions that pin the captured payload exactly now include `provider`. That is the change itself rather than a fix to accommodate it. Worth knowing that without the mock change the suite passed anyway, because the mocks had no `NAME`, so `provider` was `undefined` and `toHaveBeenCalledWith` uses `toEqual` semantics that ignore undefined keys. The mocks have to mirror the module shape or the assertion proves nothing.

Part of #511.
