### PR TITLE
feat(resolvers): tag captured failures with the provider that produced them

### DIFF
--- a/src/addressResolvers/index.ts
+++ b/src/addressResolvers/index.ts
@@ -70,7 +70,11 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
               status = 1;
             } catch (err) {
               if (!isSilencedError(err, r.MUTED_ERRORS)) {
-                capture(err, { input: { [fnName]: _input } });
+                // A top-level `input` beside `tags` is dropped rather than wrapped.
+                capture(err, {
+                  tags: { provider: r.NAME },
+                  contexts: { input: { [fnName]: _input } }
+                });
               }
             }
             end({ status });

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -28,23 +28,14 @@ type Resolver = {
   resize: boolean;
 };
 
-// Two failures, two policies, deliberately different.
-// A resolver throwing answers false and is not reported. That is the contract
-// each resolver used to implement for itself; it stays silent because the
-// no-data answers are not normalized yet (#511), and reporting before they are
-// would page on every routine upstream 404.
-// Sharp refusing the bytes is reported, because bytes we fetched but cannot
-// process are our problem rather than the upstream's.
-// Either way the wrapper answers false rather than throwing into the image
-// route, which has no guard of its own (#495). Entries with resize: false are
-// not wrapped and keep whatever contract their own module implements.
-function withResize(resolve: ResolverFn): ResolverFn {
+function withResize(name: string, resolve: ResolverFn): ResolverFn {
   return async (...args) => {
     let input: Buffer | false;
 
     try {
       input = await resolve(...args);
     } catch {
+      // Silent on purpose: capturing here reports every routine upstream 404.
       return false;
     }
 
@@ -53,7 +44,8 @@ function withResize(resolve: ResolverFn): ResolverFn {
     try {
       return await resize(input, max, max);
     } catch (err) {
-      capture(err);
+      // A top-level `input` beside `tags` is dropped rather than wrapped.
+      capture(err, { tags: { provider: name }, contexts: { input: { args } } });
       return false;
     }
   };
@@ -96,5 +88,5 @@ type ResolverMap = {
 
 // Without the cast Object.fromEntries widens the keys to string.
 export default Object.fromEntries(
-  RESOLVERS.map(entry => [entry.name, entry.resize ? withResize(entry.fn) : entry.fn])
+  RESOLVERS.map(entry => [entry.name, entry.resize ? withResize(entry.name, entry.fn) : entry.fn])
 ) as ResolverMap;

--- a/test/unit/addressResolvers.test.ts
+++ b/test/unit/addressResolvers.test.ts
@@ -102,6 +102,22 @@ describe('addressResolvers - resolver failures', () => {
     });
   });
 
+  it.each(RESOLVERS.map(resolver => [resolver.NAME, resolver] as const))(
+    'attributes a %s failure to itself',
+    async (name, resolver) => {
+      const error = new Error('boom');
+      jest.spyOn(resolver, 'lookupAddresses').mockRejectedValue(error);
+
+      await lookupAddresses([ADDRESS]);
+
+      expect(capture).toHaveBeenCalledTimes(1);
+      expect(capture).toHaveBeenCalledWith(error, {
+        tags: { provider: name },
+        contexts: { input: { lookupAddresses: [ADDRESS] } }
+      });
+    }
+  );
+
   it('keeps the other resolvers results when one fails', async () => {
     jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(new Error('boom'));
     jest.spyOn(shibarium, 'lookupAddresses').mockResolvedValue({ [ADDRESS]: 'boorger.shib' });

--- a/test/unit/addressResolvers.test.ts
+++ b/test/unit/addressResolvers.test.ts
@@ -67,7 +67,10 @@ describe('addressResolvers - resolver failures', () => {
 
     await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
     expect(capture).toHaveBeenCalledTimes(1);
-    expect(capture).toHaveBeenCalledWith(error, { input: { lookupAddresses: [ADDRESS] } });
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Ens' },
+      contexts: { input: { lookupAddresses: [ADDRESS] } }
+    });
   });
 
   it('does not capture a silenced error', async () => {
@@ -93,7 +96,10 @@ describe('addressResolvers - resolver failures', () => {
     jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);
 
     await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
-    expect(capture).toHaveBeenCalledWith(error, { input: { lookupAddresses: [ADDRESS] } });
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Ens' },
+      contexts: { input: { lookupAddresses: [ADDRESS] } }
+    });
   });
 
   it('keeps the other resolvers results when one fails', async () => {

--- a/test/unit/resolvers/failureContract.test.ts
+++ b/test/unit/resolvers/failureContract.test.ts
@@ -29,12 +29,14 @@ describe('resolvers - failure contract', () => {
 
     await expect(resolvers.ens(ADDRESS)).resolves.toBe(false);
     expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { provider: 'ens' },
+      contexts: { input: { args: [ADDRESS] } }
+    });
   });
 
-  // api.ts hands the fallback resolver's result straight to resize() with no
-  // guard of its own, so a fallback answering false would make sharp throw into
-  // the unguarded image route (#495). Until that route is fixed the fallbacks
-  // have to stay outside the false-on-failure contract.
+  // A fallback answering false makes sharp throw on the image route, which has
+  // no guard of its own.
   it('leaves the fallback resolvers throwing rather than answering false', async () => {
     const error = new Error('boom');
     (blockie as jest.Mock).mockRejectedValue(error);

--- a/test/unit/resolvers/failureContract.test.ts
+++ b/test/unit/resolvers/failureContract.test.ts
@@ -1,13 +1,26 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import resolvers from '../../../src/resolvers';
+import basename from '../../../src/resolvers/basename';
 import blockie from '../../../src/resolvers/blockie';
 import ens from '../../../src/resolvers/ens';
+import lens from '../../../src/resolvers/lens';
+import starknet from '../../../src/resolvers/starknet';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
 jest.mock('../../../src/resolvers/ens', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../src/resolvers/basename', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../src/resolvers/lens', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../src/resolvers/starknet', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../../../src/resolvers/blockie', () => ({ __esModule: true, default: jest.fn() }));
 
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+
+const WRAPPED = [
+  ['ens', ens],
+  ['basename', basename],
+  ['lens', lens],
+  ['starknet', starknet]
+] as const;
 
 describe('resolvers - failure contract', () => {
   it('answers false when a wrapped resolver throws', async () => {
@@ -24,13 +37,13 @@ describe('resolvers - failure contract', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
-  it('reports bytes sharp cannot process, and still answers false', async () => {
-    (ens as jest.Mock).mockResolvedValue(Buffer.from('not an image'));
+  it.each(WRAPPED)('attributes %s bytes sharp cannot process to itself', async (name, fn) => {
+    (fn as jest.Mock).mockResolvedValue(Buffer.from('not an image'));
 
-    await expect(resolvers.ens(ADDRESS)).resolves.toBe(false);
+    await expect(resolvers[name](ADDRESS)).resolves.toBe(false);
     expect(capture).toHaveBeenCalledTimes(1);
     expect(capture).toHaveBeenCalledWith(expect.any(Error), {
-      tags: { provider: 'ens' },
+      tags: { provider: name },
       contexts: { input: { args: [ADDRESS] } }
     });
   });


### PR DESCRIPTION
`lookupDomains` already tags the provider on every capture. These are the two families that still do not, so the same fact is now sent the same way everywhere.

`src/addressResolvers/index.ts` reported nine resolvers under one shape with nothing to tell them apart, though the name was already in scope as a Prometheus label two lines up. `src/resolvers/index.ts` reported sharp failures as a bare libvips message with neither a name nor an input, which is why tracing one back to an address was a manual job.

Two things that are not one-liners:

**The shape has to be the explicit two-key form.** Writing `{ input, tags }` looks correct and compiles, and silently loses the input. The auto-wrap that turns a bare `{ input }` into `{ contexts: { input } }` only runs when the object carries no reserved key, so adding `tags` skips it and leaves `input` as a top-level key that is not part of the event. The naive form and the correct one, through the real normalizer:

```
NAIVE   {input,tags}      -> {"input":{...},"tags":{"provider":"Ens"}}              input dropped
THIS PR {tags,contexts}   -> {"tags":{"provider":"Ens"},"contexts":{"input":{...}}} input kept
```

Both existing assertions in `test/unit/addressResolvers.test.ts` pinned the old shape and move with it. The resolver map had no capture assertion, so one is added. Rewriting either call as the one-liner compiles clean and turns those tests red, which is the point of pinning them.

**The resolver map did not have the name in scope.** `withResize` received only the function, so it takes the name too and the map build passes it.

## Comments

The block above `withResize` is gone. Testing it line by line, everything in it either restated the code or explained the reasoning, and both catches are already pinned by tests. What survived is the one thing no test states: the resolver catch is silent deliberately, because capturing there reports every routine upstream 404. That is now one line at the catch it applies to. The issue references went with the rest.

The same trim applies to a comment in the test file, which carried a reference for the same reason.
