### PR TITLE
fix(provider): keep one provider, the snapshot.js one

### DIFF
--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -3,22 +3,12 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { Address } from './types';
 
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
-const providers: Record<string, StaticJsonRpcProvider> = {};
 
-export function provider(
-  network: string,
-  providerOptions: { broviderUrl?: string; timeout?: number } = { broviderUrl, timeout: 5e3 }
+export function getProvider(
+  network: string | number,
+  providerOptions: { broviderUrl?: string; timeout?: number } = {}
 ) {
-  return snapshot.utils.getProvider(network, providerOptions);
-}
-
-export function getProvider(network: number): StaticJsonRpcProvider {
-  if (!providers[`_${network}`])
-    providers[`_${network}`] = new StaticJsonRpcProvider(
-      { url: `https://rpc.snapshot.org/${network}`, timeout: 20e3, allowGzip: true },
-      network
-    );
-  return providers[`_${network}`];
+  return snapshot.utils.getProvider(network, { broviderUrl, timeout: 5e3, ...providerOptions });
 }
 
 /**

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -4,11 +4,8 @@ import { Address } from './types';
 
 const broviderUrl = process.env.BROVIDER_URL || 'https://rpc.snapshot.org';
 
-export function getProvider(
-  network: string | number,
-  providerOptions: { broviderUrl?: string; timeout?: number } = {}
-) {
-  return snapshot.utils.getProvider(network, { broviderUrl, timeout: 5e3, ...providerOptions });
+export function getProvider(network: string | number) {
+  return snapshot.utils.getProvider(network, { broviderUrl, timeout: 5e3 });
 }
 
 /**

--- a/src/resolvers/address/basename.ts
+++ b/src/resolvers/address/basename.ts
@@ -4,7 +4,7 @@ import { namehash } from '@ethersproject/hash';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { EMPTY_ADDRESS, isEvmAddress } from '../../helpers/address';
 import { getUrl } from '../../helpers/http';
-import { provider as getProvider } from '../../helpers/provider';
+import { getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
 
 export const NAME = 'Basename';

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -6,7 +6,7 @@ import constants from '../../constants.json';
 import { isEvmAddress } from '../../helpers/address';
 import { isSilencedError } from '../../helpers/errors';
 import { graphQlCall } from '../../helpers/graphql';
-import { provider as getProvider } from '../../helpers/provider';
+import { getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
 
 export const NAME = 'Ens';

--- a/src/resolvers/address/gwei.ts
+++ b/src/resolvers/address/gwei.ts
@@ -3,7 +3,7 @@ import { concat } from '@ethersproject/bytes';
 import { keccak256 } from '@ethersproject/keccak256';
 import { toUtf8Bytes } from '@ethersproject/strings';
 import { EMPTY_ADDRESS, isEvmAddress } from '../../helpers/address';
-import { batchContractCalls, provider as getProvider } from '../../helpers/provider';
+import { batchContractCalls, getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
 
 // Gwei Name Service: an ENS-compatible .gwei namespace on Ethereum. https://gwei.domains

--- a/src/resolvers/address/spaceId.ts
+++ b/src/resolvers/address/spaceId.ts
@@ -16,7 +16,7 @@ const RESOLVER_ABI = [
   'function name(bytes32 node) view returns (string name)'
 ];
 
-const provider = getProvider(NETWORK, { timeout: 5e3 });
+const provider = getProvider(NETWORK);
 
 function normalizeAddresses(addresses: Address[]): Address[] {
   return addresses.filter(isEvmAddress);

--- a/src/resolvers/address/spaceId.ts
+++ b/src/resolvers/address/spaceId.ts
@@ -1,6 +1,6 @@
 import { namehash } from '@ethersproject/hash';
 import { EMPTY_ADDRESS, isEvmAddress } from '../../helpers/address';
-import { batchContractCalls, provider as getProvider } from '../../helpers/provider';
+import { batchContractCalls, getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
 
 // NOTE: Space ID supports multiple networks and TLDs, this file only implements BNB with .bnb TLD

--- a/src/resolvers/address/starknet.ts
+++ b/src/resolvers/address/starknet.ts
@@ -2,7 +2,7 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { CallData, constants, starknetId, validateAndParseAddress } from 'starknet';
 import { isStarkDomain, isStarknetAddress, starkDomainLabels } from '../../helpers/address';
 import { withoutEmptyValues } from '../../helpers/object';
-import { provider as getProvider } from '../../helpers/provider';
+import { getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
 
 export const NAME = 'Starknet';

--- a/src/resolvers/address/unstoppableDomains.ts
+++ b/src/resolvers/address/unstoppableDomains.ts
@@ -4,7 +4,7 @@ import Resolution, { NamingServiceName } from '@unstoppabledomains/resolution';
 import { isEvmAddress } from '../../helpers/address';
 import { isSilencedError } from '../../helpers/errors';
 import { withoutEmptyValues } from '../../helpers/object';
-import { batchContractCalls, provider as getProvider } from '../../helpers/provider';
+import { batchContractCalls, getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
 
 export const NAME = 'Unstoppable Domains';

--- a/src/resolvers/address/unstoppableDomains.ts
+++ b/src/resolvers/address/unstoppableDomains.ts
@@ -9,7 +9,7 @@ import { Address, Handle } from '../../helpers/types';
 
 export const NAME = 'Unstoppable Domains';
 const NETWORK = '137';
-const provider = getProvider(NETWORK, { timeout: 5e3 });
+const provider = getProvider(NETWORK);
 const ABI = [
   'function reverseNameOf(address addr) view returns (string reverseUri)',
   'function ownerOf(uint256 tokenId) external view returns (address address)'

--- a/src/resolvers/image/ens.ts
+++ b/src/resolvers/image/ens.ts
@@ -1,4 +1,5 @@
 import { isAddress } from '@ethersproject/address';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { fetchHttpImage } from '../../helpers/http';
 import { getProvider } from '../../helpers/provider';
 import { lookupAddresses } from '../address';
@@ -12,7 +13,8 @@ async function castToEnsName(nameOrAddress: string): Promise<string | undefined>
 }
 
 export default async function resolve(nameOrAddress: string) {
-  const provider = getProvider(1);
+  // getProvider returns `any`. Without the annotation the calls below are unchecked.
+  const provider: StaticJsonRpcProvider = getProvider(1);
   const ensName = await castToEnsName(nameOrAddress);
 
   if (!ensName) return false;

--- a/src/resolvers/image/starknet.ts
+++ b/src/resolvers/image/starknet.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { isStarkDomain } from '../../helpers/address';
 import { axiosDefaultParams, fetchHttpImage, getUrl } from '../../helpers/http';
-import { provider as getProvider } from '../../helpers/provider';
+import { getProvider } from '../../helpers/provider';
 
 const DEFAULT_IMG_URL = 'https://starknet.id/api/identicons/0';
 const provider = getProvider('0x534e5f4d41494e');

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -15,7 +15,7 @@ jest.mock('axios', () => {
 
 jest.mock('../../../../src/helpers/provider', () => ({
   ...jest.requireActual('../../../../src/helpers/provider'),
-  provider: jest.fn(() => ({
+  getProvider: jest.fn(() => ({
     resolveName: jest.fn().mockResolvedValue(null),
     lookupAddress: jest.fn().mockResolvedValue(null)
   }))

--- a/test/unit/resolvers/address/starknet-batch-guard.test.ts
+++ b/test/unit/resolvers/address/starknet-batch-guard.test.ts
@@ -12,7 +12,7 @@ jest.mock('../../../../src/resolvers/address/cache', () => ({
 jest.mock('../../../../src/helpers/provider', () => {
   const actual = jest.requireActual('../../../../src/helpers/provider');
 
-  return { ...actual, provider: () => ({ callContract: mockCallContract }) };
+  return { ...actual, getProvider: () => ({ callContract: mockCallContract }) };
 });
 
 import { capture } from '@snapshot-labs/snapshot-sentry';

--- a/test/unit/resolvers/address/starknet.test.ts
+++ b/test/unit/resolvers/address/starknet.test.ts
@@ -17,7 +17,7 @@ jest.mock('../../../../src/helpers/provider', () => {
 
   return {
     ...actual,
-    provider: () => ({ callContract: mockCallContract })
+    getProvider: () => ({ callContract: mockCallContract })
   };
 });
 


### PR DESCRIPTION
`src/helpers/provider.ts` exports two different things that both
mean "provider": `provider`, which wraps `snapshot.utils.getProvider` and points at
`BROVIDER_URL`, and `getProvider`, a hand-rolled `StaticJsonRpcProvider` with its own
cache, a hardcoded `rpc.snapshot.org` host and a longer per-request timeout. Every
address resolver imports the first one aliased to `getProvider`, and
`src/resolvers/image/ens.ts` imports the second one under that same name. So
`getProvider` means two different things depending on which file you are reading.

Drop the hand-rolled one and keep the snapshot.js wrapper, renamed to `getProvider`
so no call site has to alias it.

## This is not a pure rename

**The ENS image resolver changes both endpoint and budget.** `src/resolvers/image/ens.ts`
was the only user of the hand-rolled provider. Its import line does not change at all,
but it now resolves to the shared one, so it moves from a hardcoded `rpc.snapshot.org/1`
at a 20s per-request timeout to `BROVIDER_URL` at 5s. That timeout bounds one JSON-RPC
request rather than the whole resolution, which here is the two `eth_call`s behind
`getResolver` and `getText('avatar')`. Exceeding it is silent: the resolver answers
`false` and the avatar route serves its fallback under the short cache header.

**`spaceId` and `unstoppableDomains` start honouring `BROVIDER_URL`.** Both passed
`{ timeout: 5e3 }`, which was already the wrapper's default, and because a partial
options object replaced the defaults rather than merging into them, passing it was also
what made those two fall back to snapshot.js's own default host. Dropping the argument
fixes that, puts every call site on the same shape, and lets the options parameter go.
Worth confirming against the deployed `BROVIDER_URL` before merge: if it is
`https://rpc.snapshot.org`, as `.env.example` and `test/.env.test` both set it, this
one moves nothing.

Caching is unaffected. snapshot.js memoizes per network, URL and timeout, so the
hand-rolled cache goes away without a per-request construction taking its place.

The wrapper keeps snapshot.js's `any` return. Two of the eight call sites are Starknet,
where that same function hands back a starknet.js `RpcProvider` rather than a
`StaticJsonRpcProvider`, so no one concrete return type is true for all of them.
`src/resolvers/image/ens.ts` annotates its own local instead, which is what keeps its
ethers calls checked.

