### PR TITLE
refactor(resolvers): let the map own the resolver failure contract

### DIFF
--- a/src/resolvers/basename.ts
+++ b/src/resolvers/basename.ts
@@ -2,12 +2,8 @@ import { fetchHttpImage } from './utils';
 import { getAvatar } from '../addressResolvers/basename';
 
 export default async function resolve(nameOrAddress: string) {
-  try {
-    const url = await getAvatar(nameOrAddress);
-    if (!url) return false;
+  const url = await getAvatar(nameOrAddress);
+  if (!url) return false;
 
-    return await fetchHttpImage(url);
-  } catch {
-    return false;
-  }
+  return await fetchHttpImage(url);
 }

--- a/src/resolvers/coingecko.ts
+++ b/src/resolvers/coingecko.ts
@@ -15,19 +15,15 @@ const COINGECKO_ASSET_PLATFORMS = {
 export default async function resolve(address: string, chainId: string) {
   if (!API_KEY) return false;
 
-  try {
-    const assetPlatformId = COINGECKO_ASSET_PLATFORMS[chainId];
+  const assetPlatformId = COINGECKO_ASSET_PLATFORMS[chainId];
 
-    if (!assetPlatformId) return false;
+  if (!assetPlatformId) return false;
 
-    const checksum = getAddress(address);
-    const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
+  const checksum = getAddress(address);
+  const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
 
-    const data = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } }).then(res =>
-      res.json()
-    );
-    return await fetchHttpImage(data?.image?.large);
-  } catch {
-    return false;
-  }
+  const data = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } }).then(res =>
+    res.json()
+  );
+  return await fetchHttpImage(data?.image?.large);
 }

--- a/src/resolvers/ens.ts
+++ b/src/resolvers/ens.ts
@@ -12,23 +12,19 @@ async function castToEnsName(nameOrAddress: string): Promise<string | undefined>
 }
 
 export default async function resolve(nameOrAddress: string) {
-  try {
-    const provider = getProvider(1);
-    const ensName = await castToEnsName(nameOrAddress);
+  const provider = getProvider(1);
+  const ensName = await castToEnsName(nameOrAddress);
 
-    if (!ensName) return false;
+  if (!ensName) return false;
 
-    const ensResolver = await provider.getResolver(ensName);
+  const ensResolver = await provider.getResolver(ensName);
 
-    if (!ensResolver) {
-      return false;
-    }
-
-    let url = await ensResolver.getText('avatar');
-    url = url?.startsWith('http') ? url : `https://metadata.ens.domains/mainnet/avatar/${ensName}`;
-
-    return await fetchHttpImage(url);
-  } catch {
+  if (!ensResolver) {
     return false;
   }
+
+  let url = await ensResolver.getText('avatar');
+  url = url?.startsWith('http') ? url : `https://metadata.ens.domains/mainnet/avatar/${ensName}`;
+
+  return await fetchHttpImage(url);
 }

--- a/src/resolvers/farcaster.ts
+++ b/src/resolvers/farcaster.ts
@@ -50,10 +50,5 @@ export default async function resolve(address: string): Promise<Buffer | false> 
   const url = await fetchAddressImageUrl(normalizedAddress);
   if (!url) return false;
 
-  try {
-    const imageUrl = withCache(url);
-    return await fetchHttpImage(imageUrl);
-  } catch {
-    return false;
-  }
+  return await fetchHttpImage(withCache(url));
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -28,13 +28,26 @@ type Resolver = {
   resize: boolean;
 };
 
-// The catch keeps what each resolver had around its own resize call: bytes
-// sharp refuses answer false rather than throwing into the image route, which
-// has no guard of its own (#495). Entries with resize: false hand their bytes
-// to the bare resize() in api.ts and stay exposed to that gap.
+// Two failures, two policies, deliberately different.
+// A resolver throwing answers false and is not reported. That is the contract
+// each resolver used to implement for itself; it stays silent because the
+// no-data answers are not normalized yet (#511), and reporting before they are
+// would page on every routine upstream 404.
+// Sharp refusing the bytes is reported, because bytes we fetched but cannot
+// process are our problem rather than the upstream's.
+// Either way the wrapper answers false rather than throwing into the image
+// route, which has no guard of its own (#495). Entries with resize: false are
+// not wrapped and keep whatever contract their own module implements.
 function withResize(resolve: ResolverFn): ResolverFn {
   return async (...args) => {
-    const input = await resolve(...args);
+    let input: Buffer | false;
+
+    try {
+      input = await resolve(...args);
+    } catch {
+      return false;
+    }
+
     if (!input) return false;
 
     try {

--- a/src/resolvers/lens.ts
+++ b/src/resolvers/lens.ts
@@ -31,28 +31,24 @@ export default async function resolve(domainOrAddress: string) {
     return false;
   }
 
-  try {
-    const {
-      data: {
-        data: { account }
-      }
-    } = await graphQlCall(
-      `${API_URL}/graphql`,
-      `query Account($request: AccountRequest!) {
-        account(request: $request) {
-          metadata {
-            picture
-          }
+  const {
+    data: {
+      data: { account }
+    }
+  } = await graphQlCall(
+    `${API_URL}/graphql`,
+    `query Account($request: AccountRequest!) {
+      account(request: $request) {
+        metadata {
+          picture
         }
-      }`,
-      { request }
-    );
+      }
+    }`,
+    { request }
+  );
 
-    const img_url = normalizeImageUrl(account?.metadata?.picture);
-    if (!img_url) return false;
+  const img_url = normalizeImageUrl(account?.metadata?.picture);
+  if (!img_url) return false;
 
-    return await fetchHttpImage(img_url);
-  } catch {
-    return false;
-  }
+  return await fetchHttpImage(img_url);
 }

--- a/src/resolvers/selfid.ts
+++ b/src/resolvers/selfid.ts
@@ -6,16 +6,12 @@ import { fetchHttpImage } from './utils';
 const core = new Core({ ceramic: 'https://gateway.ceramic.network' });
 
 export default async function resolve(address: string) {
-  try {
-    const did = await core.getAccountDID(`${getAddress(address)}@eip155:1`);
-    const result = await core.get('basicProfile', did);
+  const did = await core.getAccountDID(`${getAddress(address)}@eip155:1`);
+  const result = await core.get('basicProfile', did);
 
-    const { src } = result?.image?.original || {};
-    if (!src) return false;
+  const { src } = result?.image?.original || {};
+  if (!src) return false;
 
-    const url = getUrl(src);
-    return await fetchHttpImage(url);
-  } catch {
-    return false;
-  }
+  const url = getUrl(src);
+  return await fetchHttpImage(url);
 }

--- a/src/resolvers/starknet.ts
+++ b/src/resolvers/starknet.ts
@@ -43,20 +43,16 @@ async function fetchImageOrMetadata(url: string): Promise<Buffer | { image?: str
 }
 
 export default async function resolve(domainOrAddress: string) {
-  try {
-    const img_url = await getImage(domainOrAddress);
+  const img_url = await getImage(domainOrAddress);
 
-    if (!img_url || img_url === DEFAULT_IMG_URL) return false;
+  if (!img_url || img_url === DEFAULT_IMG_URL) return false;
 
-    const fetched = await fetchImageOrMetadata(getUrl(img_url));
-    const buffer = Buffer.isBuffer(fetched)
-      ? fetched
-      : fetched.image
-        ? await fetchHttpImage(getUrl(fetched.image))
-        : null;
+  const fetched = await fetchImageOrMetadata(getUrl(img_url));
+  const buffer = Buffer.isBuffer(fetched)
+    ? fetched
+    : fetched.image
+      ? await fetchHttpImage(getUrl(fetched.image))
+      : null;
 
-    return buffer ?? false;
-  } catch {
-    return false;
-  }
+  return buffer ?? false;
 }

--- a/src/resolvers/trustwallet.ts
+++ b/src/resolvers/trustwallet.ts
@@ -8,15 +8,11 @@ const ETH = [
 ];
 
 export default async function resolve(address, chainId) {
-  try {
-    const networkName = chainIdToName(chainId) || 'ethereum';
-    const checksum = getAddress(address);
+  const networkName = chainIdToName(chainId) || 'ethereum';
+  const checksum = getAddress(address);
 
-    let url = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${networkName}/assets/${checksum}/logo.png`;
-    if (ETH.includes(checksum)) url = getBaseAssetIconUrl(chainId);
+  let url = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${networkName}/assets/${checksum}/logo.png`;
+  if (ETH.includes(checksum)) url = getBaseAssetIconUrl(chainId);
 
-    return await fetchHttpImage(url);
-  } catch {
-    return false;
-  }
+  return await fetchHttpImage(url);
 }

--- a/test/unit/graphQlEnvelope.test.ts
+++ b/test/unit/graphQlEnvelope.test.ts
@@ -122,12 +122,14 @@ describe('graphQlCall callers surface an envelope failure', () => {
   });
 
   describe('src/resolvers/lens.ts - account', () => {
+    // Unlike the two above, lens no longer answers false for itself: its catch
+    // moved to the resolver map, which is where that answer is now given.
     it('does not use a payload the upstream flagged as an error', async () => {
       respondWith(
         upstreamFailure('Rate limit exceeded', { account: { metadata: { picture: IMAGE_URL } } })
       );
 
-      await expect(lensResolve(ADDRESS)).resolves.toBe(false);
+      await expect(lensResolve(ADDRESS)).rejects.toThrow('[api.lens.xyz] Rate limit exceeded');
       expect(fetchHttpImage).not.toHaveBeenCalled();
     });
   });

--- a/test/unit/resolvers/failureContract.test.ts
+++ b/test/unit/resolvers/failureContract.test.ts
@@ -1,0 +1,44 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import resolvers from '../../../src/resolvers';
+import blockie from '../../../src/resolvers/blockie';
+import ens from '../../../src/resolvers/ens';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
+jest.mock('../../../src/resolvers/ens', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../src/resolvers/blockie', () => ({ __esModule: true, default: jest.fn() }));
+
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+
+describe('resolvers - failure contract', () => {
+  it('answers false when a wrapped resolver throws', async () => {
+    (ens as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    await expect(resolvers.ens(ADDRESS)).resolves.toBe(false);
+  });
+
+  it('does not report a resolver failure', async () => {
+    (ens as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    await resolvers.ens(ADDRESS);
+
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('reports bytes sharp cannot process, and still answers false', async () => {
+    (ens as jest.Mock).mockResolvedValue(Buffer.from('not an image'));
+
+    await expect(resolvers.ens(ADDRESS)).resolves.toBe(false);
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  // api.ts hands the fallback resolver's result straight to resize() with no
+  // guard of its own, so a fallback answering false would make sharp throw into
+  // the unguarded image route (#495). Until that route is fixed the fallbacks
+  // have to stay outside the false-on-failure contract.
+  it('leaves the fallback resolvers throwing rather than answering false', async () => {
+    const error = new Error('boom');
+    (blockie as jest.Mock).mockRejectedValue(error);
+
+    await expect(resolvers.blockie(ADDRESS)).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
Each individually written resolver ended in a whole-body `catch { return false }`, so "this resolver broke" and "this address has no avatar" were the same answer, written out separately in eight files. That answer moves to the wrapper in `index.ts`, where the rest of the pipeline already lives, and comes out of the eight.

## This is smaller than removing all the catches, deliberately

The shared factories keep theirs. `createPropertyResolver` in `snapshot.ts` produces five entries and the one in `space-sx.ts` produces two, and in both cases the factory serves bare entries as well as wrapped ones. `user-cover`, `space-cover`, `space-logo` and `space-cover-sx` have no wrapper to fall back on, so taking the catch out of the factory would take it away from them in the same edit and let them throw into the image route, which has no guard of its own (#495). `blockie` and `jazzicon` stay outside the contract for the same reason: `api.ts` hands the fallback resolver's result straight to `resize()`, so a fallback answering `false` would make sharp throw on the same unguarded path.

What makes the eight safe is that they line up exactly with the wrapped entries. Every individually written resolver that had a catch is `resize: true`, and every `resize: false` entry is either factory-produced or has no catch to move. So the set of entries covered by a catch is identical before and after. The factories come out once the flag is split and every entry has a wrapper, which is the next step, not this one.

## What changes for a caller

Nothing, and that is the intent.

`src/resolvers/index.ts` is the only production consumer of the resolver modules, so every production call already goes through the map. Before, the resolver caught and answered `false`; now the wrapper catches and answers `false`. Same value, same fallback, same path.

No new Sentry volume either. The wrapper keeps two policies and they are deliberately different: a resolver throwing is silent, a sharp failure is still reported exactly as it is today. Silent is not the end state, it is the correct state until the no-data answers are normalized. Turning capture on now would report every routine `metadata.ens.domains` 404 and every token without a trustwallet logo as an error, which is the ordering constraint #511 was built around.

## One existing test moved

`test/unit/graphQlEnvelope.test.ts`, the `src/resolvers/lens.ts` case, asserted `lensResolve(...)` resolves to `false`. It imports the module directly rather than going through the map, so it was asserting the contract this PR moves. It now asserts the rejection, and the assertion that carries the test's actual point, that a payload the upstream flagged is never fetched, is unchanged.

The `snapshot.ts` and `space-sx.ts` cases beside it still assert `false` and needed no edit, which is the scoping above visible in the test file.

## On #483

It does not unblock it. Worth saying plainly, because the opposite was the expectation.

`src/resolvers/ens.ts` is one of the eight and #483 conflicts there, but touching the same file does not clear a conflict. Merging #483 against master and against this branch produces the same three conflicted paths either way: `package.json`, `src/resolvers/ens.ts` and `yarn.lock`. All three already conflict on master today.

What does change is the shape of the resolution. After this, the target for that file is the fetch logic on its own, with no `try`/`catch` and no `resize`, so #483 keeps its Universal Resolver body and drops both wrappers rather than dropping one and keeping the other. Easier to resolve, still a manual resolve.

Refs #511.
