### PR TITLE
refactor(lookupDomains): report Shibarium failures through index.ts

### DIFF
--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -1,6 +1,4 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
 import fetch from 'node-fetch';
-import { isSilencedError } from '../addressResolvers/utils';
 import constants from '../constants.json';
 import { Address, Handle } from '../utils';
 
@@ -27,57 +25,45 @@ export default async function lookupDomains(
   let skip = 0;
   let hasMore = true;
 
-  try {
-    while (hasMore) {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
+  while (hasMore) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
 
-      try {
-        const response = await fetch(
-          `${constants.d3[chainId].apiUrl}/v1/partner/tokens/EVM/${address}?limit=${PAGE_SIZE}&skip=${skip}`,
-          {
-            headers: { 'Content-Type': 'application/json', 'Api-Key': API_KEYS[chainId] },
-            signal: controller.signal
-          }
-        );
-
-        if (response.status === 404) {
-          break;
+    try {
+      const response = await fetch(
+        `${constants.d3[chainId].apiUrl}/v1/partner/tokens/EVM/${address}?limit=${PAGE_SIZE}&skip=${skip}`,
+        {
+          headers: { 'Content-Type': 'application/json', 'Api-Key': API_KEYS[chainId] },
+          signal: controller.signal
         }
+      );
 
-        if (!response.ok) {
-          throw Object.assign(new Error(`HTTP ${response.status}: ${response.statusText}`), {
-            status: response.status
-          });
-        }
-
-        let data: { pageItems?: Array<{ sld: string; tld: string }> };
-        try {
-          data = await response.json();
-        } catch (err) {
-          throw new Error(`Invalid JSON response: ${(err as any).message}`);
-        }
-
-        const domains = data.pageItems?.map(item => `${item.sld}.${item.tld}`) || [];
-        allDomains.push(...domains);
-
-        hasMore = domains.length === PAGE_SIZE;
-        skip += PAGE_SIZE;
-      } catch (err) {
-        if (!isSilencedError(err)) {
-          capture(err, { input: { address, chainId, skip } });
-        }
+      if (response.status === 404) {
         break;
-      } finally {
-        clearTimeout(timeoutId);
       }
-    }
 
-    return allDomains;
-  } catch (err) {
-    if (!isSilencedError(err)) {
-      capture(err);
+      if (!response.ok) {
+        throw Object.assign(new Error(`HTTP ${response.status}: ${response.statusText}`), {
+          status: response.status
+        });
+      }
+
+      let data: { pageItems?: Array<{ sld: string; tld: string }> };
+      try {
+        data = await response.json();
+      } catch (err) {
+        throw new Error(`Invalid JSON response: ${(err as any).message}`);
+      }
+
+      const domains = data.pageItems?.map(item => `${item.sld}.${item.tld}`) || [];
+      allDomains.push(...domains);
+
+      hasMore = domains.length === PAGE_SIZE;
+      skip += PAGE_SIZE;
+    } finally {
+      clearTimeout(timeoutId);
     }
-    return allDomains;
   }
+
+  return allDomains;
 }

--- a/test/integration/lookupDomains/shibarium.test.ts
+++ b/test/integration/lookupDomains/shibarium.test.ts
@@ -15,6 +15,23 @@ const PAGE_SIZE = 25;
 const mockedFetch = fetch as unknown as jest.Mock;
 
 let lookupDomains: (address: Address, chainId?: string) => Promise<Handle[]>;
+let lookupDomainsThroughIndex: (address: Address, chains?: string | string[]) => Promise<Handle[]>;
+
+const apiKey = process.env.D3_API_KEY_MAINNET;
+
+beforeAll(async () => {
+  process.env.D3_API_KEY_MAINNET = 'test-key';
+  lookupDomains = (await import('../../../src/lookupDomains/shibarium')).default;
+  lookupDomainsThroughIndex = (await import('../../../src/lookupDomains')).default;
+});
+
+afterAll(() => {
+  if (apiKey === undefined) {
+    delete process.env.D3_API_KEY_MAINNET;
+  } else {
+    process.env.D3_API_KEY_MAINNET = apiKey;
+  }
+});
 
 function httpResponse(status: number, statusText: string, body: any = {}) {
   return {
@@ -32,76 +49,40 @@ function page(count: number) {
 }
 
 describe('lookupDomains/shibarium', () => {
-  const apiKey = process.env.D3_API_KEY_MAINNET;
+  it.each([
+    [429, 'Too Many Requests'],
+    [504, 'Gateway Timeout'],
+    [401, 'Unauthorized'],
+    [500, 'Internal Server Error']
+  ])('throws an error carrying the HTTP status on a %i', async (status, statusText) => {
+    mockedFetch.mockResolvedValue(httpResponse(status as number, statusText as string));
 
-  beforeAll(async () => {
-    process.env.D3_API_KEY_MAINNET = 'test-key';
-    lookupDomains = (await import('../../../src/lookupDomains/shibarium')).default;
-  });
-
-  afterAll(() => {
-    if (apiKey === undefined) {
-      delete process.env.D3_API_KEY_MAINNET;
-    } else {
-      process.env.D3_API_KEY_MAINNET = apiKey;
-    }
-  });
-
-  it('does not report a rate limit to Sentry', async () => {
-    mockedFetch.mockResolvedValue(httpResponse(429, 'Too Many Requests'));
-
-    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).rejects.toMatchObject({
+      message: `HTTP ${status}: ${statusText}`,
+      status
+    });
     expect(capture).not.toHaveBeenCalled();
   });
 
-  it('does not report a gateway timeout to Sentry', async () => {
-    mockedFetch.mockResolvedValue(httpResponse(504, 'Gateway Timeout'));
-
-    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
-    expect(capture).not.toHaveBeenCalled();
-  });
-
-  it('reports the HTTP status when the API rejects the credentials', async () => {
-    mockedFetch.mockResolvedValue(httpResponse(401, 'Unauthorized'));
-
-    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
-    expect(capture).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'HTTP 401: Unauthorized', status: 401 }),
-      { input: { address: ADDRESS, chainId: CHAIN_ID, skip: 0 } }
-    );
-  });
-
-  it('reports a server error to Sentry', async () => {
-    mockedFetch.mockResolvedValue(httpResponse(500, 'Internal Server Error'));
-
-    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
-    expect(capture).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'HTTP 500: Internal Server Error', status: 500 }),
-      { input: { address: ADDRESS, chainId: CHAIN_ID, skip: 0 } }
-    );
-  });
-
-  it('reports a failure that carries no HTTP status', async () => {
+  it('throws a failure that carries no HTTP status', async () => {
     mockedFetch.mockRejectedValue(
       Object.assign(new Error('getaddrinfo ENOTFOUND api-public.interstellar.xyz'), {
         code: 'ENOTFOUND'
       })
     );
 
-    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
-    expect(capture).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'getaddrinfo ENOTFOUND api-public.interstellar.xyz' }),
-      { input: { address: ADDRESS, chainId: CHAIN_ID, skip: 0 } }
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).rejects.toThrow(
+      'getaddrinfo ENOTFOUND api-public.interstellar.xyz'
     );
+    expect(capture).not.toHaveBeenCalled();
   });
 
-  it('keeps the domains collected before a rate limit interrupts pagination', async () => {
+  it('throws when a later page fails, instead of returning the pages already collected', async () => {
     mockedFetch
       .mockResolvedValueOnce(httpResponse(200, 'OK', page(PAGE_SIZE)))
       .mockResolvedValueOnce(httpResponse(429, 'Too Many Requests'));
 
-    await expect(lookupDomains(ADDRESS, CHAIN_ID)).resolves.toHaveLength(PAGE_SIZE);
-    expect(capture).not.toHaveBeenCalled();
+    await expect(lookupDomains(ADDRESS, CHAIN_ID)).rejects.toMatchObject({ status: 429 });
   });
 
   it('returns the domains on a successful response', async () => {
@@ -117,5 +98,34 @@ describe('lookupDomains/shibarium', () => {
     await expect(lookupDomains(ADDRESS, '1')).resolves.toEqual([]);
     expect(mockedFetch).not.toHaveBeenCalled();
     expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+describe('lookupDomains/shibarium through the shared handler', () => {
+  it('reports a shibarium failure with the address and chain as context', async () => {
+    mockedFetch.mockResolvedValue(httpResponse(500, 'Internal Server Error'));
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'HTTP 500: Internal Server Error', status: 500 }),
+      { input: { address: ADDRESS, chainId: CHAIN_ID } }
+    );
+  });
+
+  it('still silences a rate limit', async () => {
+    mockedFetch.mockResolvedValue(httpResponse(429, 'Too Many Requests'));
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('drops the pages already collected when a later page fails', async () => {
+    mockedFetch
+      .mockResolvedValueOnce(httpResponse(200, 'OK', page(PAGE_SIZE)))
+      .mockResolvedValueOnce(httpResponse(500, 'Internal Server Error'));
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
`src/lookupDomains/shibarium.ts` caught its own failures, classified them against `isSilencedError`, called `capture` itself and returned whatever pages it had already collected. `ens` and `unstoppableDomains` throw and let the fan-out in `index.ts` do all three. So Shibarium's errors never reached the shared handler and never carried the context it adds.

It now throws. `index.ts` catches, classifies and captures, which is what the other two providers do. Both `try/catch` blocks are gone along with the `capture` and `isSilencedError` imports; the `finally` that clears the abort timer stays, and a 404 still breaks the pagination loop as no-data rather than an error.

## This changes what a caller gets, not just what Sentry gets

Worth stating plainly rather than filing under unifying error reporting.

Today, if page 1 of a paginated fetch succeeds and page 2 fails, Shibarium reports the failure and returns page 1. The caller receives a list that looks complete and is not. After this change it returns nothing for that provider, matching `ens` and `unstoppableDomains`.

A partial list that looks complete is arguably worse than an empty one, especially since the caller has no way to tell the two apart, but it is a real behaviour change and it is visible through the `lookup_domains` API method.

Nothing depends on the old behaviour. The only consumer of the provider is the registry in `index.ts`, and thence `api.ts`. The only other importer is its own test.

## What does not change

The classification. `index.ts` calls the same `isSilencedError` with the same default mute list, one level up, so a 429 or a 504 is still silenced and still produces no Sentry event. There is a test for that, since it is the thing most likely to regress unnoticed.

One small loss: the old internal capture carried `skip`, so a report said which page failed. The shared handler carries the address and the chain id, like the other providers. That could be added later if it turns out to matter, but inventing a mechanism to carry it through the throw did not seem worth it here.

## Tests

Six of the eight cases in `test/integration/lookupDomains/shibarium.test.ts` changed, because their subject moved rather than because they broke. Five asserted that the provider captures and returns empty, and now assert that it throws carrying the HTTP status, which is the shape `test/integration/lookupDomains/unstoppableDomains.test.ts` already uses for the same contract. The sixth, `keeps the domains collected before a rate limit interrupts pagination`, asserted exactly the partial-return behaviour being removed, and is now `throws when a later page fails, instead of returning the pages already collected`.

`returns the domains on a successful response` and `does not call the API on an unsupported chain` are unedited.

Three cases are added, driving the real `index.ts` with `node-fetch` mocked, to prove the failure now travels the shared path: that a 500 is captured with the address and chain as context, that a 429 is still silenced, and that the earlier pages are dropped.

Part of #511.
