### PR TITLE
feat(lookupDomains): record each provider in a metric, and stop reporting our own aborts

### DIFF
--- a/src/addressResolvers/utils.ts
+++ b/src/addressResolvers/utils.ts
@@ -72,6 +72,9 @@ export function normalizeHandles(handles: Handle[]): Handle[] {
 }
 
 export function isSilencedError(error: any, additionalMessages?: string[]): boolean {
+  // An abort is always one of our own deadlines, and each transport words it differently.
+  if (error.name === 'AbortError') return true;
+
   const messages = [
     'invalid token ID',
     'is not supported',

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -26,6 +26,12 @@ export const timeAddressResolverResponse = new client.Histogram({
   labelNames: ['provider', 'method', 'status']
 });
 
+export const timeLookupDomainsResponse = new client.Histogram({
+  name: 'lookup_domains_response_duration_seconds',
+  help: "Duration in seconds of each domain provider's response.",
+  labelNames: ['provider', 'chainId', 'status']
+});
+
 export const addressResolversCacheHitCount = new client.Counter({
   name: 'address_resolvers_cache_hit_count',
   help: 'Number of hit/miss of the address resolvers cache layer',

--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -1,6 +1,7 @@
 import { isAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { isSilencedError } from '../addressResolvers/utils';
+import { timeLookupDomainsResponse as timeResponse } from '../helpers/metrics';
 import { Address, Handle } from '../utils';
 import ens, {
   CHAIN_IDS as ENS_CHAIN_IDS,
@@ -63,15 +64,26 @@ export default async function lookupDomains(
       .filter(chainId => supportedChainIds.includes(chainId))
       .forEach(chainId => {
         promises.push(
-          fn(address, chainId).catch(err => {
-            if (!isSilencedError(err)) {
-              capture(err, {
-                tags: { provider: name },
-                contexts: { input: { address, chainId } }
-              });
+          (async () => {
+            const end = timeResponse.startTimer({ provider: name, chainId });
+            let status = 0;
+
+            try {
+              const domains = await fn(address, chainId);
+              status = 1;
+              return domains;
+            } catch (err) {
+              if (!isSilencedError(err)) {
+                capture(err, {
+                  tags: { provider: name },
+                  contexts: { input: { address, chainId } }
+                });
+              }
+              return [];
+            } finally {
+              end({ status });
             }
-            return [];
-          })
+          })()
         );
       });
   });

--- a/test/integration/abortClassification.test.ts
+++ b/test/integration/abortClassification.test.ts
@@ -1,0 +1,63 @@
+import http from 'http';
+import nodeFetch from 'node-fetch';
+import { isSilencedError } from '../../src/addressResolvers/utils';
+
+let server: http.Server;
+let url: string;
+const sockets = new Set<any>();
+
+beforeAll(async () => {
+  server = http.createServer(() => {
+    // Accepts the connection and never answers, so the abort is what ends the request.
+  });
+  server.on('connection', socket => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
+  url = `http://127.0.0.1:${(server.address() as any).port}/`;
+});
+
+afterAll(async () => {
+  sockets.forEach(socket => socket.destroy());
+  await new Promise<void>(resolve => server.close(() => resolve()));
+});
+
+async function abortAgainstAHangingServer(request: (u: string, init: any) => Promise<unknown>) {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 100);
+
+  try {
+    await request(url, { signal: controller.signal });
+  } catch (err: any) {
+    return err;
+  }
+
+  return undefined;
+}
+
+describe('isSilencedError, on a request we aborted ourselves', () => {
+  it('silences an abort raised by node-fetch', async () => {
+    const error = await abortAgainstAHangingServer(nodeFetch as any);
+
+    expect(error).toBeDefined();
+    expect(error.name).toBe('AbortError');
+    expect(isSilencedError(error)).toBe(true);
+  });
+
+  it('silences an abort raised by the global fetch', async () => {
+    const error = await abortAgainstAHangingServer(fetch as any);
+
+    expect(error).toBeDefined();
+    expect(error.name).toBe('AbortError');
+    expect(isSilencedError(error)).toBe(true);
+  });
+
+  it('matches on the name because the two transports word the message differently', async () => {
+    const viaNodeFetch = await abortAgainstAHangingServer(nodeFetch as any);
+    const viaGlobalFetch = await abortAgainstAHangingServer(fetch as any);
+
+    expect(viaNodeFetch.message).not.toEqual(viaGlobalFetch.message);
+    expect(viaNodeFetch.name).toBe(viaGlobalFetch.name);
+  });
+});

--- a/test/integration/lookupDomains/shibarium.test.ts
+++ b/test/integration/lookupDomains/shibarium.test.ts
@@ -1,5 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import fetch from 'node-fetch';
+import { timeLookupDomainsResponse } from '../../../src/helpers/metrics';
 import { Address, Handle } from '../../../src/utils';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({
@@ -98,6 +99,69 @@ describe('lookupDomains/shibarium', () => {
     await expect(lookupDomains(ADDRESS, '1')).resolves.toEqual([]);
     expect(mockedFetch).not.toHaveBeenCalled();
     expect(capture).not.toHaveBeenCalled();
+  });
+});
+
+function abortError() {
+  return Object.assign(new Error('The user aborted a request.'), {
+    name: 'AbortError',
+    type: 'aborted'
+  });
+}
+
+async function recordedFor(provider: string) {
+  const metric: any = await timeLookupDomainsResponse.get();
+
+  return metric.values
+    .filter((v: any) => String(v.metricName).endsWith('_count') && v.labels.provider === provider)
+    .map((v: any) => ({ chainId: v.labels.chainId, status: v.labels.status, count: v.value }));
+}
+
+describe('lookupDomains/shibarium deadline', () => {
+  it('still aborts the request once the deadline passes', async () => {
+    const timers = jest.spyOn(global, 'setTimeout');
+    const signals: AbortSignal[] = [];
+    mockedFetch.mockImplementation(
+      (_url: string, options: any) =>
+        new Promise((_resolve, reject) => {
+          signals.push(options.signal);
+          options.signal.addEventListener('abort', () => reject(abortError()));
+        })
+    );
+
+    const result = lookupDomains(ADDRESS, CHAIN_ID);
+    await Promise.resolve();
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0].aborted).toBe(false);
+
+    const deadline = timers.mock.calls.find(call => call[1] === 10000);
+    expect(deadline).toBeDefined();
+    (deadline as unknown as [() => void])[0]();
+
+    await expect(result).rejects.toThrow('The user aborted a request.');
+    expect(signals[0].aborted).toBe(true);
+    timers.mockRestore();
+  });
+
+  it('does not report an abort, and still records it in the metric', async () => {
+    timeLookupDomainsResponse.reset();
+    mockedFetch.mockRejectedValue(abortError());
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(capture).not.toHaveBeenCalled();
+    expect(await recordedFor('Shibarium')).toEqual([{ chainId: CHAIN_ID, status: 0, count: 1 }]);
+  });
+
+  it('records a success as status 1', async () => {
+    timeLookupDomainsResponse.reset();
+    mockedFetch.mockResolvedValue(
+      httpResponse(200, 'OK', { pageItems: [{ sld: 'boorger', tld: 'shib' }] })
+    );
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, CHAIN_ID)).resolves.toEqual(['boorger.shib']);
+    expect(await recordedFor('Shibarium')).toEqual([{ chainId: CHAIN_ID, status: 1, count: 1 }]);
   });
 });
 


### PR DESCRIPTION
A Shibarium abort was the only provider timeout still reaching Sentry. The other two providers already time out into errors the shared classifier silences, so this one was loud by accident rather than by decision.

The fix is a name check in `isSilencedError` rather than a mute list on the provider. Every transport words an abort differently, so matching the message pins the behaviour to one library at one version, while the name is stable. It belongs in the shared classifier because nothing here aborts a request except one of our own deadlines, which is the same reasoning that already silences the other timeout codes.

Silencing on its own would have been a straight loss, and that is what the histogram is for. `addressResolvers` can afford to mute because it times every resolver and records the failure whether or not it reports it, so the mute hides the report and not the event. `lookupDomains` had no metric at all, so this adds the matching per-provider histogram and records the status in a `finally`, meaning a silenced failure still counts. The two halves are only correct together, which is why they are one PR.

An earlier revision of this branch added a per-provider `mutedErrors` field and put the abort in Shibarium's. That field is gone. It keyed on an English string, so a transport or version change would have turned the mute off with the suite still green, and the classifier fix leaves it with nothing to hold.

Part of #511. No closing keyword, since the resolvers half of that issue is still open.
