### PR TITLE
fix(helpers): bound the shared image fetch with a whole-call deadline

### DIFF
--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -1,9 +1,8 @@
 import http from 'http';
 import https from 'https';
 import { getAddress } from '@ethersproject/address';
-import axios from 'axios';
 import { isStarknetAddress } from './address';
-import { withDeadline } from '../utils';
+import { httpError, withDeadline } from '../utils';
 
 export const axiosDefaultParams = {
   httpAgent: new http.Agent({ keepAlive: true }),
@@ -24,26 +23,21 @@ export function spaceIds(id: string): string[] | null {
   }
 }
 
-// The deadline covers the whole call, not just the request: the axios timeout is
-// an idle timeout on the socket, so an upstream that keeps sending, however
-// slowly, resets it and never trips it.
+// Shorter than the shared budget because this covers a single transfer, where
+// the other call sites cover a chain of them.
+const IMAGE_FETCH_BUDGET = 5e3;
+
+// The budget covers the whole call, not just the request: fetch settles as soon
+// as the headers land, so a body that opens and never ends outlives a budget
+// measured per request. Redirects and the body read are inside it too.
 export async function fetchHttpImage(url: string): Promise<Buffer> {
   return withDeadline(async signal => {
-    try {
-      const { data } = await axios({
-        url,
-        responseType: 'arraybuffer',
-        ...axiosDefaultParams,
-        signal
-      });
+    const response = await fetch(url, { signal });
 
-      return data;
-    } catch (err) {
-      // axios answers an abort with a Cancel of its own, which carries neither
-      // the name isSilencedError reads nor an Error prototype.
-      if (axios.isCancel(err)) throw signal.reason;
+    // fetch resolves a non-2xx, and the resolvers that skip the resize hand what
+    // they get straight to the encoder.
+    if (!response.ok) throw httpError(new URL(url).host, response.status, response.statusText);
 
-      throw err;
-    }
-  });
+    return Buffer.from(await response.arrayBuffer());
+  }, IMAGE_FETCH_BUDGET);
 }

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -3,6 +3,7 @@ import https from 'https';
 import { getAddress } from '@ethersproject/address';
 import axios from 'axios';
 import { isStarknetAddress } from './address';
+import { withDeadline } from '../utils';
 
 export const axiosDefaultParams = {
   httpAgent: new http.Agent({ keepAlive: true }),
@@ -23,14 +24,26 @@ export function spaceIds(id: string): string[] | null {
   }
 }
 
+// The deadline covers the whole call, not just the request: the axios timeout is
+// an idle timeout on the socket, so an upstream that keeps sending, however
+// slowly, resets it and never trips it.
 export async function fetchHttpImage(url: string): Promise<Buffer> {
-  return (
-    await axios({
-      url,
-      ...{
-        responseType: 'arraybuffer',
-        ...axiosDefaultParams
-      }
-    })
-  ).data;
+  return withDeadline(async signal => {
+    try {
+      return (
+        await axios({
+          url,
+          responseType: 'arraybuffer',
+          ...axiosDefaultParams,
+          signal
+        })
+      ).data;
+    } catch (err) {
+      // axios answers an abort with a Cancel of its own, which carries neither
+      // the name isSilencedError reads nor an Error prototype.
+      if (axios.isCancel(err)) throw signal.reason;
+
+      throw err;
+    }
+  });
 }

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -23,19 +23,12 @@ export function spaceIds(id: string): string[] | null {
   }
 }
 
-// Shorter than the shared budget because this covers a single transfer, where
-// the other call sites cover a chain of them.
 const IMAGE_FETCH_BUDGET = 5e3;
 
-// The budget covers the whole call, not just the request: fetch settles as soon
-// as the headers land, so a body that opens and never ends outlives a budget
-// measured per request. Redirects and the body read are inside it too.
 export async function fetchHttpImage(url: string): Promise<Buffer> {
   return withDeadline(async signal => {
     const response = await fetch(url, { signal });
 
-    // fetch resolves a non-2xx, and the resolvers that skip the resize hand what
-    // they get straight to the encoder.
     if (!response.ok) throw httpError(new URL(url).host, response.status, response.statusText);
 
     return Buffer.from(await response.arrayBuffer());

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -30,14 +30,14 @@ export function spaceIds(id: string): string[] | null {
 export async function fetchHttpImage(url: string): Promise<Buffer> {
   return withDeadline(async signal => {
     try {
-      return (
-        await axios({
-          url,
-          responseType: 'arraybuffer',
-          ...axiosDefaultParams,
-          signal
-        })
-      ).data;
+      const { data } = await axios({
+        url,
+        responseType: 'arraybuffer',
+        ...axiosDefaultParams,
+        signal
+      });
+
+      return data;
     } catch (err) {
       // axios answers an abort with a Cancel of its own, which carries neither
       // the name isSilencedError reads nor an Error prototype.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,9 +47,12 @@ const UPSTREAM_TIMEOUT = 10000;
 // `isSilencedError` reads the error name, and the two ways to abort raise
 // different ones: `AbortController` gives `AbortError`, `AbortSignal.timeout`
 // gives `TimeoutError`.
-export async function withDeadline<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+export async function withDeadline<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  budget = UPSTREAM_TIMEOUT
+): Promise<T> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT);
+  const timeout = setTimeout(() => controller.abort(), budget);
 
   try {
     return await fn(controller.signal);

--- a/test/integration/helpers/http.test.ts
+++ b/test/integration/helpers/http.test.ts
@@ -1,0 +1,55 @@
+import http from 'http';
+import { AddressInfo, Socket } from 'net';
+import { isSilencedError } from '../../../src/helpers/errors';
+import { fetchHttpImage } from '../../../src/helpers/http';
+
+const BODY = Buffer.from('as much of an image as the fetch cares about');
+
+let server: http.Server;
+let url: string;
+let drip = false;
+const sockets = new Set<Socket>();
+
+beforeAll(async () => {
+  server = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'image/png' });
+
+    if (!drip) return res.end(BODY);
+
+    // A body that keeps arriving and never ends. The socket is never idle, so
+    // this is the shape that outlives a budget measured per request.
+    res.flushHeaders();
+    const timer = setInterval(() => res.write('x'), 250);
+    res.on('close', () => clearInterval(timer));
+  });
+  server.on('connection', socket => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
+  url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/image.png`;
+});
+
+afterAll(async () => {
+  sockets.forEach(socket => socket.destroy());
+  await new Promise<void>(resolve => server.close(() => resolve()));
+});
+
+describe('fetchHttpImage', () => {
+  it('returns the body', async () => {
+    drip = false;
+
+    await expect(fetchHttpImage(url)).resolves.toEqual(BODY);
+  });
+
+  // Silenced as well as raised: every image resolver reaches this, and an abort
+  // that the classifier cannot read reports a slow upstream as a failure.
+  it('raises a silenced abort against an upstream that never stops sending', async () => {
+    drip = true;
+
+    const error = await fetchHttpImage(url).catch(err => err);
+
+    expect(error.name).toBe('AbortError');
+    expect(isSilencedError(error)).toBe(true);
+  });
+});

--- a/test/integration/helpers/http.test.ts
+++ b/test/integration/helpers/http.test.ts
@@ -7,11 +7,17 @@ const BODY = Buffer.from('as much of an image as the fetch cares about');
 
 let server: http.Server;
 let url: string;
+let missingUrl: string;
 let neverEndingUrl: string;
 const sockets = new Set<Socket>();
 
 beforeAll(async () => {
   server = http.createServer((req, res) => {
+    if (req.url === '/missing.png') {
+      res.writeHead(404, { 'Content-Type': 'text/html' });
+      return res.end('<html><body>not found</body></html>');
+    }
+
     res.writeHead(200, { 'Content-Type': 'image/png' });
 
     if (req.url === '/image.png') return res.end(BODY);
@@ -29,6 +35,7 @@ beforeAll(async () => {
   await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
   const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
   url = `${origin}/image.png`;
+  missingUrl = `${origin}/missing.png`;
   neverEndingUrl = `${origin}/never-ends.png`;
 });
 
@@ -42,6 +49,12 @@ describe('fetchHttpImage', () => {
     await expect(fetchHttpImage(url)).resolves.toEqual(BODY);
   });
 
+  // fetch resolves a non-2xx, and the resolvers that skip the resize hand what
+  // they get straight to the encoder, so the status has to become a throw here.
+  it('raises rather than returning the body of a non-2xx', async () => {
+    await expect(fetchHttpImage(missingUrl)).rejects.toMatchObject({ status: 404 });
+  });
+
   // Silenced as well as raised: every image resolver reaches this, and an abort
   // that the classifier cannot read reports a slow upstream as a failure.
   it('raises a silenced abort against an upstream that never stops sending', async () => {
@@ -49,5 +62,17 @@ describe('fetchHttpImage', () => {
 
     expect(error.name).toBe('AbortError');
     expect(isSilencedError(error)).toBe(true);
+  });
+
+  // The budget this passes is shorter than the shared default, so without the
+  // bounds a call site that stopped passing one would still abort and still
+  // look right. The window is wide enough that only a changed budget moves it.
+  it('gives up on that upstream inside its own budget rather than the shared one', async () => {
+    const startedAt = Date.now();
+    await fetchHttpImage(neverEndingUrl).catch(() => undefined);
+
+    const elapsed = Date.now() - startedAt;
+    expect(elapsed).toBeGreaterThan(3000);
+    expect(elapsed).toBeLessThan(8000);
   });
 });

--- a/test/integration/helpers/http.test.ts
+++ b/test/integration/helpers/http.test.ts
@@ -7,14 +7,14 @@ const BODY = Buffer.from('as much of an image as the fetch cares about');
 
 let server: http.Server;
 let url: string;
-let drip = false;
+let neverEndingUrl: string;
 const sockets = new Set<Socket>();
 
 beforeAll(async () => {
-  server = http.createServer((_req, res) => {
+  server = http.createServer((req, res) => {
     res.writeHead(200, { 'Content-Type': 'image/png' });
 
-    if (!drip) return res.end(BODY);
+    if (req.url === '/image.png') return res.end(BODY);
 
     // A body that keeps arriving and never ends. The socket is never idle, so
     // this is the shape that outlives a budget measured per request.
@@ -27,7 +27,9 @@ beforeAll(async () => {
     socket.on('close', () => sockets.delete(socket));
   });
   await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()));
-  url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/image.png`;
+  const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  url = `${origin}/image.png`;
+  neverEndingUrl = `${origin}/never-ends.png`;
 });
 
 afterAll(async () => {
@@ -37,17 +39,13 @@ afterAll(async () => {
 
 describe('fetchHttpImage', () => {
   it('returns the body', async () => {
-    drip = false;
-
     await expect(fetchHttpImage(url)).resolves.toEqual(BODY);
   });
 
   // Silenced as well as raised: every image resolver reaches this, and an abort
   // that the classifier cannot read reports a slow upstream as a failure.
   it('raises a silenced abort against an upstream that never stops sending', async () => {
-    drip = true;
-
-    const error = await fetchHttpImage(url).catch(err => err);
+    const error = await fetchHttpImage(neverEndingUrl).catch(err => err);
 
     expect(error.name).toBe('AbortError');
     expect(isSilencedError(error)).toBe(true);

--- a/test/integration/helpers/http.test.ts
+++ b/test/integration/helpers/http.test.ts
@@ -22,8 +22,6 @@ beforeAll(async () => {
 
     if (req.url === '/image.png') return res.end(BODY);
 
-    // A body that keeps arriving and never ends. The socket is never idle, so
-    // this is the shape that outlives a budget measured per request.
     res.flushHeaders();
     const timer = setInterval(() => res.write('x'), 250);
     res.on('close', () => clearInterval(timer));
@@ -49,14 +47,10 @@ describe('fetchHttpImage', () => {
     await expect(fetchHttpImage(url)).resolves.toEqual(BODY);
   });
 
-  // fetch resolves a non-2xx, and the resolvers that skip the resize hand what
-  // they get straight to the encoder, so the status has to become a throw here.
   it('raises rather than returning the body of a non-2xx', async () => {
     await expect(fetchHttpImage(missingUrl)).rejects.toMatchObject({ status: 404 });
   });
 
-  // Silenced as well as raised: every image resolver reaches this, and an abort
-  // that the classifier cannot read reports a slow upstream as a failure.
   it('raises a silenced abort against an upstream that never stops sending', async () => {
     const error = await fetchHttpImage(neverEndingUrl).catch(err => err);
 
@@ -64,9 +58,6 @@ describe('fetchHttpImage', () => {
     expect(isSilencedError(error)).toBe(true);
   });
 
-  // The budget this passes is shorter than the shared default, so without the
-  // bounds a call site that stopped passing one would still abort and still
-  // look right. The window is wide enough that only a changed budget moves it.
   it('gives up on that upstream inside its own budget rather than the shared one', async () => {
     const startedAt = Date.now();
     await fetchHttpImage(neverEndingUrl).catch(() => undefined);


### PR DESCRIPTION
`fetchHttpImage` is the shared fetch behind every image resolver, and the only thing bounding it was the axios `timeout` in `axiosDefaultParams`. That is an idle timeout on the socket rather than a budget for the call: an upstream that keeps sending, however slowly, resets it every time it writes, so a response body that starts and never ends holds the resolver open with nothing underneath it. `src/api.ts` fans the resolver chain out with `Promise.all` and the failure contract in `src/resolvers/image/index.ts` turns a throw into `false`, and neither of those reaches a promise that simply never settles.

This puts the call inside the `withDeadline` from #534, the way #541 and #542 did for their own call sites, so the budget covers the transfer rather than the request.

## The budget changed

It is now 5s rather than the shared 10s, and `withDeadline` takes the number as an optional second argument so a call site can say what it is bounding. The default is unchanged and no other call site passes one.

5s is also not the 5s that went. The axios timeout was per request, re-armed by every write on the socket, and never covered the body at all. This one covers the whole call: connect, headers, redirects and the body read.

## And the client changed

axios was the only HTTP client here when the repo started, before Node had one of its own, and the buffer response was never the reason it stayed. Two things follow from dropping it.

It answers a signal with a `Cancel` of its own rather than rejecting with the signal's reason, and that object carries neither an `Error` prototype nor the name `isSilencedError` reads, so an abort arrived at a caller as a resolver failure rather than as one of our own deadlines. `fetch` raises a `DOMException` named `AbortError`, which the classifier already matches, so the translation the deadline would otherwise need is gone rather than added.

`fetch` also resolves a non-2xx where axios raised one. `user-cover`, `space-cover`, `space-logo` and `space-cover-sx` are registered with `resize: false`, so what this returns for them reaches sharp in `src/api.ts` with no guard between (#495), and an error page would arrive there as an image. The status has to become a throw, and `httpError` carries it in both the places `isSilencedError` reads, which is what keeps a 504 and a 429 muted the way axios's `response.status` did.

axios stays in the repo: `graphQlCall` and the starknet image resolver still use it.

Refs #536, #206.
