### PR TITLE
fix(lookupDomains): bound every provider call with a shared deadline

### DIFF
--- a/src/getOwner/shibarium.ts
+++ b/src/getOwner/shibarium.ts
@@ -1,6 +1,6 @@
 import { DNSConnect } from '@webinterop/dns-connect';
 import constants from '../constants.json';
-import { Address, EMPTY_ADDRESS, Handle, withDeadline } from '../utils';
+import { Address, EMPTY_ADDRESS, Handle, untilAborted, withDeadline } from '../utils';
 
 const MAINNET = '109';
 const TESTNET = '157';
@@ -46,7 +46,12 @@ async function getClaimedOwner(handle: Handle, chainId: string): Promise<Address
 async function getResolvedAddress(handle: Handle, chainId: string): Promise<Address> {
   const dnsConnect = new DNSConnect({ dns: { forwarderDomain: constants.d3[chainId].forwarder } });
 
-  return (await dnsConnect.resolve(handle, NETWORK)) || EMPTY_ADDRESS;
+  // dns-connect passes no signal to the DNS-over-HTTPS fetches it makes, so
+  // only the wait can be bounded here, not the request.
+  return withDeadline(
+    async signal =>
+      (await untilAborted(signal, dnsConnect.resolve(handle, NETWORK))) || EMPTY_ADDRESS
+  );
 }
 
 /**

--- a/src/getOwner/shibarium.ts
+++ b/src/getOwner/shibarium.ts
@@ -1,6 +1,6 @@
 import { DNSConnect } from '@webinterop/dns-connect';
 import constants from '../constants.json';
-import { Address, EMPTY_ADDRESS, Handle } from '../utils';
+import { Address, EMPTY_ADDRESS, Handle, withDeadline } from '../utils';
 
 const MAINNET = '109';
 const TESTNET = '157';
@@ -16,28 +16,31 @@ async function getClaimedOwner(handle: Handle, chainId: string): Promise<Address
   if (!handle.endsWith(`.${TLD}`) || !constants.d3[chainId]?.apiUrl || !API_KEYS[chainId])
     return EMPTY_ADDRESS;
 
-  const response = await fetch(
-    `${constants.d3[chainId].apiUrl}/v1/partner/token/${handle.replace(/\.shib$/, '')}/${TLD}`,
-    {
-      method: 'GET',
-      headers: {
-        accept: 'application/json',
-        'Api-Key': API_KEYS[chainId]
+  return withDeadline<Address | false>(async signal => {
+    const response = await fetch(
+      `${constants.d3[chainId].apiUrl}/v1/partner/token/${handle.replace(/\.shib$/, '')}/${TLD}`,
+      {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          'Api-Key': API_KEYS[chainId]
+        },
+        signal
       }
+    );
+
+    if (response.status === 404) return EMPTY_ADDRESS;
+    if (!response.ok) throw new Error(`Error fetching owner: ${response.statusText}`);
+
+    const data = await response.json();
+
+    if (data.status !== 'registered' || new Date(data.expirationDate) < new Date()) {
+      return EMPTY_ADDRESS;
     }
-  );
 
-  if (response.status === 404) return EMPTY_ADDRESS;
-  if (!response.ok) throw new Error(`Error fetching owner: ${response.statusText}`);
-
-  const data = await response.json();
-
-  if (data.status !== 'registered' || new Date(data.expirationDate) < new Date()) {
-    return EMPTY_ADDRESS;
-  }
-
-  // owner field will be missing on unclaimed names
-  return data.owner || false;
+    // owner field will be missing on unclaimed names
+    return data.owner || false;
+  });
 }
 
 async function getResolvedAddress(handle: Handle, chainId: string): Promise<Address> {

--- a/src/lookupDomains/shibarium.ts
+++ b/src/lookupDomains/shibarium.ts
@@ -1,11 +1,10 @@
 import fetch from 'node-fetch';
 import constants from '../constants.json';
-import { Address, Handle } from '../utils';
+import { Address, Handle, withDeadline } from '../utils';
 
 const MAINNET = '109';
 const TESTNET = '157';
 const PAGE_SIZE = 25;
-const TIMEOUT = 10000;
 
 const API_KEYS = {
   [MAINNET]: process.env.D3_API_KEY_MAINNET,
@@ -22,20 +21,17 @@ export default async function lookupDomains(
 ): Promise<Handle[]> {
   if (!constants.d3[chainId]?.apiUrl || !API_KEYS[chainId]) return [];
 
-  const allDomains: Handle[] = [];
-  let skip = 0;
-  let hasMore = true;
+  return withDeadline(async signal => {
+    const allDomains: Handle[] = [];
+    let skip = 0;
+    let hasMore = true;
 
-  while (hasMore) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
-
-    try {
+    while (hasMore) {
       const response = await fetch(
         `${constants.d3[chainId].apiUrl}/v1/partner/tokens/EVM/${address}?limit=${PAGE_SIZE}&skip=${skip}`,
         {
           headers: { 'Content-Type': 'application/json', 'Api-Key': API_KEYS[chainId] },
-          signal: controller.signal
+          signal
         }
       );
 
@@ -61,10 +57,8 @@ export default async function lookupDomains(
 
       hasMore = domains.length === PAGE_SIZE;
       skip += PAGE_SIZE;
-    } finally {
-      clearTimeout(timeoutId);
     }
-  }
 
-  return allDomains;
+    return allDomains;
+  });
 }

--- a/src/lookupDomains/unstoppableDomains.ts
+++ b/src/lookupDomains/unstoppableDomains.ts
@@ -1,4 +1,4 @@
-import { Address, Handle } from '../utils';
+import { Address, Handle, withDeadline } from '../utils';
 
 export const NAME = 'Unstoppable Domains';
 export const DEFAULT_CHAIN_ID = '146';
@@ -12,14 +12,16 @@ function normalizeHandles(handles: Handle[]): Handle[] {
 
 async function fetchDomains(
   address: string,
-  cursor: string
+  cursor: string,
+  signal: AbortSignal
 ): Promise<Record<'data' | 'next', any>> {
   const response = await fetch(
     `https://api.unstoppabledomains.com/resolve/owners/${address}/domains?cursor=${cursor}`,
     {
       headers: {
         Authorization: `Bearer ${process.env.UNSTOPPABLE_DOMAINS_API_KEY || ''}`
-      }
+      },
+      signal
     }
   );
 
@@ -46,14 +48,16 @@ export default async function lookupDomains(address: Address, chainId: string): 
     return [];
   }
 
-  const domains: string[] = [];
-  let cursor = '0';
+  return withDeadline(async signal => {
+    const domains: string[] = [];
+    let cursor = '0';
 
-  while (cursor !== null) {
-    const data = await fetchDomains(address, cursor);
-    cursor = data.next?.split('cursor=').pop() || null;
-    domains.push(...data.data.map((domain: any) => domain.meta.domain));
-  }
+    while (cursor !== null) {
+      const data = await fetchDomains(address, cursor, signal);
+      cursor = data.next?.split('cursor=').pop() || null;
+      domains.push(...data.data.map((domain: any) => domain.meta.domain));
+    }
 
-  return normalizeHandles(domains);
+    return normalizeHandles(domains);
+  });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,8 +44,9 @@ export function getProvider(network: number): StaticJsonRpcProvider {
 
 const UPSTREAM_TIMEOUT = 10000;
 
-// Not `AbortSignal.timeout`: it names its error `TimeoutError`, which
-// `isSilencedError` does not match, so every deadline would be reported.
+// `isSilencedError` reads the error name, and the two ways to abort raise
+// different ones: `AbortController` gives `AbortError`, `AbortSignal.timeout`
+// gives `TimeoutError`.
 export async function withDeadline<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,6 +42,21 @@ export function getProvider(network: number): StaticJsonRpcProvider {
   return providers[`_${network}`];
 }
 
+const UPSTREAM_TIMEOUT = 10000;
+
+// Not `AbortSignal.timeout`: it names its error `TimeoutError`, which
+// `isSilencedError` does not match, so every deadline would be reported.
+export async function withDeadline<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT);
+
+  try {
+    return await fn(controller.signal);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export function sha256(str) {
   return createHash('sha256').update(str).digest('hex');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,6 +58,19 @@ export async function withDeadline<T>(fn: (signal: AbortSignal) => Promise<T>): 
   }
 }
 
+// For a callee that takes no signal of its own. This bounds the wait rather
+// than the request: the work already started keeps running, capped only by
+// whatever timeout its own client has.
+export function untilAborted<T>(signal: AbortSignal, work: Promise<T>): Promise<T> {
+  const aborted = new Promise<never>((_, reject) => {
+    if (signal.aborted) return reject(signal.reason);
+
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+  });
+
+  return Promise.race([work, aborted]);
+}
+
 export function sha256(str) {
   return createHash('sha256').update(str).digest('hex');
 }

--- a/test/integration/getOwner/shibarium.test.ts
+++ b/test/integration/getOwner/shibarium.test.ts
@@ -1,0 +1,73 @@
+import { DNSConnect } from '@webinterop/dns-connect';
+import { Address, Handle } from '../../../src/utils';
+
+jest.mock('@webinterop/dns-connect', () => ({
+  DNSConnect: jest.fn()
+}));
+
+const HANDLE = 'boorger.shib';
+const CHAIN_ID = '109';
+const TIMEOUT = 10000;
+
+const mockedDNSConnect = DNSConnect as unknown as jest.Mock;
+
+let getOwner: (handle: Handle, chainId?: string) => Promise<Address>;
+
+const apiKey = process.env.D3_API_KEY_MAINNET;
+
+beforeAll(async () => {
+  process.env.D3_API_KEY_MAINNET = 'test-key';
+  getOwner = (await import('../../../src/getOwner/shibarium')).default;
+});
+
+afterAll(() => {
+  if (apiKey === undefined) {
+    delete process.env.D3_API_KEY_MAINNET;
+  } else {
+    process.env.D3_API_KEY_MAINNET = apiKey;
+  }
+});
+
+// Registered but with no `owner`, which is the shape that sends getOwner on to
+// the DNS resolution path.
+function unclaimed() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({
+      status: 'registered',
+      expirationDate: new Date(Date.now() + 86400e3).toISOString()
+    })
+  } as Response;
+}
+
+describe('getOwner/shibarium deadline', () => {
+  it('bounds the DNS resolution, which takes no signal of its own', async () => {
+    const timers = jest.spyOn(global, 'setTimeout');
+    jest.spyOn(global, 'fetch').mockResolvedValue(unclaimed());
+
+    let reachedDNS: () => void;
+    const atDNS = new Promise<void>(resolve => (reachedDNS = resolve));
+
+    // dns-connect never forwards a signal, so a hung DNS-over-HTTPS request is
+    // indistinguishable from a promise that simply never settles.
+    mockedDNSConnect.mockImplementation(() => ({
+      resolve: () => {
+        reachedDNS();
+        return new Promise(() => undefined);
+      }
+    }));
+
+    const result = getOwner(HANDLE, CHAIN_ID);
+    await atDNS;
+
+    const deadlines = timers.mock.calls.filter(call => call[1] === TIMEOUT);
+    expect(deadlines).toHaveLength(2);
+    (deadlines[1] as unknown as [() => void])[0]();
+
+    await expect(result).rejects.toThrow('This operation was aborted');
+
+    timers.mockRestore();
+  });
+});

--- a/test/integration/lookupDomains/unstoppableDomains.test.ts
+++ b/test/integration/lookupDomains/unstoppableDomains.test.ts
@@ -1,6 +1,14 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import { timeLookupDomainsResponse } from '../../../src/helpers/metrics';
+import lookupDomainsThroughIndex from '../../../src/lookupDomains';
 import lookupDomains, { DEFAULT_CHAIN_ID } from '../../../src/lookupDomains/unstoppableDomains';
 
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
 const ADDRESS = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
+const TIMEOUT = 10000;
 
 function mockFetch(response: { status: number; statusText: string; body: any }) {
   return jest.spyOn(global, 'fetch').mockResolvedValue({
@@ -9,6 +17,18 @@ function mockFetch(response: { status: number; statusText: string; body: any }) 
     statusText: response.statusText,
     json: async () => response.body
   } as Response);
+}
+
+function abortError() {
+  return Object.assign(new Error('This operation was aborted'), { name: 'AbortError' });
+}
+
+async function recordedFor(provider: string) {
+  const metric: any = await timeLookupDomainsResponse.get();
+
+  return metric.values
+    .filter((v: any) => String(v.metricName).endsWith('_count') && v.labels.provider === provider)
+    .map((v: any) => ({ chainId: v.labels.chainId, status: v.labels.status, count: v.value }));
 }
 
 // This resolver reports nothing itself: it throws the original error and
@@ -75,5 +95,86 @@ describe('lookupDomains/unstoppableDomains', () => {
 
     await expect(lookupDomains(ADDRESS, '1')).resolves.toEqual([]);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('lookupDomains/unstoppableDomains deadline', () => {
+  const apiKey = process.env.UNSTOPPABLE_DOMAINS_API_KEY;
+
+  beforeEach(() => {
+    process.env.UNSTOPPABLE_DOMAINS_API_KEY = 'test-key';
+    timeLookupDomainsResponse.reset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (apiKey === undefined) {
+      delete process.env.UNSTOPPABLE_DOMAINS_API_KEY;
+    } else {
+      process.env.UNSTOPPABLE_DOMAINS_API_KEY = apiKey;
+    }
+  });
+
+  it('aborts the request once the deadline passes', async () => {
+    const timers = jest.spyOn(global, 'setTimeout');
+    const signals: AbortSignal[] = [];
+    jest.spyOn(global, 'fetch').mockImplementation(
+      (_url: any, options: any) =>
+        new Promise((_resolve, reject) => {
+          signals.push(options.signal);
+          options.signal.addEventListener('abort', () => reject(abortError()));
+        })
+    );
+
+    const result = lookupDomains(ADDRESS, DEFAULT_CHAIN_ID);
+    await Promise.resolve();
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0].aborted).toBe(false);
+
+    const deadline = timers.mock.calls.find(call => call[1] === TIMEOUT);
+    expect(deadline).toBeDefined();
+    (deadline as unknown as [() => void])[0]();
+
+    await expect(result).rejects.toThrow('This operation was aborted');
+    expect(signals[0].aborted).toBe(true);
+  });
+
+  it('sets one deadline for the whole call, not one per page', async () => {
+    const timers = jest.spyOn(global, 'setTimeout');
+    const signals: AbortSignal[] = [];
+    jest.spyOn(global, 'fetch').mockImplementation((_url: any, options: any) => {
+      signals.push(options.signal);
+      const body =
+        signals.length === 1
+          ? { data: [{ meta: { domain: 'first.sonic' } }], next: '?cursor=1' }
+          : { data: [{ meta: { domain: 'second.sonic' } }], next: null };
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => body
+      } as Response);
+    });
+
+    await expect(lookupDomains(ADDRESS, DEFAULT_CHAIN_ID)).resolves.toEqual([
+      'first.sonic',
+      'second.sonic'
+    ]);
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+    expect(new Set(signals).size).toBe(1);
+    expect(timers.mock.calls.filter(call => call[1] === TIMEOUT)).toHaveLength(1);
+  });
+
+  it('does not report an abort, and still records it in the metric', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(abortError());
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, DEFAULT_CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+    expect(await recordedFor('Unstoppable Domains')).toEqual([
+      { chainId: DEFAULT_CHAIN_ID, status: 0, count: 1 }
+    ]);
   });
 });


### PR DESCRIPTION
`lookupDomains/unstoppableDomains` called the global `fetch` with no signal and
no timeout, so a provider that accepts the connection and then never answers
held the whole `lookup_domains` call open. The fan-out awaits `Promise.all`, and
the per-promise catch from #493 covers a provider that *fails* rather than one
that never settles, so nothing in the application bounded the wait. Its two
siblings each set a deadline of their own, in two different ways, and
`getOwner/shibarium` set none at all.

This puts the deadline behind one `withDeadline` helper and uses it in all three
places. It wraps a whole provider call rather than a single request, so the
providers that paginate are bounded by it too. Where the callee takes no signal
at all, as `getOwner`'s DNS resolution does not, `untilAborted` bounds the wait
instead: the request it started keeps running, but nothing waits on it past the
deadline.

Aborting through an `AbortController` rather than `AbortSignal.timeout` is what
keeps the error ours: `isSilencedError` matches `AbortError` by name. In
`lookupDomains` that means a deadline raises no Sentry event and is still
recorded in the per-provider histogram as a failure. `getOwner` has neither. It
reports through the unconditional capture in `api.ts`, as its undici headers
timeout already did, so there the deadline changes when it reports, not whether.

Closes #531
