### PR TITLE
refactor(resolvers): normalize each resolver's no-data answer, and harden isSilencedError

### DIFF
--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -1,4 +1,9 @@
 export function isSilencedError(error: any, additionalMessages?: string[]): boolean {
+  // A rejection carries whatever it was given, null included. There is nothing
+  // in one to classify, and reporting it is not an option either: `capture`
+  // dereferences it and throws, from inside the catch block that called this.
+  if (!error) return true;
+
   // An abort is always one of our own deadlines, and each transport words it differently.
   if (error.name === 'AbortError') return true;
 

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -1,12 +1,27 @@
 import http from 'http';
 import https from 'https';
+import { getAddress } from '@ethersproject/address';
 import axios from 'axios';
+import { isStarknetAddress } from './address';
 
 export const axiosDefaultParams = {
   httpAgent: new http.Agent({ keepAlive: true }),
   httpsAgent: new https.Agent({ keepAlive: true }),
   timeout: 5e3
 };
+
+// Spaces are keyed by address on the onchain APIs, and both accept the raw id
+// as well as the checksummed one. An id that is not an address is not a space
+// there, so it is no-data rather than something to ask about.
+export function spaceIds(id: string): string[] | null {
+  if (isStarknetAddress(id)) return [id];
+
+  try {
+    return [id, getAddress(id)];
+  } catch {
+    return null;
+  }
+}
 
 export async function fetchHttpImage(url: string): Promise<Buffer> {
   return (

--- a/src/resolvers/image/coingecko.ts
+++ b/src/resolvers/image/coingecko.ts
@@ -1,5 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import { fetchHttpImage } from '../../helpers/http';
+import { httpError } from '../../utils';
 
 const API_KEY = process.env.COINGECKO_API_KEY;
 
@@ -22,8 +23,12 @@ export default async function resolve(address: string, chainId: string) {
   const checksum = getAddress(address);
   const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
 
-  const data = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } }).then(res =>
-    res.json()
-  );
-  return await fetchHttpImage(data?.image?.large);
+  const response = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } });
+  if (response.status === 404) return false;
+  if (!response.ok) throw httpError('coingecko', response.status, response.statusText);
+
+  const data = await response.json();
+  if (!data?.image?.large) return false;
+
+  return await fetchHttpImage(data.image.large);
 }

--- a/src/resolvers/image/farcaster.ts
+++ b/src/resolvers/image/farcaster.ts
@@ -2,7 +2,7 @@ import { getAddress } from '@ethersproject/address';
 import fetch from 'node-fetch';
 import { max } from '../../constants.json';
 import { fetchHttpImage } from '../../helpers/http';
-import { Address } from '../../utils';
+import { Address, httpError } from '../../utils';
 
 const NEYNAR_API_URL = 'https://api.neynar.com/v2/farcaster/user/bulk-by-address';
 const API_KEY = process.env.NEYNAR_API_KEY ?? '';
@@ -26,21 +26,18 @@ function normalizeAddress(address: Address): Address | null {
 }
 
 async function fetchAddressImageUrl(normalizedAddress: string): Promise<string | null> {
-  try {
-    const response = await fetch(`${NEYNAR_API_URL}?addresses=${normalizedAddress}`, {
-      headers: { Accept: 'application/json', api_key: API_KEY }
-    });
+  const response = await fetch(`${NEYNAR_API_URL}?addresses=${normalizedAddress}`, {
+    headers: { Accept: 'application/json', api_key: API_KEY }
+  });
 
-    if (!response.ok) {
-      throw new Error(`Invalid network response (${response.url} ${response.status})`);
-    }
+  // Neynar answers 404 for an address with no Farcaster account, which is the
+  // routine no-avatar case rather than a failure.
+  if (response.status === 404) return null;
+  if (!response.ok) throw httpError('farcaster', response.status, response.statusText);
 
-    const data: Record<Address, UserDetails[]> = await response.json();
+  const data: Record<Address, UserDetails[]> = await response.json();
 
-    return data[normalizedAddress.toLowerCase()]?.[0].pfp_url;
-  } catch {
-    return null;
-  }
+  return data[normalizedAddress.toLowerCase()]?.[0]?.pfp_url ?? null;
 }
 
 export default async function resolve(address: string): Promise<Buffer | false> {

--- a/src/resolvers/image/snapshot.ts
+++ b/src/resolvers/image/snapshot.ts
@@ -1,7 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import { defaultOffchainNetwork, offchainNetworks } from '../../constants.json';
-import { isStarknetAddress } from '../../helpers/address';
-import { fetchHttpImage } from '../../helpers/http';
+import { fetchHttpImage, spaceIds } from '../../helpers/http';
 import { getUrl, graphQlCall } from '../../utils';
 
 const UNIFIED_API_URL = 'https://api.snapshot.box';
@@ -76,10 +75,12 @@ async function getOnchainProperty(
   entity: Entity,
   property: Property
 ) {
-  const ids = [id];
-  if (!isStarknetAddress(id)) {
-    ids.push(getAddress(id));
-  }
+  // The onchain API's SpaceMetadataItem carries no logo field, so asking for
+  // one is a guaranteed validation error rather than a miss.
+  if (property === 'logo') return null;
+
+  const ids = spaceIds(id);
+  if (!ids) return null;
 
   const {
     data: {

--- a/src/resolvers/image/space-sx.ts
+++ b/src/resolvers/image/space-sx.ts
@@ -1,16 +1,13 @@
-import { getAddress } from '@ethersproject/address';
-import { isStarknetAddress } from '../../helpers/address';
-import { fetchHttpImage } from '../../helpers/http';
+import { fetchHttpImage, spaceIds } from '../../helpers/http';
 import { getUrl, graphQlCall } from '../../utils';
 
 const SUBGRAPH_URLS = ['https://api.snapshot.box', 'https://testnet-api.snapshot.box'];
 
-async function getSpaceProperty(key: string, url: string, property: 'avatar' | 'cover') {
-  const ids = [key];
-  if (!isStarknetAddress(key)) {
-    ids.push(getAddress(key));
-  }
-
+async function getSpaceProperty(
+  ids: string[],
+  url: string,
+  property: 'avatar' | 'cover'
+): Promise<string | null> {
   const {
     data: {
       data: { spaces }
@@ -27,17 +24,29 @@ async function getSpaceProperty(key: string, url: string, property: 'avatar' | '
     { ids }
   );
 
-  const result = spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0];
-
-  return result || Promise.reject(false);
+  return spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0] ?? null;
 }
 
 function createPropertyResolver(property: 'avatar' | 'cover') {
   return async key => {
-    const value = await Promise.any(SUBGRAPH_URLS.map(url => getSpaceProperty(key, url, property)));
+    const ids = spaceIds(key);
+    if (!ids) return false;
 
-    const url = getUrl(value);
-    return await fetchHttpImage(url);
+    const settled = await Promise.allSettled(
+      SUBGRAPH_URLS.map(url => getSpaceProperty(ids, url, property))
+    );
+    const answers = settled.flatMap(result =>
+      result.status === 'fulfilled' ? [result.value] : []
+    );
+
+    // One API down while the other answers "no such space" is still no-data.
+    // Keeping that resilience is why both are asked at all.
+    if (!answers.length) throw (settled[0] as PromiseRejectedResult).reason;
+
+    const value = answers.find(Boolean);
+    if (!value) return false;
+
+    return await fetchHttpImage(getUrl(value));
   };
 }
 

--- a/src/resolvers/image/starknet.ts
+++ b/src/resolvers/image/starknet.ts
@@ -7,10 +7,8 @@ import { getUrl } from '../../utils';
 const DEFAULT_IMG_URL = 'https://starknet.id/api/identicons/0';
 const provider = getProvider('0x534e5f4d41494e');
 
-function normalizeAddress(address: string): string {
-  if (!address.match(/^(0x)?[0-9a-fA-F]{64}$/)) throw new Error('Invalid starknet address');
-
-  return address;
+function normalizeAddress(address: string): string | null {
+  return /^(0x)?[0-9a-fA-F]{64}$/.test(address) ? address : null;
 }
 
 async function getStarknetAddress(domain: string): Promise<string | null> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -287,6 +287,15 @@ export type GraphQlResponse<T = any> = {
   errors?: { message?: string }[];
 };
 
+// Both locations are load-bearing: isSilencedError reads `status` and
+// `response.status`, and a status only in the message string is unreachable to it.
+export function httpError(source: string, status: number, message: string) {
+  return Object.assign(new Error(`[${source}] ${message}`), {
+    status,
+    response: { status }
+  });
+}
+
 function graphQlEnvelopeError(url: string, status: number, message: string) {
   let source = url;
   try {
@@ -295,12 +304,7 @@ function graphQlEnvelopeError(url: string, status: number, message: string) {
     // Not an absolute url; keep the whole string as the source.
   }
 
-  // Both locations are load-bearing: isSilencedError reads `status` and
-  // `response.status`, and a status only in the message string is unreachable to it.
-  return Object.assign(new Error(`[${source}] ${message}`), {
-    status,
-    response: { status }
-  });
+  return httpError(source, status, message);
 }
 
 export async function graphQlCall<T = any>(

--- a/test/integration/helpers/errors.test.ts
+++ b/test/integration/helpers/errors.test.ts
@@ -25,6 +25,10 @@ describe('isSilencedError', () => {
     expect(isSilencedError(wrapped)).toBe(true);
   });
 
+  it.each([null, undefined, false])('silences a rejection carrying %p', value => {
+    expect(isSilencedError(value)).toBe(true);
+  });
+
   it('silences an axios 504 (status on error.response)', () => {
     // Shape observed from Sentry STAMP-7: axios throws with the HTTP status
     // on error.response.status, while error.code is 'ERR_BAD_RESPONSE'.

--- a/test/unit/graphQlEnvelope.test.ts
+++ b/test/unit/graphQlEnvelope.test.ts
@@ -118,11 +118,9 @@ describe('graphQlCall callers surface an envelope failure', () => {
         upstreamFailure('subgraph is down', { spaces: [{ metadata: { avatar: IMAGE_URL } }] })
       );
 
-      await expect(resolveSxSpaceAvatar(ADDRESS)).rejects.toMatchObject({
-        errors: expect.arrayContaining([
-          expect.objectContaining({ message: '[api.snapshot.box] subgraph is down' })
-        ])
-      });
+      await expect(resolveSxSpaceAvatar(ADDRESS)).rejects.toThrow(
+        '[api.snapshot.box] subgraph is down'
+      );
       expect(fetchHttpImage).not.toHaveBeenCalled();
     });
   });

--- a/test/unit/resolvers/image/noData.test.ts
+++ b/test/unit/resolvers/image/noData.test.ts
@@ -1,0 +1,134 @@
+import axios from 'axios';
+import nodeFetch from 'node-fetch';
+import farcaster from '../../../../src/resolvers/image/farcaster';
+import { resolveSpaceAvatar, resolveSpaceLogo } from '../../../../src/resolvers/image/snapshot';
+import { resolveAvatar as resolveSxAvatar } from '../../../../src/resolvers/image/space-sx';
+import starknet from '../../../../src/resolvers/image/starknet';
+
+jest.mock('axios', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('node-fetch', () => ({ __esModule: true, default: jest.fn() }));
+
+jest.mock('../../../../src/helpers/http', () => ({
+  ...jest.requireActual('../../../../src/helpers/http'),
+  fetchHttpImage: jest.fn()
+}));
+
+const mockedAxios = axios as unknown as jest.Mock;
+const mockedFetch = nodeFetch as unknown as jest.Mock;
+
+// coingecko reads its key at module load and answers false without one, so the
+// module has to be loaded with the key already set to reach the response at all.
+function loadCoingecko() {
+  process.env.COINGECKO_API_KEY = 'test-key';
+
+  let resolve: (address: string, chainId: string) => Promise<Buffer | false>;
+  jest.isolateModules(() => {
+    resolve = jest.requireActual('../../../../src/resolvers/image/coingecko').default;
+  });
+
+  return resolve!;
+}
+
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const NOT_AN_ADDRESS = '0x00006ba9855965EeEc09B5D43B113944c27F45aD3Ce';
+
+const spaces = (found: any[]) => ({ status: 200, data: { data: { spaces: found } } });
+
+describe('resolvers answer false rather than throwing when there is no data', () => {
+  describe('starknet', () => {
+    it('answers false for an EVM address, which is what every avatar request carries', async () => {
+      await expect(starknet(ADDRESS)).resolves.toBe(false);
+    });
+  });
+
+  describe('space-sx', () => {
+    it('answers false for an id that is not an address, without asking', async () => {
+      await expect(resolveSxAvatar(NOT_AN_ADDRESS)).resolves.toBe(false);
+      expect(mockedAxios).not.toHaveBeenCalled();
+    });
+
+    it('answers false when neither API has the space', async () => {
+      mockedAxios.mockResolvedValue(spaces([]));
+
+      await expect(resolveSxAvatar(ADDRESS)).resolves.toBe(false);
+    });
+
+    it('answers false when one API is down and the other has no space', async () => {
+      mockedAxios
+        .mockRejectedValueOnce(new Error('mainnet is down'))
+        .mockResolvedValueOnce(spaces([]));
+
+      await expect(resolveSxAvatar(ADDRESS)).resolves.toBe(false);
+    });
+
+    it('rejects when every API is down', async () => {
+      mockedAxios.mockRejectedValue(new Error('everything is down'));
+
+      await expect(resolveSxAvatar(ADDRESS)).rejects.toThrow('everything is down');
+    });
+  });
+
+  describe('snapshot', () => {
+    it('answers false for a space id that is not an address, without asking', async () => {
+      await expect(resolveSpaceAvatar('ens.eth', 1, 'eth')).resolves.toBe(false);
+      expect(mockedAxios).not.toHaveBeenCalled();
+    });
+
+    it('answers false for an onchain logo instead of asking for a field that is not there', async () => {
+      await expect(resolveSpaceLogo(ADDRESS, 1, 'eth')).resolves.toBe(false);
+      expect(mockedAxios).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('coingecko', () => {
+    const apiKey = process.env.COINGECKO_API_KEY;
+    const globalFetch = global.fetch;
+
+    afterEach(() => {
+      process.env.COINGECKO_API_KEY = apiKey;
+      global.fetch = globalFetch;
+    });
+
+    const respondWith = (response: any) => {
+      global.fetch = jest.fn().mockResolvedValue(response) as any;
+    };
+
+    it('answers false for a token the API does not have', async () => {
+      respondWith({ ok: false, status: 404 });
+
+      await expect(loadCoingecko()(ADDRESS, '1')).resolves.toBe(false);
+    });
+
+    it('answers false for a token the API has no image for', async () => {
+      respondWith({ ok: true, status: 200, json: async () => ({ image: {} }) });
+
+      await expect(loadCoingecko()(ADDRESS, '1')).resolves.toBe(false);
+    });
+
+    it('rejects on any other non-2xx, carrying the status', async () => {
+      respondWith({ ok: false, status: 401, statusText: 'Unauthorized' });
+
+      await expect(loadCoingecko()(ADDRESS, '1')).rejects.toMatchObject({ status: 401 });
+    });
+  });
+
+  describe('farcaster', () => {
+    it('answers false for an address with no account', async () => {
+      mockedFetch.mockResolvedValue({ ok: false, status: 404 });
+
+      await expect(farcaster(ADDRESS)).resolves.toBe(false);
+    });
+
+    it('answers false when the response carries no account for the address', async () => {
+      mockedFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+
+      await expect(farcaster(ADDRESS)).resolves.toBe(false);
+    });
+
+    it('rejects on any other non-2xx, carrying the status', async () => {
+      mockedFetch.mockResolvedValue({ ok: false, status: 402, statusText: 'Payment Required' });
+
+      await expect(farcaster(ADDRESS)).rejects.toMatchObject({ status: 402 });
+    });
+  });
+});

--- a/test/unit/resolvers/lookupDomains.test.ts
+++ b/test/unit/resolvers/lookupDomains.test.ts
@@ -111,6 +111,15 @@ describe('lookupDomains - error reporting', () => {
     });
   });
 
+  // `capture` reads `.error` off whatever it is handed, so a falsy one throws
+  // from inside the catch block and takes the whole fan-out down with it.
+  it.each([null, undefined])('does not hand capture a rejection carrying %p', async value => {
+    (ens as jest.Mock).mockRejectedValue(value);
+
+    await expect(lookupDomains(VALID_ADDRESS, '1')).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
   it('does not capture a silenced error', async () => {
     (ens as jest.Mock).mockRejectedValue(
       Object.assign(new Error('Unstoppable Domains API error: HTTP 429 Too Many Requests'), {


### PR DESCRIPTION
Depends on #538.

Every resolver answers `false` for "this input has no image", but only some of them do it by returning `false`. The rest throw, and the map's failure contract turns the throw into the same `false`, so from the outside the two are the same event. `starknet` is the sharpest case: it sits on the `avatar` chain and throws for anything that is not 64 hex characters, so every ordinary EVM avatar request produces a throw on its way to a normal answer.

That is harmless while nothing looks at the throws. It stops being harmless the moment capture goes inside the failure contract, which is the next step in #511, because normal traffic would page.

So the no-data answer becomes a return rather than a throw, resolver by resolver: the starknet address check, the space-sx fan-out, the onchain space id list that `snapshot.ts` and `space-sx.ts` each built for themselves, the onchain logo query that asks for a field the API does not have, and the coingecko and farcaster responses. A resolver throws only when the upstream actually failed. No response moves, because the map already turned both into `false`.

## The space-sx fan-out

The one with a real decision in it. `getSpaceProperty` used `Promise.reject(false)` to mean "not on this API" and the two were aggregated with `Promise.any`, which made a space that is on neither API and both APIs being down the same `AggregateError`. It fans out with `allSettled` now and rethrows only when every API failed, so one API being down while the other answers "no such space" stays no-data. That two-API resilience is why both are asked at all.

The cost is that both are now always waited for, where `Promise.any` returned on the first hit. Both endpoints answer a miss about as fast as they answer a hit, and this sits behind the base cache, so ordinarily that is the difference between the slower and the faster of two calls. Where it costs something real is a degraded endpoint: the wait is then bounded by the axios timeout already on the call, and the old code could have returned on the other endpoint's hit. Telling a space that does not exist from both APIs being down is worth that.

## isSilencedError

Hardened in the same change because it is the classifier capture will consult, and it reads properties off the raw caught value as its first statement. A rejection carrying null makes the classifier itself throw, from inside a catch block, on a route with no guard of its own (#495).

It silences such a rejection rather than reporting it, because reporting is not available: `capture` reads `.error` off whatever it is handed and throws on the same values, so classifying one as worth reporting only moves the throw one line down. There is nothing in a bare null to report anyway.

## Left alone

`ens` and `trustwallet` still throw on their routine upstream 404. Silencing that is a muting decision and belongs with capture rather than here.

`getAddress` also throws for a malformed token id, in `trustwallet` and in `coingecko`, before any upstream call. That is invalid input rather than no-data, and a `false` is the wrong answer to it.

Closes #539. Refs #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
