### PR TITLE
fix(addressResolvers): bound the shibarium DNS fan-out

### DIFF
--- a/src/addressResolvers/shibarium.ts
+++ b/src/addressResolvers/shibarium.ts
@@ -1,5 +1,5 @@
 import { DNSConnect } from '@webinterop/dns-connect';
-import { Address, Handle } from '../utils';
+import { Address, Handle, untilAborted, withDeadline } from '../utils';
 import { isEvmAddress, withoutEmptyValues } from './utils';
 import constants from '../constants.json';
 
@@ -18,6 +18,14 @@ function normalizeHandles(handles: Handle[]): Handle[] {
   return handles.filter(handle => handle.endsWith(`.${TLD}`));
 }
 
+// dns-connect's resolver passes no signal to the DNS-over-HTTPS fetches it makes, so this
+// bounds the wait and the requests it started keep running. The budget covers the whole
+// fan-out rather than one query: each entry issues several queries in sequence and the
+// fan-out is as wide as the batch, so a per-query bound would leave the call unbounded.
+function boundedAll<T>(queries: Promise<T>[]): Promise<T[]> {
+  return withDeadline(signal => untilAborted(signal, Promise.all(queries)));
+}
+
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
   const normalizedAddresses = normalizeAddresses(addresses);
 
@@ -27,8 +35,8 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
     dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
   });
 
-  const results = await Promise.all(
-    normalizedAddresses.map(async address => dnsConnect.reverseResolve(address, NETWORK))
+  const results = await boundedAll(
+    normalizedAddresses.map(address => dnsConnect.reverseResolve(address, NETWORK))
   );
 
   return withoutEmptyValues(
@@ -45,8 +53,8 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
     dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
   });
 
-  const results = await Promise.all(
-    normalizedHandles.map(async handle => dnsConnect.resolve(handle, NETWORK))
+  const results = await boundedAll(
+    normalizedHandles.map(handle => dnsConnect.resolve(handle, NETWORK))
   );
 
   return withoutEmptyValues(

--- a/test/unit/addressResolvers/shibarium.test.ts
+++ b/test/unit/addressResolvers/shibarium.test.ts
@@ -1,0 +1,67 @@
+import { DNSConnect } from '@webinterop/dns-connect';
+import { lookupAddresses, resolveNames } from '../../../src/addressResolvers/shibarium';
+import { isSilencedError } from '../../../src/addressResolvers/utils';
+
+jest.mock('@webinterop/dns-connect', () => ({
+  DNSConnect: jest.fn()
+}));
+
+const ADDRESSES = [
+  '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6',
+  '0x91FD2c8d24767db4Ece7069AA27832ffaf8590f3',
+  '0x89ceF96c58A85d9bE6DFa46D667e71f45f9Ad046'
+];
+const HANDLES = ['boorger.shib', 'second.shib', 'third.shib'];
+const TIMEOUT = 10000;
+
+const mockedDNSConnect = DNSConnect as unknown as jest.Mock;
+
+type Query = 'resolve' | 'reverseResolve';
+type Case = [string, Query, string[], (entries: string[]) => Promise<Record<string, string>>];
+
+function mockQuery(method: Query, query: (entry: string) => Promise<unknown>) {
+  mockedDNSConnect.mockImplementation(() => ({ [method]: query }));
+}
+
+function deadlines(timers: jest.SpyInstance) {
+  return timers.mock.calls.filter(call => call[1] === TIMEOUT);
+}
+
+describe.each<Case>([
+  ['lookupAddresses', 'reverseResolve', ADDRESSES, lookupAddresses],
+  ['resolveNames', 'resolve', HANDLES, resolveNames]
+])('addressResolvers/shibarium %s deadline', (_name, method, entries, call) => {
+  it('ends the call, on queries that never settle and take no signal of their own', async () => {
+    const timers = jest.spyOn(global, 'setTimeout');
+    const started: string[] = [];
+
+    // dns-connect forwards no signal, so a hung DNS-over-HTTPS request is
+    // indistinguishable from a promise that simply never settles.
+    mockQuery(method, entry => {
+      started.push(entry);
+      return new Promise(() => undefined);
+    });
+
+    const result = call(entries);
+
+    expect(started).toEqual(entries);
+
+    const scheduled = deadlines(timers);
+    expect(scheduled).toHaveLength(1);
+    scheduled[0][0]();
+
+    const error = await result.catch(err => err);
+    expect(error.name).toBe('AbortError');
+    expect(isSilencedError(error)).toBe(true);
+  });
+
+  it('spends one budget on the whole fan-out, not one per entry', async () => {
+    const timers = jest.spyOn(global, 'setTimeout');
+    mockQuery(method, async entry => `${entry}-result`);
+
+    await expect(call(entries)).resolves.toEqual(
+      Object.fromEntries(entries.map(entry => [entry, `${entry}-result`]))
+    );
+    expect(deadlines(timers)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
`lookup_addresses` and `resolve_names` fan out over `DNSConnect` with `Promise.all`, and nothing bounds that call. The per-provider catch in `addressResolvers/index.ts` covers a provider that throws rather than one that never settles, so a DNS-over-HTTPS request that is accepted and never answered holds the whole call open, with only undici's own headers timeout underneath it.

`dnsConnect.resolve()` and `reverseResolve()` take no signal, and `DNSConnectOptions` exposes none, so this bounds the wait rather than the request, the way #534 did for `getOwner`. Cancelling the request instead would mean supplying our own `DNSResolver`, and with it a copy of dns-connect's NXDomain handling and of its DNSSEC `AD` check, which is what stops a resolution downgrade from passing as an answer.

The budget wraps the whole fan-out rather than a single query, because each entry issues several DNS queries in sequence and `lookup_addresses` accepts up to 50 addresses. A per-query bound would put no ceiling on the call, for the same reason the deadline in `lookupDomains` sits outside the paging loop rather than inside it.

The abort surfaces as an `AbortError`, which `isSilencedError` already matches, so a deadline reports nothing to Sentry.

One thing worth your judgement: the budget is all or nothing over the batch, so if it trips every address in that batch comes back unresolved, and `addressResolvers/index.ts` then caches an unresolved address exactly as it does after any other provider failure. `lookup_addresses` accepts 50 addresses, and a cold connection pool makes a batch that size the case that sits closest to the shared budget.

Part of #536.
