### PR TITLE
fix(lookupDomains): assert the capture shape the provider naming produces

### DIFF
--- a/test/integration/lookupDomains/shibarium.test.ts
+++ b/test/integration/lookupDomains/shibarium.test.ts
@@ -109,7 +109,10 @@ describe('lookupDomains/shibarium through the shared handler', () => {
     expect(capture).toHaveBeenCalledTimes(1);
     expect(capture).toHaveBeenCalledWith(
       expect.objectContaining({ message: 'HTTP 500: Internal Server Error', status: 500 }),
-      { input: { address: ADDRESS, chainId: CHAIN_ID } }
+      {
+        tags: { provider: 'Shibarium' },
+        contexts: { input: { address: ADDRESS, chainId: CHAIN_ID } }
+      }
     );
   });
 


### PR DESCRIPTION
Master is red. `test/integration/lookupDomains/shibarium.test.ts` asserts a Sentry capture shape that `src/lookupDomains/index.ts` no longer produces.

#526 and #528 were each cut from a master that did not contain the other. #528 asserted the captured context as `{ input: { address, chainId } }`, which was the shape at the time. #526 moved the provider name into a Sentry tag and the rest under `contexts.input`. #526 merged second, so master now has the new shape and the old assertion:

```
- Expected
+ Received

  [Error: HTTP 500: Internal Server Error],
  Object {
+   "contexts": Object {
      "input": Object {
        "address": "0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6",
        "chainId": "109",
+     },
+   },
+   "tags": Object {
+     "provider": "Shibarium",
    },
  },
```

Only the assertion is stale. Both changes are individually correct and they compose correctly, so this updates the expectation rather than any behaviour. It now also pins the tag as `Shibarium`, which is the part that actually proves they compose: a Shibarium failure reaches the shared handler because of #528, and arrives named because of #526.

No source file changes.
