### PR TITLE
refactor: simplify the lookupDomains and resolvers registries

### DIFF
--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -3,51 +3,21 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import { isSilencedError } from '../addressResolvers/utils';
 import { timeLookupDomainsResponse as timeResponse } from '../helpers/metrics';
 import { Address, Handle } from '../utils';
-import ens, {
-  CHAIN_IDS as ENS_CHAIN_IDS,
-  DEFAULT_CHAIN_ID as ENS_DEFAULT_CHAIN_ID,
-  NAME as ENS_NAME
-} from './ens';
-import shibarium, {
-  CHAIN_IDS as SHIBARIUM_CHAIN_IDS,
-  DEFAULT_CHAIN_ID as SHIBARIUM_DEFAULT_CHAIN_ID,
-  NAME as SHIBARIUM_NAME
-} from './shibarium';
-import unstoppableDomains, {
-  CHAIN_IDS as UNSTOPPABLE_DOMAINS_CHAIN_IDS,
-  DEFAULT_CHAIN_ID as UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID,
-  NAME as UNSTOPPABLE_DOMAINS_NAME
-} from './unstoppableDomains';
+import * as ens from './ens';
+import * as shibarium from './shibarium';
+import * as unstoppableDomains from './unstoppableDomains';
 
 type Provider = {
-  name: string;
-  fn: (address: Address, chainId: string) => Promise<Handle[]>;
-  defaultChainId: string;
-  chainIds: string[];
+  NAME: string;
+  DEFAULT_CHAIN_ID: string;
+  CHAIN_IDS: string[];
+  default: (address: Address, chainId: string) => Promise<Handle[]>;
 };
 
-const PROVIDERS: Provider[] = [
-  {
-    name: ENS_NAME,
-    fn: ens,
-    defaultChainId: ENS_DEFAULT_CHAIN_ID,
-    chainIds: ENS_CHAIN_IDS
-  },
-  {
-    name: SHIBARIUM_NAME,
-    fn: shibarium,
-    defaultChainId: SHIBARIUM_DEFAULT_CHAIN_ID,
-    chainIds: SHIBARIUM_CHAIN_IDS
-  },
-  {
-    name: UNSTOPPABLE_DOMAINS_NAME,
-    fn: unstoppableDomains,
-    defaultChainId: UNSTOPPABLE_DOMAINS_DEFAULT_CHAIN_ID,
-    chainIds: UNSTOPPABLE_DOMAINS_CHAIN_IDS
-  }
-];
+// Without the annotation a provider missing NAME still compiles.
+const PROVIDERS: Provider[] = [ens, shibarium, unstoppableDomains];
 
-const DEFAULT_CHAIN_IDS = PROVIDERS.map(provider => provider.defaultChainId);
+const DEFAULT_CHAIN_IDS = PROVIDERS.map(provider => provider.DEFAULT_CHAIN_ID);
 
 export default async function lookupDomains(
   address: Address,
@@ -59,13 +29,13 @@ export default async function lookupDomains(
 
   if (!isAddress(address)) return [];
 
-  PROVIDERS.forEach(({ name, fn, chainIds: supportedChainIds }) => {
+  PROVIDERS.forEach(({ NAME, default: fn, CHAIN_IDS }) => {
     chainIds
-      .filter(chainId => supportedChainIds.includes(chainId))
+      .filter(chainId => CHAIN_IDS.includes(chainId))
       .forEach(chainId => {
         promises.push(
           (async () => {
-            const end = timeResponse.startTimer({ provider: name, chainId });
+            const end = timeResponse.startTimer({ provider: NAME, chainId });
             let status = 0;
 
             try {
@@ -75,7 +45,7 @@ export default async function lookupDomains(
             } catch (err) {
               if (!isSilencedError(err)) {
                 capture(err, {
-                  tags: { provider: name },
+                  tags: { provider: NAME },
                   contexts: { input: { address, chainId } }
                 });
               }

--- a/src/lookupDomains/index.ts
+++ b/src/lookupDomains/index.ts
@@ -23,25 +23,24 @@ export default async function lookupDomains(
   address: Address,
   chains: string | string[] = DEFAULT_CHAIN_IDS
 ): Promise<Handle[]> {
-  const promises: Promise<Handle[]>[] = [];
   let chainIds = Array.isArray(chains) ? chains : [chains];
   chainIds = [...new Set(chainIds.map(String))];
 
   if (!isAddress(address)) return [];
 
-  PROVIDERS.forEach(({ NAME, default: fn, CHAIN_IDS }) => {
-    chainIds
-      .filter(chainId => CHAIN_IDS.includes(chainId))
-      .forEach(chainId => {
-        promises.push(
+  const domains = await Promise.all(
+    PROVIDERS.flatMap(({ NAME, default: fn, CHAIN_IDS }) =>
+      chainIds
+        .filter(chainId => CHAIN_IDS.includes(chainId))
+        .map(chainId =>
           (async () => {
             const end = timeResponse.startTimer({ provider: NAME, chainId });
             let status = 0;
 
             try {
-              const domains = await fn(address, chainId);
+              const result = await fn(address, chainId);
               status = 1;
-              return domains;
+              return result;
             } catch (err) {
               if (!isSilencedError(err)) {
                 capture(err, {
@@ -54,11 +53,9 @@ export default async function lookupDomains(
               end({ status });
             }
           })()
-        );
-      });
-  });
-
-  const domains = await Promise.all(promises);
+        )
+    )
+  );
 
   return [...new Set(domains.flat())];
 }

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -86,11 +86,15 @@ const RESOLVERS = [
   { name: 'farcaster', fn: farcaster, resize: true }
 ] as const satisfies readonly Resolver[];
 
-type ResolverName = (typeof RESOLVERS)[number]['name'];
+// Returning E['fn'] here lets a caller treat a wrapped resolver as one that
+// never answers false.
+type ResolverMap = {
+  [E in (typeof RESOLVERS)[number] as E['name']]: (
+    ...args: Parameters<E['fn']>
+  ) => Promise<Buffer | false>;
+};
 
-// Object.fromEntries types its result as Record<string, ...>, which compiles
-// everywhere and silently drops the name check that api.ts and the integration
-// helper rely on. The cast is what keeps the keys a literal union.
+// Without the cast Object.fromEntries widens the keys to string.
 export default Object.fromEntries(
   RESOLVERS.map(entry => [entry.name, entry.resize ? withResize(entry.fn) : entry.fn])
-) as Record<ResolverName, ResolverFn>;
+) as ResolverMap;

--- a/test/integration/lookupDomains/shibarium.test.ts
+++ b/test/integration/lookupDomains/shibarium.test.ts
@@ -50,13 +50,13 @@ function page(count: number) {
 }
 
 describe('lookupDomains/shibarium', () => {
-  it.each([
+  it.each<[number, string]>([
     [429, 'Too Many Requests'],
     [504, 'Gateway Timeout'],
     [401, 'Unauthorized'],
     [500, 'Internal Server Error']
   ])('throws an error carrying the HTTP status on a %i', async (status, statusText) => {
-    mockedFetch.mockResolvedValue(httpResponse(status as number, statusText as string));
+    mockedFetch.mockResolvedValue(httpResponse(status, statusText));
 
     await expect(lookupDomains(ADDRESS, CHAIN_ID)).rejects.toMatchObject({
       message: `HTTP ${status}: ${statusText}`,


### PR DESCRIPTION
Follow-up to the lookupDomains and resolvers series that just merged, not a fix. It changes no behaviour: no runtime path, no error policy and no reported payload moves. A quality pass over the lines that series touched, and nothing else.

Four commits, each independent, so any one can be dropped without disturbing the others.

## 1. `refactor(lookupDomains): let the modules be the provider registry`

The registry restated each provider's exported constants under new lowercase names, which took a block of aliased imports per provider to feed. The providers already export the names the registry wants, and the address resolver registry next door already imports its providers as namespaces, so the module can be the provider directly and a mis-wired alias stops being representable.

## 2. `refactor(lookupDomains): fan out with flatMap instead of an accumulator`

Drops the mutable promise array the fan-out pushed into.

**This is the one commit that leaves the series' own lines.** The accumulator and its `Promise.all` predate the series; only the nested loop between them was series code. Drop this commit if the pass should stay strictly inside those lines. The other three do not depend on it.

## 3. `refactor(resolvers): keep each resolver's own parameters on the map`

The exported map was cast to a record keyed by resolver name with every signature flattened to a rest tuple of `any`. The names were checked, the arguments were not, so calling a resolver with the wrong arity compiled. Keying the map off the registry entries keeps both, since those entries already carry the real function types.

The return type stays wider than the entry's own on purpose. The resize wrapper answers `false` for a resolver that throws, including resolvers whose own signature says they only ever return a buffer, so taking the return type from the entry would let a caller treat one of those as never failing.

## 4. `test(lookupDomains): type the shibarium status table`

The untyped `it.each` table widened its columns, so each case cast them back at the call site. Annotating the table removes the casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
