### PR TITLE
refactor(resolvers): split the resize flag from the failure contract

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -55,13 +55,7 @@ function withResize(name: string, resolve: ResolverFn): ResolverFn {
   };
 }
 
-// Covers and logos take resize: false so the base cache keeps its upstream
-// aspect ratio: resize() passes no fit option, so sharp center-crops, and a
-// banner cached as a square can never be served wide again (api.ts resizes
-// every response to the requested w x h regardless).
-// blockie and jazzicon take resize: false because they already call resize()
-// themselves, and failureContract: false because api.ts hands the fallback's
-// result straight to resize(), which throws on a false.
+// blockie and jazzicon resize themselves.
 export const RESOLVERS = [
   { name: 'blockie', fn: blockie, resize: false, failureContract: false },
   { name: 'jazzicon', fn: jazzicon, resize: false, failureContract: false },

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -26,19 +26,23 @@ type Resolver = {
   name: string;
   fn: ResolverFn;
   resize: boolean;
+  failureContract: boolean;
 };
 
-function withResize(name: string, resolve: ResolverFn): ResolverFn {
+function withFailureContract(resolve: ResolverFn): ResolverFn {
   return async (...args) => {
-    let input: Buffer | false;
-
     try {
-      input = await resolve(...args);
+      return await resolve(...args);
     } catch {
       // Silent on purpose: capturing here reports every routine upstream 404.
       return false;
     }
+  };
+}
 
+function withResize(name: string, resolve: ResolverFn): ResolverFn {
+  return async (...args) => {
+    const input = await resolve(...args);
     if (!input) return false;
 
     try {
@@ -55,27 +59,26 @@ function withResize(name: string, resolve: ResolverFn): ResolverFn {
 // aspect ratio: resize() passes no fit option, so sharp center-crops, and a
 // banner cached as a square can never be served wide again (api.ts resizes
 // every response to the requested w x h regardless).
-// blockie and jazzicon take it for a different reason: api.ts feeds their
-// result straight into resize(), so they resize themselves and must never
-// answer false.
+// blockie and jazzicon take failureContract: false because api.ts hands the
+// fallback's result straight to resize(), which throws on a false.
 const RESOLVERS = [
-  { name: 'blockie', fn: blockie, resize: false },
-  { name: 'jazzicon', fn: jazzicon, resize: false },
-  { name: 'ens', fn: ens, resize: true },
-  { name: 'basename', fn: basename, resize: true },
-  { name: 'trustwallet', fn: trustwallet, resize: true },
-  { name: 'coingecko', fn: coingecko, resize: true },
-  { name: 'snapshot', fn: sResolveUserAvatar, resize: true },
-  { name: 'user-cover', fn: sResolveUserCover, resize: false },
-  { name: 'space', fn: sResolveSpaceAvatar, resize: true },
-  { name: 'space-cover', fn: sResolveSpaceCover, resize: false },
-  { name: 'space-logo', fn: sResolveSpaceLogo, resize: false },
-  { name: 'space-sx', fn: sxResolveAvatar, resize: true },
-  { name: 'space-cover-sx', fn: sxResolveCover, resize: false },
-  { name: 'selfid', fn: selfid, resize: true },
-  { name: 'lens', fn: lens, resize: true },
-  { name: 'starknet', fn: starknet, resize: true },
-  { name: 'farcaster', fn: farcaster, resize: true }
+  { name: 'blockie', fn: blockie, resize: false, failureContract: false },
+  { name: 'jazzicon', fn: jazzicon, resize: false, failureContract: false },
+  { name: 'ens', fn: ens, resize: true, failureContract: true },
+  { name: 'basename', fn: basename, resize: true, failureContract: true },
+  { name: 'trustwallet', fn: trustwallet, resize: true, failureContract: true },
+  { name: 'coingecko', fn: coingecko, resize: true, failureContract: true },
+  { name: 'snapshot', fn: sResolveUserAvatar, resize: true, failureContract: true },
+  { name: 'user-cover', fn: sResolveUserCover, resize: false, failureContract: true },
+  { name: 'space', fn: sResolveSpaceAvatar, resize: true, failureContract: true },
+  { name: 'space-cover', fn: sResolveSpaceCover, resize: false, failureContract: true },
+  { name: 'space-logo', fn: sResolveSpaceLogo, resize: false, failureContract: true },
+  { name: 'space-sx', fn: sxResolveAvatar, resize: true, failureContract: true },
+  { name: 'space-cover-sx', fn: sxResolveCover, resize: false, failureContract: true },
+  { name: 'selfid', fn: selfid, resize: true, failureContract: true },
+  { name: 'lens', fn: lens, resize: true, failureContract: true },
+  { name: 'starknet', fn: starknet, resize: true, failureContract: true },
+  { name: 'farcaster', fn: farcaster, resize: true, failureContract: true }
 ] as const satisfies readonly Resolver[];
 
 // Returning E['fn'] here lets a caller treat a wrapped resolver as one that
@@ -88,5 +91,9 @@ type ResolverMap = {
 
 // Without the cast Object.fromEntries widens the keys to string.
 export default Object.fromEntries(
-  RESOLVERS.map(entry => [entry.name, entry.resize ? withResize(entry.name, entry.fn) : entry.fn])
+  RESOLVERS.map(entry => {
+    const resolve = entry.resize ? withResize(entry.name, entry.fn) : entry.fn;
+
+    return [entry.name, entry.failureContract ? withFailureContract(resolve) : resolve];
+  })
 ) as ResolverMap;

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -59,9 +59,10 @@ function withResize(name: string, resolve: ResolverFn): ResolverFn {
 // aspect ratio: resize() passes no fit option, so sharp center-crops, and a
 // banner cached as a square can never be served wide again (api.ts resizes
 // every response to the requested w x h regardless).
-// blockie and jazzicon take failureContract: false because api.ts hands the
-// fallback's result straight to resize(), which throws on a false.
-const RESOLVERS = [
+// blockie and jazzicon take resize: false because they already call resize()
+// themselves, and failureContract: false because api.ts hands the fallback's
+// result straight to resize(), which throws on a false.
+export const RESOLVERS = [
   { name: 'blockie', fn: blockie, resize: false, failureContract: false },
   { name: 'jazzicon', fn: jazzicon, resize: false, failureContract: false },
   { name: 'ens', fn: ens, resize: true, failureContract: true },

--- a/src/resolvers/snapshot.ts
+++ b/src/resolvers/snapshot.ts
@@ -115,25 +115,21 @@ function createPropertyResolver(entity: Entity, property: Property) {
 
     if (!Object.keys(API_URLS).includes(networkId)) return false;
 
-    try {
-      if (offchainNetworks.includes(networkId) || entity === 'user') {
-        value = await getOffchainProperty(
-          offchainNetworks.includes(networkId) ? networkId : defaultOffchainNetwork,
-          normalizeEvmAddress(address),
-          entity,
-          property
-        );
-      } else {
-        value = await getOnchainProperty(networkId, address, entity, property);
-      }
-
-      if (!value) return false;
-
-      const url = getUrl(value);
-      return await fetchHttpImage(url);
-    } catch {
-      return false;
+    if (offchainNetworks.includes(networkId) || entity === 'user') {
+      value = await getOffchainProperty(
+        offchainNetworks.includes(networkId) ? networkId : defaultOffchainNetwork,
+        normalizeEvmAddress(address),
+        entity,
+        property
+      );
+    } else {
+      value = await getOnchainProperty(networkId, address, entity, property);
     }
+
+    if (!value) return false;
+
+    const url = getUrl(value);
+    return await fetchHttpImage(url);
   };
 }
 

--- a/src/resolvers/space-sx.ts
+++ b/src/resolvers/space-sx.ts
@@ -34,16 +34,10 @@ async function getSpaceProperty(key: string, url: string, property: 'avatar' | '
 
 function createPropertyResolver(property: 'avatar' | 'cover') {
   return async key => {
-    try {
-      const value = await Promise.any(
-        SUBGRAPH_URLS.map(url => getSpaceProperty(key, url, property))
-      );
+    const value = await Promise.any(SUBGRAPH_URLS.map(url => getSpaceProperty(key, url, property)));
 
-      const url = getUrl(value);
-      return await fetchHttpImage(url);
-    } catch {
-      return false;
-    }
+    const url = getUrl(value);
+    return await fetchHttpImage(url);
   };
 }
 

--- a/test/unit/graphQlEnvelope.test.ts
+++ b/test/unit/graphQlEnvelope.test.ts
@@ -94,7 +94,7 @@ describe('graphQlCall callers surface an envelope failure', () => {
     it('does not use a payload the upstream flagged as an error', async () => {
       respondWith(upstreamFailure('hub is down', { entry: { avatar: IMAGE_URL } }));
 
-      await expect(resolveUserAvatar(ADDRESS)).resolves.toBe(false);
+      await expect(resolveUserAvatar(ADDRESS)).rejects.toThrow('hub is down');
       expect(fetchHttpImage).not.toHaveBeenCalled();
     });
   });
@@ -105,7 +105,9 @@ describe('graphQlCall callers surface an envelope failure', () => {
         upstreamFailure('subgraph is down', { spaces: [{ metadata: { avatar: IMAGE_URL } }] })
       );
 
-      await expect(resolveSpaceAvatar(ADDRESS, 1, 'eth')).resolves.toBe(false);
+      await expect(resolveSpaceAvatar(ADDRESS, 1, 'eth')).rejects.toThrow(
+        '[api.snapshot.box] subgraph is down'
+      );
       expect(fetchHttpImage).not.toHaveBeenCalled();
     });
   });
@@ -116,14 +118,18 @@ describe('graphQlCall callers surface an envelope failure', () => {
         upstreamFailure('subgraph is down', { spaces: [{ metadata: { avatar: IMAGE_URL } }] })
       );
 
-      await expect(resolveSxSpaceAvatar(ADDRESS)).resolves.toBe(false);
+      // Promise.any reports both APIs failing as one AggregateError, so the
+      // upstream message is in `errors` rather than in the message.
+      await expect(resolveSxSpaceAvatar(ADDRESS)).rejects.toMatchObject({
+        errors: expect.arrayContaining([
+          expect.objectContaining({ message: '[api.snapshot.box] subgraph is down' })
+        ])
+      });
       expect(fetchHttpImage).not.toHaveBeenCalled();
     });
   });
 
   describe('src/resolvers/lens.ts - account', () => {
-    // Unlike the two above, lens no longer answers false for itself: its catch
-    // moved to the resolver map, which is where that answer is now given.
     it('does not use a payload the upstream flagged as an error', async () => {
       respondWith(
         upstreamFailure('Rate limit exceeded', { account: { metadata: { picture: IMAGE_URL } } })

--- a/test/unit/graphQlEnvelope.test.ts
+++ b/test/unit/graphQlEnvelope.test.ts
@@ -118,8 +118,6 @@ describe('graphQlCall callers surface an envelope failure', () => {
         upstreamFailure('subgraph is down', { spaces: [{ metadata: { avatar: IMAGE_URL } }] })
       );
 
-      // Promise.any reports both APIs failing as one AggregateError, so the
-      // upstream message is in `errors` rather than in the message.
       await expect(resolveSxSpaceAvatar(ADDRESS)).rejects.toMatchObject({
         errors: expect.arrayContaining([
           expect.objectContaining({ message: '[api.snapshot.box] subgraph is down' })

--- a/test/unit/resolvers.test.ts
+++ b/test/unit/resolvers.test.ts
@@ -1,7 +1,6 @@
 import constants from '../../src/constants.json';
 import resolvers, { RESOLVERS } from '../../src/resolvers';
 
-// The only two values api.ts can pass as `fallback` (src/utils.ts).
 const FALLBACKS = ['blockie', 'jazzicon'];
 
 const NAMES = [
@@ -41,9 +40,6 @@ describe('resolvers', () => {
     expect(Object.keys(resolvers)).toEqual([...NAMES]);
   });
 
-  // Nothing else stops a chained entry being registered with
-  // failureContract: false, and the throw it would then let out reaches the
-  // image route, which has no guard of its own.
   it('puts every resolver a chain can reach under the failure contract', () => {
     const chained = new Set<string>(Object.values(constants.resolvers).flat());
     const contracted = new Set<string>(

--- a/test/unit/resolvers.test.ts
+++ b/test/unit/resolvers.test.ts
@@ -1,4 +1,8 @@
-import resolvers from '../../src/resolvers';
+import constants from '../../src/constants.json';
+import resolvers, { RESOLVERS } from '../../src/resolvers';
+
+// The only two values api.ts can pass as `fallback` (src/utils.ts).
+const FALLBACKS = ['blockie', 'jazzicon'];
 
 const NAMES = [
   'blockie',
@@ -35,5 +39,23 @@ describe('resolvers', () => {
 
   it('exposes every registered resolver, in order', () => {
     expect(Object.keys(resolvers)).toEqual([...NAMES]);
+  });
+
+  // Nothing else stops a chained entry being registered with
+  // failureContract: false, and the throw it would then let out reaches the
+  // image route, which has no guard of its own.
+  it('puts every resolver a chain can reach under the failure contract', () => {
+    const chained = new Set<string>(Object.values(constants.resolvers).flat());
+    const contracted = new Set<string>(
+      RESOLVERS.filter(entry => entry.failureContract).map(entry => entry.name)
+    );
+
+    expect([...chained].filter(name => !contracted.has(name))).toEqual([]);
+  });
+
+  it('leaves the fallback resolvers outside it', () => {
+    expect(RESOLVERS.filter(entry => !entry.failureContract).map(entry => entry.name)).toEqual(
+      FALLBACKS
+    );
   });
 });

--- a/test/unit/resolvers/failureContract.test.ts
+++ b/test/unit/resolvers/failureContract.test.ts
@@ -88,8 +88,6 @@ describe('resolvers - failure contract', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
-  // A fallback answering false makes sharp throw on the image route, which has
-  // no guard of its own.
   it('leaves the fallback resolvers throwing rather than answering false', async () => {
     const error = new Error('boom');
     (blockie as jest.Mock).mockRejectedValue(error);

--- a/test/unit/resolvers/failureContract.test.ts
+++ b/test/unit/resolvers/failureContract.test.ts
@@ -34,7 +34,7 @@ jest.mock('../../../src/resolvers/space-sx', () => ({
 
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 
-const WRAPPED = [
+const RESIZED = [
   ['ens', ens],
   ['basename', basename],
   ['lens', lens],
@@ -63,7 +63,7 @@ describe('resolvers - failure contract', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
-  it.each(WRAPPED)('attributes %s bytes sharp cannot process to itself', async (name, fn) => {
+  it.each(RESIZED)('attributes %s bytes sharp cannot process to itself', async (name, fn) => {
     (fn as jest.Mock).mockResolvedValue(Buffer.from('not an image'));
 
     await expect(resolvers[name](ADDRESS)).resolves.toBe(false);

--- a/test/unit/resolvers/failureContract.test.ts
+++ b/test/unit/resolvers/failureContract.test.ts
@@ -4,6 +4,12 @@ import basename from '../../../src/resolvers/basename';
 import blockie from '../../../src/resolvers/blockie';
 import ens from '../../../src/resolvers/ens';
 import lens from '../../../src/resolvers/lens';
+import {
+  resolveSpaceCover,
+  resolveSpaceLogo,
+  resolveUserCover
+} from '../../../src/resolvers/snapshot';
+import { resolveCover } from '../../../src/resolvers/space-sx';
 import starknet from '../../../src/resolvers/starknet';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
@@ -12,6 +18,19 @@ jest.mock('../../../src/resolvers/basename', () => ({ __esModule: true, default:
 jest.mock('../../../src/resolvers/lens', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../../../src/resolvers/starknet', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('../../../src/resolvers/blockie', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../src/resolvers/snapshot', () => ({
+  __esModule: true,
+  resolveUserAvatar: jest.fn(),
+  resolveUserCover: jest.fn(),
+  resolveSpaceAvatar: jest.fn(),
+  resolveSpaceCover: jest.fn(),
+  resolveSpaceLogo: jest.fn()
+}));
+jest.mock('../../../src/resolvers/space-sx', () => ({
+  __esModule: true,
+  resolveAvatar: jest.fn(),
+  resolveCover: jest.fn()
+}));
 
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 
@@ -20,6 +39,13 @@ const WRAPPED = [
   ['basename', basename],
   ['lens', lens],
   ['starknet', starknet]
+] as const;
+
+const UNRESIZED = [
+  ['user-cover', resolveUserCover],
+  ['space-cover', resolveSpaceCover],
+  ['space-logo', resolveSpaceLogo],
+  ['space-cover-sx', resolveCover]
 ] as const;
 
 describe('resolvers - failure contract', () => {
@@ -46,6 +72,20 @@ describe('resolvers - failure contract', () => {
       tags: { provider: name },
       contexts: { input: { args: [ADDRESS] } }
     });
+  });
+
+  it.each(UNRESIZED)('answers false when %s throws', async (name, fn) => {
+    (fn as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    await expect(resolvers[name](ADDRESS)).resolves.toBe(false);
+  });
+
+  it.each(UNRESIZED)('serves %s at the size the upstream sent', async (name, fn) => {
+    const bytes = Buffer.from('not an image');
+    (fn as jest.Mock).mockResolvedValue(bytes);
+
+    await expect(resolvers[name](ADDRESS)).resolves.toBe(bytes);
+    expect(capture).not.toHaveBeenCalled();
   });
 
   // A fallback answering false makes sharp throw on the image route, which has


### PR DESCRIPTION
`resize` was answering two unrelated questions. Whether the base cache keeps the upstream aspect ratio, and whether the entry gets a wrapper at all. Covers and logos want the first and not the second, and one flag cannot say that, so they sit outside the failure contract for a reason that has nothing to do with failure.

The registry carries the two answers separately now and the map composes them: resize the entry if it asks to be resized, then put it under the contract if it belongs there. `user-cover`, `space-cover`, `space-logo` and `space-cover-sx` come under the contract while staying unresized.

## The factory catches go with it

`createPropertyResolver` in `snapshot.ts` and in `space-sx.ts` kept theirs in #529 because they serve bare entries as well as wrapped ones: taking the catch out would have taken it away from the bare ones in the same edit and let them throw into the image route, which has no guard of its own (#495). Every entry those factories produce now has a wrapper to fall back on, so both come out. That is the last of the catch move.

Nothing changes for a caller. `src/resolvers/index.ts` is the only production consumer of these modules, so every production call already goes through the map: before, the factory caught and answered `false`; now the wrapper catches and answers `false`. No new Sentry volume either, because the contract wrapper is as silent as the catches it replaces.

## blockie and jazzicon stay outside the contract

`api.ts` hands the fallback resolver's result straight to `resize()`, and guards neither call, so a fallback answering `false` and a fallback that throws both end as an unhandled rejection out of the route. The exemption does not keep the route alive, it surfaces the resolver's own error rather than sharp's. It is the one combination the split deliberately does not enable, and the case pinning it in `test/unit/resolvers/failureContract.test.ts` is untouched.

## Tests

`test/unit/graphQlEnvelope.test.ts` imports the two factories directly and asserted they answer `false` on a flagged envelope, which is the contract this PR moves out of them. Those cases now assert the rejection, the way the `lens` case did in #529. What the file is actually about, that a payload the upstream flagged is never fetched, is unchanged throughout.

The failure contract file picks up the entries that just joined it: that they answer `false` when the factory throws, and that they still come back at the size the upstream sent. The second is what goes red if the two flags are ever folded back into one.

The registry gets an assertion of its own, because the flag now decides on its own whether an entry can throw out of the map, where `resize: true` used to be a total guard. A wrong value compiles and passes and only shows up as a request that never answers, so the rule is written down: every resolver a chain in `constants.json` can reach is under the contract, and the only entries outside it are the two fallbacks.

## Left for later

Guarding the fallback call in `api.ts` rather than exempting two resolvers from the contract is the deeper fix, and it is the reason the exemption exists at all. It changes behaviour, since a broken fallback would answer a 500 instead of hanging, so it is not folded in here.

Closes #537. Refs #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

