### PR TITLE
fix(resolvers): bound the farcaster and coingecko calls with a deadline

### DIFF
--- a/src/resolvers/image/coingecko.ts
+++ b/src/resolvers/image/coingecko.ts
@@ -1,6 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import { fetchHttpImage } from '../../helpers/http';
-import { httpError } from '../../utils';
+import { httpError, withDeadline } from '../../utils';
 
 const API_KEY = process.env.COINGECKO_API_KEY;
 
@@ -23,11 +23,18 @@ export default async function resolve(address: string, chainId: string) {
   const checksum = getAddress(address);
   const url = `https://pro-api.coingecko.com/api/v3/coins/${assetPlatformId}/contract/${checksum}`;
 
-  const response = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY } });
-  if (response.status === 404) return false;
-  if (!response.ok) throw httpError('coingecko', response.status, response.statusText);
+  // The body read is inside the deadline, not just the request: the response
+  // settles as soon as the headers land, so a budget ending at the request would
+  // leave a stalled body unbounded.
+  const data = await withDeadline(async signal => {
+    const response = await fetch(url, { headers: { 'x-cg-pro-api-key': API_KEY }, signal });
 
-  const data = await response.json();
+    if (response.status === 404) return null;
+    if (!response.ok) throw httpError('coingecko', response.status, response.statusText);
+
+    return await response.json();
+  });
+
   if (!data?.image?.large) return false;
 
   return await fetchHttpImage(data.image.large);

--- a/src/resolvers/image/farcaster.ts
+++ b/src/resolvers/image/farcaster.ts
@@ -2,7 +2,7 @@ import { getAddress } from '@ethersproject/address';
 import fetch from 'node-fetch';
 import { max } from '../../constants.json';
 import { fetchHttpImage } from '../../helpers/http';
-import { Address, httpError } from '../../utils';
+import { Address, httpError, withDeadline } from '../../utils';
 
 const NEYNAR_API_URL = 'https://api.neynar.com/v2/farcaster/user/bulk-by-address';
 const API_KEY = process.env.NEYNAR_API_KEY ?? '';
@@ -25,19 +25,25 @@ function normalizeAddress(address: Address): Address | null {
   }
 }
 
+// The body read is inside the deadline, not just the request: node-fetch hands
+// back a response as soon as the headers land, so a budget ending at the request
+// would leave a stalled body unbounded.
 async function fetchAddressImageUrl(normalizedAddress: string): Promise<string | null> {
-  const response = await fetch(`${NEYNAR_API_URL}?addresses=${normalizedAddress}`, {
-    headers: { Accept: 'application/json', api_key: API_KEY }
+  return withDeadline(async signal => {
+    const response = await fetch(`${NEYNAR_API_URL}?addresses=${normalizedAddress}`, {
+      headers: { Accept: 'application/json', api_key: API_KEY },
+      signal
+    });
+
+    // Neynar answers 404 for an address with no Farcaster account, which is the
+    // routine no-avatar case rather than a failure.
+    if (response.status === 404) return null;
+    if (!response.ok) throw httpError('farcaster', response.status, response.statusText);
+
+    const data: Record<Address, UserDetails[]> = await response.json();
+
+    return data[normalizedAddress.toLowerCase()]?.[0]?.pfp_url ?? null;
   });
-
-  // Neynar answers 404 for an address with no Farcaster account, which is the
-  // routine no-avatar case rather than a failure.
-  if (response.status === 404) return null;
-  if (!response.ok) throw httpError('farcaster', response.status, response.statusText);
-
-  const data: Record<Address, UserDetails[]> = await response.json();
-
-  return data[normalizedAddress.toLowerCase()]?.[0]?.pfp_url ?? null;
 }
 
 export default async function resolve(address: string): Promise<Buffer | false> {

--- a/test/integration/resolvers/deadline.test.ts
+++ b/test/integration/resolvers/deadline.test.ts
@@ -2,8 +2,9 @@ import http from 'http';
 import { AddressInfo, Socket } from 'net';
 import { Address } from '../../../src/utils';
 
-const TIMEOUT = 10000;
 const ADDRESS = '0x91fd2c8d24767db4ece7069aa27832ffaf8590f3';
+
+type Stall = 'headers' | 'body';
 
 // Both resolvers hold their upstream as a module constant, so the only place a
 // server that never answers can be substituted is the transport.
@@ -17,8 +18,7 @@ jest.mock('node-fetch', () => {
 
 let server: http.Server;
 const sockets = new Set<Socket>();
-let reachedUpstream: () => void;
-let atUpstream: Promise<void>;
+let stall: Stall;
 
 let coingecko: (address: Address, chainId: string) => Promise<Buffer | false>;
 let farcaster: (address: Address) => Promise<Buffer | false>;
@@ -26,7 +26,16 @@ let farcaster: (address: Address) => Promise<Buffer | false>;
 const apiKey = process.env.COINGECKO_API_KEY;
 
 beforeAll(async () => {
-  server = http.createServer(() => reachedUpstream());
+  server = http.createServer((_req, res) => {
+    if (stall !== 'body') return;
+
+    // A body that opens and never closes. flushHeaders puts the head on the
+    // wire by itself, so the response settles for the caller while the read of
+    // it cannot.
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.flushHeaders();
+    res.write('{"');
+  });
   server.on('connection', socket => sockets.add(socket));
   await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
   mockHangingUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/`;
@@ -50,37 +59,39 @@ afterAll(async () => {
   await new Promise<void>(resolve => server.close(() => resolve()));
 });
 
-beforeEach(() => {
-  atUpstream = new Promise<void>(resolve => (reachedUpstream = resolve));
-});
+// These wait out the real deadline rather than firing its timer by hand.
+// Reaching into the timer would abort the signal even where the code under test
+// had already cleared it, which is exactly the case these need to be able to
+// fail on.
+describe('resolvers, against an upstream that never finishes answering', () => {
+  describe('when it sends no headers at all', () => {
+    it('farcaster answers false, as it does for any other failure', async () => {
+      stall = 'headers';
 
-// Fires the deadline as soon as the request is in flight, rather than waiting
-// out the real ten seconds.
-async function callAndExpire<T>(call: () => Promise<T>): Promise<T> {
-  const timers = jest.spyOn(global, 'setTimeout');
+      await expect(farcaster(ADDRESS)).resolves.toBe(false);
+    });
 
-  try {
-    const result = call();
-    await atUpstream;
+    it('coingecko raises the abort, which its withResize wrapper turns into false', async () => {
+      stall = 'headers';
 
-    const deadlines = timers.mock.calls.filter(timer => timer[1] === TIMEOUT);
-    expect(deadlines).toHaveLength(1);
-    (deadlines[0][0] as () => void)();
-
-    return await result;
-  } finally {
-    timers.mockRestore();
-  }
-}
-
-describe('resolvers, against an upstream that accepts and never answers', () => {
-  it('farcaster answers false at the deadline, as it does for any other failure', async () => {
-    await expect(callAndExpire(() => farcaster(ADDRESS))).resolves.toBe(false);
+      await expect(coingecko(ADDRESS, '1')).rejects.toMatchObject({ name: 'AbortError' });
+    });
   });
 
-  it('coingecko raises the abort, which its withResize wrapper turns into false', async () => {
-    await expect(callAndExpire(() => coingecko(ADDRESS, '1'))).rejects.toMatchObject({
-      name: 'AbortError'
+  // The deadline has to cover the body read and not just the request: both
+  // transports hand back a response as soon as the headers land, so a 200 whose
+  // body then stops is the shape that outlives a budget ending at the request.
+  describe('when it sends headers and then stops mid-body', () => {
+    it('farcaster answers false', async () => {
+      stall = 'body';
+
+      await expect(farcaster(ADDRESS)).resolves.toBe(false);
+    });
+
+    it('coingecko raises the abort', async () => {
+      stall = 'body';
+
+      await expect(coingecko(ADDRESS, '1')).rejects.toMatchObject({ name: 'AbortError' });
     });
   });
 });

--- a/test/integration/resolvers/deadline.test.ts
+++ b/test/integration/resolvers/deadline.test.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { AddressInfo, Socket } from 'net';
 import { Address } from '../../../src/utils';
 
 const TIMEOUT = 10000;
@@ -14,10 +15,8 @@ jest.mock('node-fetch', () => {
   return jest.fn((_url: string, init: unknown) => actual(mockHangingUrl, init));
 });
 
-const realFetch = global.fetch;
-
 let server: http.Server;
-const sockets = new Set<any>();
+const sockets = new Set<Socket>();
 let reachedUpstream: () => void;
 let atUpstream: Promise<void>;
 
@@ -28,12 +27,12 @@ const apiKey = process.env.COINGECKO_API_KEY;
 
 beforeAll(async () => {
   server = http.createServer(() => reachedUpstream());
-  server.on('connection', socket => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-  });
+  server.on('connection', socket => sockets.add(socket));
   await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
-  mockHangingUrl = `http://127.0.0.1:${(server.address() as any).port}/`;
+  mockHangingUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/`;
+
+  const realFetch = global.fetch;
+  jest.spyOn(global, 'fetch').mockImplementation((_url, init) => realFetch(mockHangingUrl, init));
 
   process.env.COINGECKO_API_KEY = 'test-key';
   coingecko = (await import('../../../src/resolvers/coingecko')).default;
@@ -53,7 +52,6 @@ afterAll(async () => {
 
 beforeEach(() => {
   atUpstream = new Promise<void>(resolve => (reachedUpstream = resolve));
-  jest.spyOn(global, 'fetch').mockImplementation((_url, init) => realFetch(mockHangingUrl, init));
 });
 
 // Fires the deadline as soon as the request is in flight, rather than waiting
@@ -67,7 +65,7 @@ async function callAndExpire<T>(call: () => Promise<T>): Promise<T> {
 
     const deadlines = timers.mock.calls.filter(timer => timer[1] === TIMEOUT);
     expect(deadlines).toHaveLength(1);
-    (deadlines[0] as unknown as [() => void])[0]();
+    (deadlines[0][0] as () => void)();
 
     return await result;
   } finally {
@@ -80,7 +78,7 @@ describe('resolvers, against an upstream that accepts and never answers', () => 
     await expect(callAndExpire(() => farcaster(ADDRESS))).resolves.toBe(false);
   });
 
-  it('coingecko raises the abort at the deadline', async () => {
+  it('coingecko raises the abort, which its withResize wrapper turns into false', async () => {
     await expect(callAndExpire(() => coingecko(ADDRESS, '1'))).rejects.toMatchObject({
       name: 'AbortError'
     });

--- a/test/integration/resolvers/deadline.test.ts
+++ b/test/integration/resolvers/deadline.test.ts
@@ -80,7 +80,7 @@ describe('resolvers, against an upstream that accepts and never answers', () => 
     await expect(callAndExpire(() => farcaster(ADDRESS))).resolves.toBe(false);
   });
 
-  it('coingecko raises the abort, which isSilencedError matches by name', async () => {
+  it('coingecko raises the abort at the deadline', async () => {
     await expect(callAndExpire(() => coingecko(ADDRESS, '1'))).rejects.toMatchObject({
       name: 'AbortError'
     });

--- a/test/integration/resolvers/deadline.test.ts
+++ b/test/integration/resolvers/deadline.test.ts
@@ -1,0 +1,88 @@
+import http from 'http';
+import { Address } from '../../../src/utils';
+
+const TIMEOUT = 10000;
+const ADDRESS = '0x91fd2c8d24767db4ece7069aa27832ffaf8590f3';
+
+// Both resolvers hold their upstream as a module constant, so the only place a
+// server that never answers can be substituted is the transport.
+let mockHangingUrl: string;
+
+jest.mock('node-fetch', () => {
+  const actual = jest.requireActual('node-fetch');
+
+  return jest.fn((_url: string, init: unknown) => actual(mockHangingUrl, init));
+});
+
+const realFetch = global.fetch;
+
+let server: http.Server;
+const sockets = new Set<any>();
+let reachedUpstream: () => void;
+let atUpstream: Promise<void>;
+
+let coingecko: (address: Address, chainId: string) => Promise<Buffer | false>;
+let farcaster: (address: Address) => Promise<Buffer | false>;
+
+const apiKey = process.env.COINGECKO_API_KEY;
+
+beforeAll(async () => {
+  server = http.createServer(() => reachedUpstream());
+  server.on('connection', socket => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
+  mockHangingUrl = `http://127.0.0.1:${(server.address() as any).port}/`;
+
+  process.env.COINGECKO_API_KEY = 'test-key';
+  coingecko = (await import('../../../src/resolvers/coingecko')).default;
+  farcaster = (await import('../../../src/resolvers/farcaster')).default;
+});
+
+afterAll(async () => {
+  if (apiKey === undefined) {
+    delete process.env.COINGECKO_API_KEY;
+  } else {
+    process.env.COINGECKO_API_KEY = apiKey;
+  }
+
+  sockets.forEach(socket => socket.destroy());
+  await new Promise<void>(resolve => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  atUpstream = new Promise<void>(resolve => (reachedUpstream = resolve));
+  jest.spyOn(global, 'fetch').mockImplementation((_url, init) => realFetch(mockHangingUrl, init));
+});
+
+// Fires the deadline as soon as the request is in flight, rather than waiting
+// out the real ten seconds.
+async function callAndExpire<T>(call: () => Promise<T>): Promise<T> {
+  const timers = jest.spyOn(global, 'setTimeout');
+
+  try {
+    const result = call();
+    await atUpstream;
+
+    const deadlines = timers.mock.calls.filter(timer => timer[1] === TIMEOUT);
+    expect(deadlines).toHaveLength(1);
+    (deadlines[0] as unknown as [() => void])[0]();
+
+    return await result;
+  } finally {
+    timers.mockRestore();
+  }
+}
+
+describe('resolvers, against an upstream that accepts and never answers', () => {
+  it('farcaster answers false at the deadline, as it does for any other failure', async () => {
+    await expect(callAndExpire(() => farcaster(ADDRESS))).resolves.toBe(false);
+  });
+
+  it('coingecko raises the abort, which isSilencedError matches by name', async () => {
+    await expect(callAndExpire(() => coingecko(ADDRESS, '1'))).rejects.toMatchObject({
+      name: 'AbortError'
+    });
+  });
+});

--- a/test/integration/resolvers/image/deadline.test.ts
+++ b/test/integration/resolvers/image/deadline.test.ts
@@ -1,6 +1,6 @@
 import http from 'http';
 import { AddressInfo, Socket } from 'net';
-import { Address } from '../../../src/utils';
+import { Address } from '../../../../src/utils';
 
 const ADDRESS = '0x91fd2c8d24767db4ece7069aa27832ffaf8590f3';
 
@@ -44,8 +44,8 @@ beforeAll(async () => {
   jest.spyOn(global, 'fetch').mockImplementation((_url, init) => realFetch(mockHangingUrl, init));
 
   process.env.COINGECKO_API_KEY = 'test-key';
-  coingecko = (await import('../../../src/resolvers/coingecko')).default;
-  farcaster = (await import('../../../src/resolvers/farcaster')).default;
+  coingecko = (await import('../../../../src/resolvers/image/coingecko')).default;
+  farcaster = (await import('../../../../src/resolvers/image/farcaster')).default;
 });
 
 afterAll(async () => {
@@ -71,7 +71,7 @@ describe('resolvers, against an upstream that never finishes answering', () => {
       await expect(farcaster(ADDRESS)).resolves.toBe(false);
     });
 
-    it('coingecko raises the abort, which its withResize wrapper turns into false', async () => {
+    it('coingecko raises the abort, which withFailureContract turns into false', async () => {
       stall = 'headers';
 
       await expect(coingecko(ADDRESS, '1')).rejects.toMatchObject({ name: 'AbortError' });

--- a/test/integration/resolvers/image/deadline.test.ts
+++ b/test/integration/resolvers/image/deadline.test.ts
@@ -63,33 +63,27 @@ afterAll(async () => {
 // Reaching into the timer would abort the signal even where the code under test
 // had already cleared it, which is exactly the case these need to be able to
 // fail on.
+// Both raise the abort rather than answering: neither discards its own errors,
+// and withFailureContract in the resolver map is what turns it into a false for
+// the caller.
+//
+// The body case is the one that needs the deadline to cover more than the
+// request: both transports hand back a response as soon as the headers land, so
+// a 200 whose body then stops is the shape that outlives a budget ending at the
+// request.
 describe('resolvers, against an upstream that never finishes answering', () => {
-  describe('when it sends no headers at all', () => {
-    it('farcaster answers false, as it does for any other failure', async () => {
-      stall = 'headers';
+  describe.each([
+    ['no headers at all', 'headers'],
+    ['headers and then nothing more', 'body']
+  ] as const)('when it sends %s', (_, at) => {
+    it('farcaster raises the abort', async () => {
+      stall = at;
 
-      await expect(farcaster(ADDRESS)).resolves.toBe(false);
-    });
-
-    it('coingecko raises the abort, which withFailureContract turns into false', async () => {
-      stall = 'headers';
-
-      await expect(coingecko(ADDRESS, '1')).rejects.toMatchObject({ name: 'AbortError' });
-    });
-  });
-
-  // The deadline has to cover the body read and not just the request: both
-  // transports hand back a response as soon as the headers land, so a 200 whose
-  // body then stops is the shape that outlives a budget ending at the request.
-  describe('when it sends headers and then stops mid-body', () => {
-    it('farcaster answers false', async () => {
-      stall = 'body';
-
-      await expect(farcaster(ADDRESS)).resolves.toBe(false);
+      await expect(farcaster(ADDRESS)).rejects.toMatchObject({ name: 'AbortError' });
     });
 
     it('coingecko raises the abort', async () => {
-      stall = 'body';
+      stall = at;
 
       await expect(coingecko(ADDRESS, '1')).rejects.toMatchObject({ name: 'AbortError' });
     });


### PR DESCRIPTION
Two of the four call sites listed in #536.

Neither `farcaster` nor `coingecko` sets a deadline of any kind, so an upstream that accepts the connection and then never answers holds the resolver open. `src/api.ts` fans the resolver chain out with `Promise.all`, and `withResize` in `src/resolvers/index.ts` turns a resolver throw into `false` but has nothing to catch when the promise simply never settles, so the whole image request waits behind it. `farcaster` is the worse of the two: node-fetch v2 arms no timer unless one is asked for, so there is no backstop at all, where `coingecko` at least has undici's.

Both move onto the `withDeadline` helper added in #534, rather than a per-transport option. Neither transport's own option does the job here. node-fetch's `timeout` raises a `FetchError`, so a deadline this code set for itself would not be recognised as the abort it is. The global `fetch` has no `timeout` option at all and ignores the key silently, which typechecks and does nothing.

The deadline wraps the whole call rather than the request. Both transports resolve as soon as the response headers arrive, so a body that then stalls falls outside a budget that ends at the request.

`farcaster` already discarded its own errors, so nothing about its result changes and a deadline only makes it end. `coingecko` raises the abort onto the same path any other failure there takes.
