### PR TITLE
feat(cache): share one cache module between the DNS and address stores

### DIFF
--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,3 @@
+export { CachePolicy, CacheStore } from './types';
+export { MemoryStore, MemoryStoreOptions } from './stores/memory';
+export { RedisStore, RedisStoreOptions } from './stores/redis';

--- a/src/cache/stores/memory.ts
+++ b/src/cache/stores/memory.ts
@@ -1,0 +1,64 @@
+import { CachePolicy, CacheStore } from '../types';
+
+export type MemoryStoreOptions = CachePolicy & {
+  maxEntries: number;
+};
+
+type Entry = { value: string; expiresAt: number };
+
+export class MemoryStore implements CacheStore {
+  private entries = new Map<string, Entry>();
+
+  constructor(private readonly options: MemoryStoreOptions) {}
+
+  async get(key: string): Promise<string | undefined> {
+    const entry = this.entries.get(key);
+
+    if (!entry) return undefined;
+
+    if (entry.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+
+      return undefined;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+
+    return entry.value;
+  }
+
+  async getMany(keys: string[]): Promise<Record<string, string>> {
+    const values = await Promise.all(keys.map(key => this.get(key)));
+
+    return Object.fromEntries(
+      keys.map((key, index) => [key, values[index]]).filter(([, value]) => value !== undefined)
+    );
+  }
+
+  async set(key: string, value: string, ttl = this.options.maxTtl): Promise<void> {
+    if (!value && !this.options.cacheEmpty) return;
+
+    this.entries.delete(key);
+    this.entries.set(key, {
+      value,
+      expiresAt: Date.now() + Math.min(ttl, this.options.maxTtl) * 1e3
+    });
+
+    while (this.entries.size > this.options.maxEntries) {
+      const [oldest] = this.entries.keys();
+
+      this.entries.delete(oldest);
+    }
+  }
+
+  async setMany(values: Record<string, string>, ttl?: number): Promise<void> {
+    for (const [key, value] of Object.entries(values)) {
+      await this.set(key, value, ttl);
+    }
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.entries.delete(key);
+  }
+}

--- a/src/cache/stores/redis.ts
+++ b/src/cache/stores/redis.ts
@@ -1,0 +1,65 @@
+import redis from '../../helpers/redis';
+import { CachePolicy, CacheStore } from '../types';
+
+export type RedisStoreOptions = CachePolicy & {
+  prefix: string;
+};
+
+export class RedisStore implements CacheStore {
+  constructor(private readonly options: RedisStoreOptions) {}
+
+  private prefixed(key: string): string {
+    return `${this.options.prefix}:${key}`;
+  }
+
+  private expiry(ttl = this.options.maxTtl) {
+    return { EX: Math.min(ttl, this.options.maxTtl) };
+  }
+
+  private stores(value: string): boolean {
+    return !!value || this.options.cacheEmpty;
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    if (!redis) return undefined;
+
+    return (await redis.get(this.prefixed(key))) ?? undefined;
+  }
+
+  async getMany(keys: string[]): Promise<Record<string, string>> {
+    if (!redis) return {};
+
+    const transaction = redis.multi();
+    keys.forEach(key => transaction.get(this.prefixed(key)));
+    const results = await transaction.exec();
+
+    return Object.fromEntries(
+      keys.map((key, index) => [key, results[index]]).filter(([, value]) => value !== null)
+    );
+  }
+
+  async set(key: string, value: string, ttl?: number): Promise<void> {
+    if (!redis || !this.stores(value)) return;
+
+    await redis.set(this.prefixed(key), value || '', this.expiry(ttl));
+  }
+
+  async setMany(values: Record<string, string>, ttl?: number): Promise<void> {
+    if (!redis) return;
+
+    const transaction = redis.multi();
+    Object.entries(values)
+      .filter(([, value]) => this.stores(value))
+      .forEach(([key, value]) =>
+        transaction.set(this.prefixed(key), value || '', this.expiry(ttl))
+      );
+
+    await transaction.exec();
+  }
+
+  async delete(key: string): Promise<boolean> {
+    if (!redis) return false;
+
+    return (await redis.del(this.prefixed(key))) > 0;
+  }
+}

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -1,0 +1,12 @@
+export type CachePolicy = {
+  maxTtl: number;
+  cacheEmpty: boolean;
+};
+
+export interface CacheStore {
+  get(key: string): Promise<string | undefined>;
+  getMany(keys: string[]): Promise<Record<string, string>>;
+  set(key: string, value: string, ttl?: number): Promise<void>;
+  setMany(values: Record<string, string>, ttl?: number): Promise<void>;
+  delete(key: string): Promise<boolean>;
+}

--- a/src/helpers/dns.ts
+++ b/src/helpers/dns.ts
@@ -1,36 +1,39 @@
 import { DNSConnect, DNSConnectCacheProvider } from '@webinterop/dns-connect';
+import { CacheStore, MemoryStore } from '../cache';
 
-// Not dns-connect's own InMemoryCache: that one arms a ref'd setTimeout per entry to
-// evict it, and the TLD registration status it writes on every resolve() carries a
-// one-day TTL, so a single resolution keeps the Node process alive for 24 hours after
-// the work is done. Expiring on read instead needs no timer and answers the same.
-class ExpiringCache implements DNSConnectCacheProvider {
-  private entries = new Map<string, { value: string; expiresAt: number }>();
+const ONE_DAY = 86400;
+const MAX_ENTRIES = 5000;
 
-  async set(key: string, value: string, ttl: number): Promise<void> {
-    this.entries.set(key, { value, expiresAt: Date.now() + ttl * 1e3 });
-  }
+const stores = new Map<string, CacheStore>();
 
-  async get(key: string): Promise<string | undefined> {
-    const entry = this.entries.get(key);
+function storeFor(forwarderDomain: string): CacheStore {
+  const existing = stores.get(forwarderDomain);
 
-    if (!entry) return undefined;
-    if (entry.expiresAt <= Date.now()) {
-      this.entries.delete(key);
-      return undefined;
+  if (existing) return existing;
+
+  const store = new MemoryStore({
+    maxEntries: MAX_ENTRIES,
+    maxTtl: ONE_DAY,
+    cacheEmpty: false
+  });
+  stores.set(forwarderDomain, store);
+
+  return store;
+}
+
+function cacheProvider(store: CacheStore): DNSConnectCacheProvider {
+  return {
+    get: key => store.get(key),
+    set: (key, value, ttl) => store.set(key, value, ttl),
+    delete: async key => {
+      await store.delete(key);
     }
-
-    return entry.value;
-  }
-
-  async delete(key: string): Promise<void> {
-    this.entries.delete(key);
-  }
+  };
 }
 
 export function dnsConnect(forwarderDomain: string): DNSConnect {
   return new DNSConnect({
     dns: { forwarderDomain },
-    caching: { cacheProvider: new ExpiringCache() }
+    caching: { cacheProvider: cacheProvider(storeFor(forwarderDomain)) }
   });
 }

--- a/src/resolvers/address/cache.ts
+++ b/src/resolvers/address/cache.ts
@@ -1,30 +1,17 @@
+import { RedisStore } from '../../cache';
 import constants from '../../constants.json';
 import { addressResolversCacheHitCount } from '../../helpers/metrics';
-import redis from '../../helpers/redis';
 
 export const KEY_PREFIX = 'address-resolvers';
 
-export async function getCache(keys: string[]): Promise<Record<string, string>> {
-  if (!redis) return {};
+const store = new RedisStore({ prefix: KEY_PREFIX, maxTtl: constants.ttl, cacheEmpty: true });
 
-  const transaction = redis.multi();
-  keys.map(key => transaction.get(`${KEY_PREFIX}:${key}`));
-  const results = await transaction.exec();
-
-  return Object.fromEntries(
-    keys.map((key, index) => [key, results[index]]).filter(([, value]) => value !== null)
-  );
+export function getCache(keys: string[]): Promise<Record<string, string>> {
+  return store.getMany(keys);
 }
 
-export function setCache(payload: Record<string, string>) {
-  if (!redis) return;
-
-  const transaction = redis.multi();
-  Object.entries(payload).map(([key, value]) =>
-    transaction.set(`${KEY_PREFIX}:${key}`, value || '', { EX: constants.ttl })
-  );
-
-  return transaction.exec();
+export function setCache(payload: Record<string, string>): Promise<void> {
+  return store.setMany(payload);
 }
 
 export default async function cache(input: string[], callback) {
@@ -45,10 +32,8 @@ export default async function cache(input: string[], callback) {
   return cache;
 }
 
-export async function clear(input: string): Promise<boolean> {
+export function clear(input: string): Promise<boolean> {
   // TODO: When redis is not available, it should probably throw instead of returning false
   // causing the api the return "failed to clear cache" instead of "not found"
-  if (!redis) return false;
-
-  return (await redis?.del(`${KEY_PREFIX}:${input}`)) > 0;
+  return store.delete(input);
 }

--- a/test/integration/resolvers/address/cache.test.ts
+++ b/test/integration/resolvers/address/cache.test.ts
@@ -1,0 +1,23 @@
+import redis from '../../../../src/helpers/redis';
+import { setCache } from '../../../../src/resolvers/address/cache';
+
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const KEY = `address-resolvers:${ADDRESS}`;
+const TTL = 43200;
+
+// Written out rather than derived from KEY_PREFIX and constants.ttl: derived, this would
+// pass symmetrically and check nothing.
+describe('address resolvers cache', () => {
+  beforeEach(() => redis?.flushDb());
+
+  it('stores an answer under its own key for twelve hours', async () => {
+    await setCache({ [ADDRESS]: 'less.eth' });
+
+    await expect(redis?.get(KEY)).resolves.toBe('less.eth');
+
+    const ttl = await redis?.ttl(KEY);
+
+    expect(ttl).toBeGreaterThan(TTL - 10);
+    expect(ttl).toBeLessThanOrEqual(TTL);
+  });
+});

--- a/test/unit/cache/memory.test.ts
+++ b/test/unit/cache/memory.test.ts
@@ -1,0 +1,64 @@
+import { MemoryStore, MemoryStoreOptions } from '../../../src/cache';
+
+function store(options: Partial<MemoryStoreOptions> = {}) {
+  return new MemoryStore({ maxEntries: 3, maxTtl: 60, cacheEmpty: false, ...options });
+}
+
+describe('cache/stores/memory', () => {
+  describe('the entry bound', () => {
+    it('holds no more than max, however many are written', async () => {
+      const cache = store({ maxEntries: 10 });
+
+      for (let i = 0; i < 1000; i++) {
+        await cache.set(`key-${i}`, `value-${i}`);
+      }
+
+      const answered = await Promise.all(
+        Array.from({ length: 1000 }, (_, i) => cache.get(`key-${i}`))
+      );
+
+      expect(answered.filter(value => value !== undefined)).toHaveLength(10);
+    });
+
+    it('evicts what has gone unread longest, not what was written first', async () => {
+      const cache = store({ maxEntries: 3 });
+
+      await cache.set('old-but-read', 'kept');
+      await cache.set('old-and-unread', 'dropped');
+      await cache.set('filler', 'filler');
+
+      await cache.get('old-but-read');
+      await cache.set('newest', 'newest');
+
+      await expect(cache.get('old-but-read')).resolves.toBe('kept');
+      await expect(cache.get('old-and-unread')).resolves.toBeUndefined();
+    });
+  });
+
+  it('holds an entry no longer than the policy, whatever the caller asks for', async () => {
+    const cache = store({ maxTtl: 60 });
+
+    await cache.set('key', 'value', 86400);
+    jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 61 * 1e3);
+
+    await expect(cache.get('key')).resolves.toBeUndefined();
+  });
+
+  describe('an empty answer', () => {
+    it('is dropped when the policy does not cache empties', async () => {
+      const cache = store({ cacheEmpty: false });
+
+      await cache.set('key', '');
+
+      await expect(cache.get('key')).resolves.toBeUndefined();
+    });
+
+    it('is kept when the policy caches empties', async () => {
+      const cache = store({ cacheEmpty: true });
+
+      await cache.set('key', '');
+
+      await expect(cache.get('key')).resolves.toBe('');
+    });
+  });
+});

--- a/test/unit/helpers/dns.test.ts
+++ b/test/unit/helpers/dns.test.ts
@@ -7,19 +7,17 @@ jest.mock('@webinterop/dns-connect', () => ({
 
 const mockedDNSConnect = DNSConnect as unknown as jest.Mock;
 
-// The one-day TLD entry is what used to keep the process alive, so that is the TTL
-// this asks about.
 const ONE_DAY = 86400;
 
-function installedCache() {
-  dnsConnect('vana');
+function installedCache(forwarderDomain: string) {
+  dnsConnect(forwarderDomain);
 
-  return mockedDNSConnect.mock.calls[0][0].caching.cacheProvider;
+  return mockedDNSConnect.mock.calls.at(-1)[0].caching.cacheProvider;
 }
 
 describe('helpers/dns', () => {
   it('caches an answer without arming a timer for its expiry', async () => {
-    const cache = installedCache();
+    const cache = installedCache('no-timer');
     const timers = jest.spyOn(global, 'setTimeout');
 
     await cache.set('_tld:shib', 'true', ONE_DAY);
@@ -29,11 +27,37 @@ describe('helpers/dns', () => {
   });
 
   it('stops answering once the TTL has passed', async () => {
-    const cache = installedCache();
+    const cache = installedCache('expiry');
 
     await cache.set('_tld:shib', 'true', ONE_DAY);
     jest.spyOn(Date, 'now').mockReturnValue(Date.now() + (ONE_DAY + 1) * 1e3);
 
     await expect(cache.get('_tld:shib')).resolves.toBeUndefined();
+  });
+
+  it('does not cache a name the resolver could not fill', async () => {
+    const cache = installedCache('empty-answer');
+
+    await cache.set('missing.shib:BONE', '', ONE_DAY);
+
+    await expect(cache.get('missing.shib:BONE')).resolves.toBeUndefined();
+  });
+
+  it('answers a later client from what an earlier one cached', async () => {
+    const first = installedCache('reused');
+    const second = installedCache('reused');
+
+    await first.set('_tld:shib', 'false', ONE_DAY);
+
+    await expect(second.get('_tld:shib')).resolves.toBe('false');
+  });
+
+  it('does not let one forwarder domain answer from another', async () => {
+    const mainnet = installedCache('mainnet');
+    const testnet = installedCache('testnet');
+
+    await mainnet.set('alice.shib:BONE', '0xmainnet', ONE_DAY);
+
+    await expect(testnet.get('alice.shib:BONE')).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
Depends on #555

#555 is in master, so the Shibarium DNS cache expires on read now instead of holding a timer.
It is still built inside `dnsConnect()` though: every call gets a fresh client with a fresh
cache, so nothing that cache learns outlives the request that filled it and the TLD
registration lookup starts from cold every time. The memory store below is what makes that
cache survive across requests rather than being created and discarded inside each call, which
is the whole point of it and easier to see now the timer fix has landed.

The address resolvers cache is the same job again, written straight against redis in
`resolvers/address/cache.ts`.

So there is one `src/cache` module now: a `CacheStore` interface with a memory store and a
redis store behind it, and a policy per kind instead of one policy for everything.

The address cache moves onto the redis store with its behaviour held still: same
`address-resolvers` prefix, same TTL, same empty string for an address that resolves to no
name.

The DNS cache moves onto the memory store, kept at module scope per forwarder domain.
dns-connect keys its entries by name and network alone, so mainnet and testnet need separate
stores or they answer each other's lookups.

Memory rather than redis for that one. dns-connect's provider interface is async so redis
would fit, but the library awaits the cache unguarded and a rejected read propagates straight
out of `resolve()`, which would let a redis blip fail a Shibarium resolution that would
otherwise have succeeded. What redis would add is sharing between instances, and the repeats
that sharing would serve are largely absorbed by the address resolvers cache sitting in front
of Shibarium.

Two things the module is explicit about.

**The memory store is bounded.** Expiring on read is what keeps it timer-free, but it never
reaches an entry that nothing asks for again. Per call that did not matter, since the whole
cache died with the call. At module scope it does, so the store takes a maximum entry count
and drops whatever has gone unread longest.

**Empty answers are a per-kind choice.** The address routes go on caching an address with no
name for the full TTL. DNS does not cache one at all, so a name that failed to resolve is
tried again on the next request rather than held for the record's TTL.

Not addressed here: the address routes cache an empty answer for twelve hours, so one
transient upstream timeout pins "no name" for half a day and the recovered upstream is not
consulted again until the key expires. That is a production behaviour change and wants its
own review.
