### PR TITLE
fix(resolvers): stop the shibarium DNS cache from holding the process open

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "start": "node dist/src/index.js",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:integration": "jest --runInBand --forceExit test/integration",
-    "test:e2e": "jest --runInBand --forceExit test/e2e/"
+    "test:integration": "jest --runInBand test/integration",
+    "test:e2e": "jest --runInBand test/e2e/"
   },
   "dependencies": {
     "@adraffy/ens-normalize": "^1.10.0",

--- a/src/helpers/dns.ts
+++ b/src/helpers/dns.ts
@@ -8,7 +8,7 @@ class ExpiringCache implements DNSConnectCacheProvider {
   private entries = new Map<string, { value: string; expiresAt: number }>();
 
   async set(key: string, value: string, ttl: number): Promise<void> {
-    this.entries.set(key, { value, expiresAt: Date.now() + ttl * 1000 });
+    this.entries.set(key, { value, expiresAt: Date.now() + ttl * 1e3 });
   }
 
   async get(key: string): Promise<string | undefined> {

--- a/src/helpers/dns.ts
+++ b/src/helpers/dns.ts
@@ -1,0 +1,36 @@
+import { DNSConnect, DNSConnectCacheProvider } from '@webinterop/dns-connect';
+
+// Not dns-connect's own InMemoryCache: that one arms a ref'd setTimeout per entry to
+// evict it, and the TLD registration status it writes on every resolve() carries a
+// one-day TTL, so a single resolution keeps the Node process alive for 24 hours after
+// the work is done. Expiring on read instead needs no timer and answers the same.
+class ExpiringCache implements DNSConnectCacheProvider {
+  private entries = new Map<string, { value: string; expiresAt: number }>();
+
+  async set(key: string, value: string, ttl: number): Promise<void> {
+    this.entries.set(key, { value, expiresAt: Date.now() + ttl * 1000 });
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    const entry = this.entries.get(key);
+
+    if (!entry) return undefined;
+    if (entry.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+      return undefined;
+    }
+
+    return entry.value;
+  }
+
+  async delete(key: string): Promise<void> {
+    this.entries.delete(key);
+  }
+}
+
+export function dnsConnect(forwarderDomain: string): DNSConnect {
+  return new DNSConnect({
+    dns: { forwarderDomain },
+    caching: { cacheProvider: new ExpiringCache() }
+  });
+}

--- a/src/resolvers/address/shibarium.ts
+++ b/src/resolvers/address/shibarium.ts
@@ -1,6 +1,6 @@
-import { DNSConnect } from '@webinterop/dns-connect';
 import constants from '../../constants.json';
 import { isEvmAddress } from '../../helpers/address';
+import { dnsConnect } from '../../helpers/dns';
 import { withoutEmptyValues } from '../../helpers/object';
 import { Address, Handle, untilAborted, withDeadline } from '../../utils';
 
@@ -32,12 +32,10 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  const dnsConnect = new DNSConnect({
-    dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
-  });
+  const client = dnsConnect(constants.d3[CHAIN_ID].forwarder);
 
   const results = await boundedAll(
-    normalizedAddresses.map(address => dnsConnect.reverseResolve(address, NETWORK))
+    normalizedAddresses.map(address => client.reverseResolve(address, NETWORK))
   );
 
   return withoutEmptyValues(
@@ -50,12 +48,10 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  const dnsConnect = new DNSConnect({
-    dns: { forwarderDomain: constants.d3[CHAIN_ID].forwarder }
-  });
+  const client = dnsConnect(constants.d3[CHAIN_ID].forwarder);
 
   const results = await boundedAll(
-    normalizedHandles.map(handle => dnsConnect.resolve(handle, NETWORK))
+    normalizedHandles.map(handle => client.resolve(handle, NETWORK))
   );
 
   return withoutEmptyValues(

--- a/src/resolvers/getOwner/shibarium.ts
+++ b/src/resolvers/getOwner/shibarium.ts
@@ -1,5 +1,5 @@
-import { DNSConnect } from '@webinterop/dns-connect';
 import constants from '../../constants.json';
+import { dnsConnect } from '../../helpers/dns';
 import { Address, EMPTY_ADDRESS, Handle, untilAborted, withDeadline } from '../../utils';
 
 const MAINNET = '109';
@@ -44,13 +44,12 @@ async function getClaimedOwner(handle: Handle, chainId: string): Promise<Address
 }
 
 async function getResolvedAddress(handle: Handle, chainId: string): Promise<Address> {
-  const dnsConnect = new DNSConnect({ dns: { forwarderDomain: constants.d3[chainId].forwarder } });
+  const client = dnsConnect(constants.d3[chainId].forwarder);
 
   // dns-connect passes no signal to the DNS-over-HTTPS fetches it makes, so
   // only the wait can be bounded here, not the request.
   return withDeadline(
-    async signal =>
-      (await untilAborted(signal, dnsConnect.resolve(handle, NETWORK))) || EMPTY_ADDRESS
+    async signal => (await untilAborted(signal, client.resolve(handle, NETWORK))) || EMPTY_ADDRESS
   );
 }
 

--- a/test/unit/helpers/dns.test.ts
+++ b/test/unit/helpers/dns.test.ts
@@ -1,0 +1,39 @@
+import { DNSConnect } from '@webinterop/dns-connect';
+import { dnsConnect } from '../../../src/helpers/dns';
+
+jest.mock('@webinterop/dns-connect', () => ({
+  DNSConnect: jest.fn()
+}));
+
+const mockedDNSConnect = DNSConnect as unknown as jest.Mock;
+
+// The one-day TLD entry is what used to keep the process alive, so that is the TTL
+// this asks about.
+const ONE_DAY = 86400;
+
+function installedCache() {
+  dnsConnect('vana');
+
+  return mockedDNSConnect.mock.calls[0][0].caching.cacheProvider;
+}
+
+describe('helpers/dns', () => {
+  it('caches an answer without arming a timer for its expiry', async () => {
+    const cache = installedCache();
+    const timers = jest.spyOn(global, 'setTimeout');
+
+    await cache.set('_tld:shib', 'true', ONE_DAY);
+
+    expect(timers).not.toHaveBeenCalled();
+    await expect(cache.get('_tld:shib')).resolves.toBe('true');
+  });
+
+  it('stops answering once the TTL has passed', async () => {
+    const cache = installedCache();
+
+    await cache.set('_tld:shib', 'true', ONE_DAY);
+    jest.spyOn(Date, 'now').mockReturnValue(Date.now() + (ONE_DAY + 1) * 1e3);
+
+    await expect(cache.get('_tld:shib')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
`yarn test` prints its summary and then the node process stays up. `package.json` already
worked around that on two of the three test scripts: `test:integration` and `test:e2e` both
pass `--forceExit`, and they are also the two that pass `--runInBand`, which is where it
bites. `test` inherits the same problem wherever jest picks a single worker.

What holds the event loop open is the DNS cache inside `@webinterop/dns-connect`. Its
`InMemoryCache` evicts each entry with a plain `setTimeout`, and the DNS module writes the
TLD registration status with a one-day TTL on every `resolve()`. That timer is ref'd, so one
Shibarium name resolution keeps the process alive for a day after the work is done.

This is not only a test problem. `lookupAddresses`, `resolveNames` and `getOwner` each build
their own `DNSConnect`, so every request reaching a Shibarium resolver arms its own timers
over a cache instance nothing will ever read again, and the pending timer keeps that cache
reachable until it fires.

So the cache is replaced with one that expires on read rather than on a timer. It answers the
same and holds nothing open. The client is built in one place now instead of three, and the
`--forceExit` flags go with it.

Not addressed here: those call sites each build a fresh client, so the cache it carries can
only ever serve hits inside a single call. Sharing one client per forwarder domain would be a
real improvement, but it is a behaviour change and belongs on its own.
