### PR TITLE
refactor(ens): batch reverse lookup through the Universal Resolver

### DIFF
--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -7,14 +7,44 @@ export function httpError(source: string, status: number, message: string) {
   });
 }
 
+function getErrorNodes(error: any): any[] {
+  const nodes: any[] = [];
+  const pending = [error];
+  const seen = new Set();
+
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (!node || (typeof node !== 'object' && typeof node !== 'function') || seen.has(node)) {
+      continue;
+    }
+
+    seen.add(node);
+    nodes.push(node);
+    pending.push(node.error, node.cause);
+  }
+
+  return nodes;
+}
+
 export function isSilencedError(error: any, additionalMessages?: string[]): boolean {
   // A rejection carries whatever it was given, null included. There is nothing
   // in one to classify, and reporting it is not an option either: `capture`
   // dereferences it and throws, from inside the catch block that called this.
   if (!error) return true;
 
+  // ethers v5 re-labels a non-JSON response from an RPC as CALL_EXCEPTION.
+  // The nested HTTP status is the reliable signal that this was an upstream
+  // endpoint outage rather than a contract revert.
+  const upstreamStatus = Number(error.error?.status);
+  if (upstreamStatus >= 500 && upstreamStatus < 600) return true;
+
+  const nodes = getErrorNodes(error);
+  const statuses = nodes.flatMap(node => [node.status, node.response?.status]);
+
+  if (statuses.some(status => status === 401 || status === 403)) return false;
+
   // An abort is always one of our own deadlines, and each transport words it differently.
-  if (error.name === 'AbortError') return true;
+  if (nodes.some(node => node.name === 'AbortError')) return true;
 
   const messages = [
     'invalid token ID',
@@ -30,31 +60,21 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
     'bad port',
     ...(additionalMessages || [])
   ];
-  const codes = [
-    error.error?.code,
-    error.error?.status,
-    error.code,
-    error.status,
-    error.response?.status,
-    error.cause?.code
-  ];
-
-  // ethers v5 re-labels a non-JSON response from an RPC as CALL_EXCEPTION.
-  // The nested HTTP status is the reliable signal that this was an upstream
-  // endpoint outage rather than a contract revert.
-  const upstreamStatus = Number(error.error?.status);
-  if (upstreamStatus >= 500 && upstreamStatus < 600) return true;
-
+  const codes = nodes.flatMap(node => [node.code, node.status, node.response?.status, node.name]);
   return (
-    messages.some(
-      m =>
-        error.message?.includes(m) ||
-        error.error?.message?.includes(m) ||
-        error.cause?.message?.includes(m)
+    messages.some(m =>
+      nodes.some(node => node.message?.includes(m) || node.details?.includes(m))
     ) ||
-    ['TIMEOUT', 'ETIMEDOUT', 'ECONNRESET', 'UND_ERR_SOCKET', 504, 429].some(c =>
-      codes.some(v => String(v ?? '').includes(String(c)))
-    )
+    [
+      'TIMEOUT',
+      'TimeoutError',
+      'ETIMEDOUT',
+      'ECONNRESET',
+      'ECONNREFUSED',
+      'UND_ERR_SOCKET',
+      504,
+      429
+    ].some(c => codes.some(v => String(v ?? '').includes(String(c))))
   );
 }
 

--- a/src/resolvers/address/cache.ts
+++ b/src/resolvers/address/cache.ts
@@ -1,3 +1,4 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import { RedisStore } from '../../cache';
 import constants from '../../constants.json';
 import { addressResolversCacheHitCount } from '../../helpers/metrics';
@@ -38,7 +39,7 @@ export default async function cache(
     const cacheable = Object.fromEntries(
       Object.entries(results).filter(([key]) => !nonCacheable.has(key))
     );
-    await setCache(cacheable);
+    setCache(cacheable).catch(capture);
 
     return { ...cache, ...results };
   }

--- a/src/resolvers/address/cache.ts
+++ b/src/resolvers/address/cache.ts
@@ -3,6 +3,13 @@ import constants from '../../constants.json';
 import { addressResolversCacheHitCount } from '../../helpers/metrics';
 
 export const KEY_PREFIX = 'address-resolvers';
+export const NON_CACHEABLE = Symbol('non-cacheable');
+export type CacheResult = Record<string, string> & { [NON_CACHEABLE]?: string[] };
+
+export function markNonCacheable(result: Record<string, string>, keys: string[]): CacheResult {
+  if (keys.length > 0) Object.defineProperty(result, NON_CACHEABLE, { value: keys });
+  return result;
+}
 
 const store = new RedisStore({ prefix: KEY_PREFIX, maxTtl: constants.ttl, cacheEmpty: true });
 
@@ -14,7 +21,10 @@ export function setCache(payload: Record<string, string>): Promise<void> {
   return store.setMany(payload);
 }
 
-export default async function cache(input: string[], callback) {
+export default async function cache(
+  input: string[],
+  callback: (input: string[]) => Promise<CacheResult>
+) {
   const cache = await getCache(input);
   const cachedKeys = Object.keys(cache);
   const uncachedInputs = input.filter(a => !cachedKeys.includes(a));
@@ -24,7 +34,11 @@ export default async function cache(input: string[], callback) {
 
   if (uncachedInputs.length > 0) {
     const results = await callback(uncachedInputs);
-    setCache(results);
+    const nonCacheable = new Set(results[NON_CACHEABLE] || []);
+    const cacheable = Object.fromEntries(
+      Object.entries(results).filter(([key]) => !nonCacheable.has(key))
+    );
+    await setCache(cacheable);
 
     return { ...cache, ...results };
   }

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -1,6 +1,7 @@
 import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { markNonCacheable } from './cache';
 import { reverseLookup } from './universalResolver';
 import constants from '../../constants.json';
 import { isEvmAddress } from '../../helpers/address';
@@ -38,16 +39,29 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   const { values, errors } = await reverseLookup(normalizedAddresses);
 
-  if (errors.length > 0 && Object.keys(values).length === 0) {
-    throw errors[0];
+  if (errors.length === normalizedAddresses.length) {
+    throw (errors.find(({ error }) => !isSilencedError(error)) || errors[0]).error;
   }
 
-  const validNames = normalizeEns(normalizedAddresses.map(address => values[address] || ''));
+  errors.forEach(({ address, error }) => {
+    if (!isSilencedError(error)) {
+      capture(error, {
+        tags: { provider: NAME },
+        contexts: { input: { lookupAddresses: [address] } }
+      });
+    }
+  });
 
-  return Object.fromEntries(
+  const validNames = normalizeEns(normalizedAddresses.map(address => values[address] || ''));
+  const result = Object.fromEntries(
     normalizedAddresses
       .map((address, index) => [address, validNames[index]])
       .filter((_, index) => !!validNames[index])
+  );
+
+  return markNonCacheable(
+    result,
+    errors.map(({ address }) => address)
   );
 }
 

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -1,7 +1,7 @@
 import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import snapshot from '@snapshot-labs/snapshot.js';
+import { reverseLookup } from './universalResolver';
 import constants from '../../constants.json';
 import { isEvmAddress } from '../../helpers/address';
 import { isSilencedError, isTransportFailure } from '../../helpers/errors';
@@ -32,35 +32,17 @@ function normalizeHandles(names: Handle[]): Handle[] {
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
-  const abi = ['function getNames(address[] addresses) view returns (string[] r)'];
   const normalizedAddresses = normalizeAddresses(addresses);
 
   if (normalizedAddresses.length === 0) return {};
 
-  let reverseRecords: string[] = [];
-  try {
-    reverseRecords = await snapshot.utils.call(
-      provider,
-      abi,
-      ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [normalizedAddresses]],
-      { blockTag: 'latest' }
-    );
-  } catch (err: any) {
-    if (err?.code !== 'CALL_EXCEPTION') throw err;
-  }
-  const validNames = normalizeEns(reverseRecords);
+  const { values, errors } = await reverseLookup(normalizedAddresses);
 
-  // The batch contract only reads on-chain reverse records. Names served by
-  // off-chain resolvers (CCIP-Read) need provider.lookupAddress, which follows
-  // the OffchainLookup flow via the ENS UniversalResolver.
-  const missing = normalizedAddresses.map((_, i) => i).filter(i => !validNames[i]);
-  const lookups = await Promise.allSettled(
-    missing.map(idx => provider.lookupAddress(normalizedAddresses[idx]))
-  );
-  const fallbackNames = normalizeEns(lookups.map(r => (r.status === 'fulfilled' && r.value) || ''));
-  missing.forEach((idx, j) => {
-    if (fallbackNames[j]) validNames[idx] = fallbackNames[j];
-  });
+  if (errors.length > 0 && Object.keys(values).length === 0) {
+    throw errors[0];
+  }
+
+  const validNames = normalizeEns(normalizedAddresses.map(address => values[address] || ''));
 
   return Object.fromEntries(
     normalizedAddresses

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -2,7 +2,7 @@ import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { markNonCacheable } from './cache';
-import { reverseLookup } from './universalResolver';
+import { isSilencedReverseError, reverseLookup } from './universalResolver';
 import constants from '../../constants.json';
 import { isEvmAddress } from '../../helpers/address';
 import { isSilencedError, isTransportFailure } from '../../helpers/errors';
@@ -32,6 +32,10 @@ function normalizeHandles(names: Handle[]): Handle[] {
   return normalizeEns(names).filter(h => h);
 }
 
+function isSilencedLookupError(error: unknown): boolean {
+  return isSilencedError(error) || isSilencedReverseError(error);
+}
+
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
   const normalizedAddresses = normalizeAddresses(addresses);
 
@@ -40,11 +44,13 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
   const { values, errors } = await reverseLookup(normalizedAddresses);
 
   if (errors.length === normalizedAddresses.length) {
-    throw (errors.find(({ error }) => !isSilencedError(error)) || errors[0]).error;
+    const actionable = errors.find(({ error }) => !isSilencedLookupError(error));
+    if (actionable) throw actionable.error;
+    return markNonCacheable({}, normalizedAddresses);
   }
 
   errors.forEach(({ address, error }) => {
-    if (!isSilencedError(error)) {
+    if (!isSilencedLookupError(error)) {
       capture(error, {
         tags: { provider: NAME },
         contexts: { input: { lookupAddresses: [address] } }

--- a/src/resolvers/address/index.ts
+++ b/src/resolvers/address/index.ts
@@ -69,6 +69,7 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
               result = await r[fnName](_input);
               status = 1;
             } catch (err) {
+              result = markNonCacheable({}, _input);
               if (!isSilencedError(err, r.MUTED_ERRORS) && !isTransportFailure(err)) {
                 // A top-level `input` beside `tags` is dropped rather than wrapped.
                 capture(err, {

--- a/src/resolvers/address/index.ts
+++ b/src/resolvers/address/index.ts
@@ -85,7 +85,7 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
         );
 
         const merged = Object.fromEntries(
-          _input.map(item => [item, results.map(r => r[item]).filter(i => !!i)[0] || ''])
+          _input.map(item => [item, results.map(result => result[item]).find(Boolean) || ''])
         );
         const nonCacheable = new Set(results.flatMap(result => result[NON_CACHEABLE] || []));
 

--- a/src/resolvers/address/index.ts
+++ b/src/resolvers/address/index.ts
@@ -1,6 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import * as basenameResolver from './basename';
-import cache, { clear } from './cache';
+import cache, { CacheResult, clear, markNonCacheable, NON_CACHEABLE } from './cache';
 import * as ensResolver from './ens';
 import * as gweiResolver from './gwei';
 import * as lensResolver from './lens';
@@ -25,8 +25,8 @@ import { Address, Handle } from '../../helpers/types';
 type Resolver = {
   NAME: string;
   MUTED_ERRORS?: string[];
-  lookupAddresses: (addresses: Address[]) => Promise<Record<Address, Handle>>;
-  resolveNames: (handles: Handle[]) => Promise<Record<Handle, Address>>;
+  lookupAddresses: (addresses: Address[]) => Promise<CacheResult>;
+  resolveNames: (handles: Handle[]) => Promise<CacheResult>;
 };
 
 const RESOLVERS: Resolver[] = [
@@ -62,7 +62,7 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
               provider: r.NAME,
               method: fnName
             });
-            let result = {};
+            let result: CacheResult = {};
             let status = 0;
 
             try {
@@ -83,8 +83,14 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
           })
         );
 
-        return Object.fromEntries(
+        const merged = Object.fromEntries(
           _input.map(item => [item, results.map(r => r[item]).filter(i => !!i)[0] || ''])
+        );
+        const nonCacheable = new Set(results.flatMap(result => result[NON_CACHEABLE] || []));
+
+        return markNonCacheable(
+          merged,
+          [...nonCacheable].filter(item => !merged[item])
         );
       })
     )

--- a/src/resolvers/address/universalResolver.ts
+++ b/src/resolvers/address/universalResolver.ts
@@ -13,7 +13,6 @@ import { getProviderOptions } from '../../helpers/provider';
 
 const rpcUrl = `${getProviderOptions().broviderUrl}/${mainnet.id}`;
 const EMPTY_REVERSE_ERRORS = new Set([
-  'ResolverError',
   'ResolverNotContract',
   'ResolverNotFound',
   'ReverseAddressMismatch',

--- a/src/resolvers/address/universalResolver.ts
+++ b/src/resolvers/address/universalResolver.ts
@@ -1,6 +1,8 @@
 import {
+  BaseError,
   ccipRequest,
   CcipRequestParameters,
+  ContractFunctionRevertedError,
   createPublicClient,
   http,
   Address as ViemAddress
@@ -10,6 +12,24 @@ import { withDeadline } from '../../helpers/deadline';
 import { getProviderOptions } from '../../helpers/provider';
 
 const rpcUrl = `${getProviderOptions().broviderUrl}/${mainnet.id}`;
+const EMPTY_REVERSE_ERRORS = new Set([
+  'ResolverError',
+  'ResolverNotContract',
+  'ResolverNotFound',
+  'ReverseAddressMismatch',
+  'UnsupportedResolverProfile'
+]);
+
+function isEmptyReverseError(error: unknown): boolean {
+  if (!(error instanceof BaseError)) return false;
+
+  const reverted = error.walk(cause => cause instanceof ContractFunctionRevertedError);
+
+  return (
+    reverted instanceof ContractFunctionRevertedError &&
+    EMPTY_REVERSE_ERRORS.has(reverted.data?.errorName || '')
+  );
+}
 const client = createPublicClient({
   chain: mainnet,
   batch: { multicall: { batchSize: 16 * 1024 } },
@@ -35,7 +55,7 @@ export type BatchResult = { values: Record<string, string>; errors: BatchError[]
 
 export async function reverseLookup(addresses: string[]): Promise<BatchResult> {
   const settled = await Promise.allSettled(
-    addresses.map(address => client.getEnsName({ address: address as ViemAddress }))
+    addresses.map(address => client.getEnsName({ address: address as ViemAddress, strict: true }))
   );
   const values: Record<string, string> = {};
   const errors: BatchError[] = [];
@@ -43,7 +63,7 @@ export async function reverseLookup(addresses: string[]): Promise<BatchResult> {
   settled.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       if (result.value) values[addresses[index]] = result.value;
-    } else {
+    } else if (!isEmptyReverseError(result.reason)) {
       errors.push({ address: addresses[index], error: result.reason });
     }
   });

--- a/src/resolvers/address/universalResolver.ts
+++ b/src/resolvers/address/universalResolver.ts
@@ -1,27 +1,50 @@
-import { createPublicClient, http, Address as ViemAddress } from 'viem';
+import {
+  ccipRequest,
+  CcipRequestParameters,
+  createPublicClient,
+  http,
+  Address as ViemAddress
+} from 'viem';
 import { mainnet } from 'viem/chains';
+import { withDeadline } from '../../helpers/deadline';
+import { getProviderOptions } from '../../helpers/provider';
 
-const rpcUrl = `${process.env.BROVIDER_URL || 'https://rpc.snapshot.org'}/1`;
+const rpcUrl = `${getProviderOptions().broviderUrl}/${mainnet.id}`;
 const client = createPublicClient({
   chain: mainnet,
-  batch: { multicall: { batchSize: 64 * 1024, wait: 0 } },
-  transport: http(rpcUrl, { retryCount: 0, timeout: 5e3 })
+  batch: { multicall: { batchSize: 16 * 1024 } },
+  transport: http(rpcUrl, { retryCount: 0, timeout: 5e3 }),
+  ccipRead: {
+    request: (parameters: CcipRequestParameters) =>
+      withDeadline(signal =>
+        ccipRequest({
+          ...parameters,
+          requestOptions: {
+            ...parameters.requestOptions,
+            signal: parameters.requestOptions?.signal
+              ? AbortSignal.any([parameters.requestOptions.signal, signal])
+              : signal
+          }
+        })
+      )
+  }
 });
 
-export type BatchResult = { values: Record<string, string>; errors: unknown[] };
+export type BatchError = { address: string; error: unknown };
+export type BatchResult = { values: Record<string, string>; errors: BatchError[] };
 
 export async function reverseLookup(addresses: string[]): Promise<BatchResult> {
   const settled = await Promise.allSettled(
     addresses.map(address => client.getEnsName({ address: address as ViemAddress }))
   );
   const values: Record<string, string> = {};
-  const errors: unknown[] = [];
+  const errors: BatchError[] = [];
 
   settled.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       if (result.value) values[addresses[index]] = result.value;
     } else {
-      errors.push(result.reason);
+      errors.push({ address: addresses[index], error: result.reason });
     }
   });
 

--- a/src/resolvers/address/universalResolver.ts
+++ b/src/resolvers/address/universalResolver.ts
@@ -1,0 +1,29 @@
+import { createPublicClient, http, Address as ViemAddress } from 'viem';
+import { mainnet } from 'viem/chains';
+
+const rpcUrl = `${process.env.BROVIDER_URL || 'https://rpc.snapshot.org'}/1`;
+const client = createPublicClient({
+  chain: mainnet,
+  batch: { multicall: { batchSize: 64 * 1024, wait: 0 } },
+  transport: http(rpcUrl, { retryCount: 0, timeout: 5e3 })
+});
+
+export type BatchResult = { values: Record<string, string>; errors: unknown[] };
+
+export async function reverseLookup(addresses: string[]): Promise<BatchResult> {
+  const settled = await Promise.allSettled(
+    addresses.map(address => client.getEnsName({ address: address as ViemAddress }))
+  );
+  const values: Record<string, string> = {};
+  const errors: unknown[] = [];
+
+  settled.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      if (result.value) values[addresses[index]] = result.value;
+    } else {
+      errors.push(result.reason);
+    }
+  });
+
+  return { values, errors };
+}

--- a/src/resolvers/address/universalResolver.ts
+++ b/src/resolvers/address/universalResolver.ts
@@ -19,15 +19,35 @@ const EMPTY_REVERSE_ERRORS = new Set([
   'ReverseAddressMismatch',
   'UnsupportedResolverProfile'
 ]);
+const TRANSIENT_GATEWAY_ERRORS = new Set(['This operation was aborted', 'HTTP request failed.']);
 
-function isEmptyReverseError(error: unknown): boolean {
-  if (!(error instanceof BaseError)) return false;
+function getRevertedError(error: unknown): ContractFunctionRevertedError | undefined {
+  if (!(error instanceof BaseError)) return;
 
   const reverted = error.walk(cause => cause instanceof ContractFunctionRevertedError);
+  return reverted instanceof ContractFunctionRevertedError ? reverted : undefined;
+}
+
+function isEmptyReverseError(error: unknown): boolean {
+  return EMPTY_REVERSE_ERRORS.has(getRevertedError(error)?.data?.errorName || '');
+}
+
+export function isSilencedReverseError(error: unknown): boolean {
+  if (!(error instanceof BaseError)) return false;
+  if (!error.walk(cause => cause instanceof Error && cause.name === 'OffchainLookupError')) {
+    return false;
+  }
+
+  const data = getRevertedError(error)?.data;
+  if (data?.errorName === 'HttpError') {
+    const status = data.args?.[0];
+    return typeof status === 'number' && (status === 429 || status >= 500);
+  }
 
   return (
-    reverted instanceof ContractFunctionRevertedError &&
-    EMPTY_REVERSE_ERRORS.has(reverted.data?.errorName || '')
+    data?.errorName === 'Error' &&
+    typeof data.args?.[0] === 'string' &&
+    TRANSIENT_GATEWAY_ERRORS.has(data.args[0])
   );
 }
 const client = createPublicClient({

--- a/test/integration/helpers/errors.test.ts
+++ b/test/integration/helpers/errors.test.ts
@@ -1,3 +1,4 @@
+import { BaseError, HttpRequestError, TimeoutError } from 'viem';
 import { isSilencedError } from '../../../src/helpers/errors';
 
 describe('isSilencedError', () => {
@@ -110,6 +111,51 @@ describe('isSilencedError', () => {
     };
 
     expect(isSilencedError(upstreamError)).toBe(false);
+  });
+
+  it('silences a deeply wrapped viem timeout', () => {
+    const timeout = new TimeoutError({ body: { method: 'eth_call' }, url: 'https://rpc.test' });
+    const wrapped = new BaseError('Contract call failed', {
+      cause: new BaseError('Call failed', { cause: timeout })
+    });
+
+    expect(isSilencedError(wrapped)).toBe(true);
+  });
+
+  it('silences a deeply wrapped viem connection refusal', () => {
+    const refused = Object.assign(new Error('connect ECONNREFUSED'), {
+      code: 'ECONNREFUSED'
+    });
+    const request = new HttpRequestError({ cause: refused, url: 'https://rpc.test' });
+    const wrapped = new BaseError('Contract call failed', {
+      cause: new BaseError('Call failed', { cause: request })
+    });
+
+    expect(isSilencedError(wrapped)).toBe(true);
+  });
+
+  it('does not silence a deeply wrapped viem authentication failure', () => {
+    const request = new HttpRequestError({
+      details: 'Unauthorized',
+      status: 401,
+      url: 'https://rpc.test'
+    });
+    const wrapped = new BaseError('Contract call failed', {
+      cause: new BaseError('Call failed', { cause: request })
+    });
+
+    expect(isSilencedError(wrapped)).toBe(false);
+  });
+
+  it('does not silence a deeply wrapped viem contract failure', () => {
+    const contract = new BaseError('Invalid contract return data', {
+      name: 'AbiDecodingDataSizeTooSmallError'
+    });
+    const wrapped = new BaseError('Contract call failed', {
+      cause: new BaseError('Call failed', { cause: contract })
+    });
+
+    expect(isSilencedError(wrapped)).toBe(false);
   });
 
   it('silences transient SERVFAIL DNS server status (2)', () => {

--- a/test/integration/resolvers/address/cache.test.ts
+++ b/test/integration/resolvers/address/cache.test.ts
@@ -48,8 +48,7 @@ describe('address resolvers cache', () => {
 
     let responseValue: Record<string, string> | undefined;
     let responseError: unknown;
-    const response = cache([ADDRESS], async () => ({ [ADDRESS]: 'less.eth' }));
-    const trackedResponse = response.then(
+    const trackedResponse = cache([ADDRESS], async () => ({ [ADDRESS]: 'less.eth' })).then(
       value => {
         responseValue = value;
       },

--- a/test/integration/resolvers/address/cache.test.ts
+++ b/test/integration/resolvers/address/cache.test.ts
@@ -1,3 +1,5 @@
+import * as sentry from '@snapshot-labs/snapshot-sentry';
+import { RedisStore } from '../../../../src/cache';
 import redis from '../../../../src/helpers/redis';
 import cache, {
   getCache,
@@ -15,6 +17,7 @@ const TTL = 43200;
 // pass symmetrically and check nothing.
 describe('address resolvers cache', () => {
   beforeEach(() => redis?.flushDb());
+  afterEach(() => jest.restoreAllMocks());
 
   it('stores an answer under its own key for twelve hours', async () => {
     await setCache({ [ADDRESS]: 'less.eth' });
@@ -25,6 +28,47 @@ describe('address resolvers cache', () => {
 
     expect(ttl).toBeGreaterThan(TTL - 10);
     expect(ttl).toBeLessThanOrEqual(TTL);
+  });
+
+  it('returns an answer before a cache write settles and reports a rejected write', async () => {
+    const failure = new Error('redis write failed');
+    let rejectWrite!: (error: Error) => void;
+    let writeStarted!: () => void;
+    const started = new Promise<void>(resolve => {
+      writeStarted = resolve;
+    });
+    const write = new Promise<void>((_resolve, reject) => {
+      rejectWrite = reject;
+    });
+    jest.spyOn(RedisStore.prototype, 'setMany').mockImplementationOnce(() => {
+      writeStarted();
+      return write;
+    });
+    const capture = jest.spyOn(sentry, 'capture').mockReturnValue('' as any);
+
+    let responseValue: Record<string, string> | undefined;
+    let responseError: unknown;
+    const response = cache([ADDRESS], async () => ({ [ADDRESS]: 'less.eth' }));
+    const trackedResponse = response.then(
+      value => {
+        responseValue = value;
+      },
+      error => {
+        responseError = error;
+      }
+    );
+
+    await started;
+    await new Promise(resolve => setImmediate(resolve));
+    const settledBeforeWrite = responseValue !== undefined || responseError !== undefined;
+    rejectWrite(failure);
+    await trackedResponse;
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(settledBeforeWrite).toBe(true);
+    expect(responseValue).toEqual({ [ADDRESS]: 'less.eth' });
+    expect(responseError).toBeUndefined();
+    expect(capture).toHaveBeenCalledWith(failure);
   });
 
   it('does not cache a rejected lookup beside cacheable results', async () => {

--- a/test/integration/resolvers/address/cache.test.ts
+++ b/test/integration/resolvers/address/cache.test.ts
@@ -1,7 +1,13 @@
 import redis from '../../../../src/helpers/redis';
-import { setCache } from '../../../../src/resolvers/address/cache';
+import cache, {
+  getCache,
+  markNonCacheable,
+  setCache
+} from '../../../../src/resolvers/address/cache';
 
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const FAILED_ADDRESS = '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1';
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000001';
 const KEY = `address-resolvers:${ADDRESS}`;
 const TTL = 43200;
 
@@ -19,5 +25,23 @@ describe('address resolvers cache', () => {
 
     expect(ttl).toBeGreaterThan(TTL - 10);
     expect(ttl).toBeLessThanOrEqual(TTL);
+  });
+
+  it('does not cache a rejected lookup beside cacheable results', async () => {
+    await cache([ADDRESS, FAILED_ADDRESS, EMPTY_ADDRESS], async () =>
+      markNonCacheable(
+        {
+          [ADDRESS]: 'less.eth',
+          [FAILED_ADDRESS]: '',
+          [EMPTY_ADDRESS]: ''
+        },
+        [FAILED_ADDRESS]
+      )
+    );
+
+    await expect(getCache([ADDRESS, FAILED_ADDRESS, EMPTY_ADDRESS])).resolves.toEqual({
+      [ADDRESS]: 'less.eth',
+      [EMPTY_ADDRESS]: ''
+    });
   });
 });

--- a/test/integration/resolvers/address/ens.test.ts
+++ b/test/integration/resolvers/address/ens.test.ts
@@ -1,4 +1,5 @@
 import testAddressResolver from './helper';
+import { CacheResult, NON_CACHEABLE } from '../../../../src/resolvers/address/cache';
 import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address/ens';
 
 testAddressResolver({
@@ -23,9 +24,9 @@ describe('ENS address resolver: CCIP-Read', () => {
     const expiredAddress = '0x3a872f8FED4421E7d5BE5c98Ab5Ea0e0245169A0';
     const goodAddress = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
 
-    await expect(lookupAddresses([expiredAddress])).resolves.toEqual({});
-    await expect(lookupAddresses([expiredAddress, goodAddress])).resolves.toEqual({
-      [goodAddress]: 'sdntestens.eth'
-    });
+    const result = (await lookupAddresses([expiredAddress, goodAddress])) as CacheResult;
+
+    expect(result).toEqual({ [goodAddress]: 'sdntestens.eth' });
+    expect(result[NON_CACHEABLE]).toEqual([expiredAddress]);
   }, 20e3);
 });

--- a/test/integration/resolvers/address/ens.test.ts
+++ b/test/integration/resolvers/address/ens.test.ts
@@ -1,11 +1,5 @@
-import { capture } from '@snapshot-labs/snapshot-sentry';
-import snapshot from '@snapshot-labs/snapshot.js';
 import testAddressResolver from './helper';
 import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address/ens';
-
-jest.mock('@snapshot-labs/snapshot-sentry', () => ({
-  capture: jest.fn()
-}));
 
 testAddressResolver({
   name: 'ENS',
@@ -17,41 +11,21 @@ testAddressResolver({
   invalidDomains: ['domain.crypto', 'domain.lens', 'domain.com']
 });
 
-describe('ENS address resolver: CCIP-Read fallback', () => {
-  // jesse.base.eth's primary name is set via an off-chain resolver that the batch
-  // getNames contract doesn't follow, so the fallback to provider.lookupAddress
-  // is required.
-  it('resolves names that the batch contract misses', async () => {
+describe('ENS address resolver: CCIP-Read', () => {
+  it('resolves a name served by an offchain resolver', async () => {
     const address = '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9';
     await expect(lookupAddresses([address])).resolves.toEqual({
       [address]: 'jesse.base.eth'
     });
   }, 15e3);
 
-  it('falls back to per-address lookups when the batch reverse call reverts', async () => {
-    const ccipAddress = '0x3a872f8FED4421E7d5BE5c98Ab5Ea0e0245169A0';
+  it('keeps another result when one reverse name has expired', async () => {
+    const expiredAddress = '0x3a872f8FED4421E7d5BE5c98Ab5Ea0e0245169A0';
     const goodAddress = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
 
-    await expect(lookupAddresses([ccipAddress])).resolves.toEqual({});
-    await expect(lookupAddresses([ccipAddress, goodAddress])).resolves.toEqual({
+    await expect(lookupAddresses([expiredAddress])).resolves.toEqual({});
+    await expect(lookupAddresses([expiredAddress, goodAddress])).resolves.toEqual({
       [goodAddress]: 'sdntestens.eth'
     });
   }, 20e3);
-
-  it('still surfaces non-CALL_EXCEPTION batch errors', async () => {
-    const error = Object.assign(new Error('boom'), {
-      code: 'SERVER_ERROR'
-    });
-    const callSpy = jest.spyOn(snapshot.utils, 'call').mockRejectedValueOnce(error);
-    const address = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
-
-    try {
-      // The resolver rethrows the original error untouched. Reporting it is
-      // resolvers/address/index.ts' job now, so nothing is captured here.
-      await expect(lookupAddresses([address])).rejects.toBe(error);
-      expect(capture).not.toHaveBeenCalled();
-    } finally {
-      callSpy.mockRestore();
-    }
-  });
 });

--- a/test/integration/resolvers/address/index.test.ts
+++ b/test/integration/resolvers/address/index.test.ts
@@ -115,7 +115,7 @@ describe('address resolvers', () => {
 
       it('does not cache an address when every ENS lookup rejects', async () => {
         const failedAddress = '0x0000000000000000000000000000000000000001';
-        const error = Object.assign(new Error('aborted'), { name: 'AbortError' });
+        const error = new Error('resolver failed');
         const reverseLookup = jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
           values: {},
           errors: [{ address: failedAddress, error }]

--- a/test/integration/resolvers/address/index.test.ts
+++ b/test/integration/resolvers/address/index.test.ts
@@ -113,6 +113,22 @@ describe('address resolvers', () => {
         }
       });
 
+      it('does not cache an address when every ENS lookup rejects', async () => {
+        const failedAddress = '0x0000000000000000000000000000000000000001';
+        const error = Object.assign(new Error('aborted'), { name: 'AbortError' });
+        const reverseLookup = jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+          values: {},
+          errors: [{ address: failedAddress, error }]
+        });
+
+        try {
+          await expect(lookupAddresses([failedAddress])).resolves.toEqual({});
+          await expect(getCache([failedAddress])).resolves.toEqual({});
+        } finally {
+          reverseLookup.mockRestore();
+        }
+      });
+
       it('should return the cached results', async () => {
         await setCache({
           '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'test.eth',

--- a/test/integration/resolvers/address/index.test.ts
+++ b/test/integration/resolvers/address/index.test.ts
@@ -1,6 +1,7 @@
 import redis from '../../../../src/helpers/redis';
 import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address';
 import { getCache, setCache } from '../../../../src/resolvers/address/cache';
+import * as universalResolver from '../../../../src/resolvers/address/universalResolver';
 import randomAddresses from '../../../fixtures/addresses';
 
 function purge() {
@@ -91,6 +92,25 @@ describe('address resolvers', () => {
           '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 'less',
           '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1': ''
         });
+      });
+
+      it('does not cache an address whose ENS lookup rejected', async () => {
+        const emptyAddress = '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1';
+        const failedAddress = '0x0000000000000000000000000000000000000001';
+        const error = Object.assign(new Error('aborted'), { name: 'AbortError' });
+        const reverseLookup = jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+          values: {},
+          errors: [{ address: failedAddress, error }]
+        });
+
+        try {
+          await expect(lookupAddresses([emptyAddress, failedAddress])).resolves.toEqual({});
+          await expect(getCache([emptyAddress, failedAddress])).resolves.toEqual({
+            [emptyAddress]: ''
+          });
+        } finally {
+          reverseLookup.mockRestore();
+        }
       });
 
       it('should return the cached results', async () => {

--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -19,6 +19,7 @@ jest.mock('@snapshot-labs/snapshot-sentry', () => ({
 
 // Run the resolver fan-out on every call, without a redis round trip.
 jest.mock('../../../src/resolvers/address/cache', () => ({
+  ...jest.requireActual('../../../src/resolvers/address/cache'),
   __esModule: true,
   default: (input: string[], callback: (input: string[]) => any) => callback(input),
   clear: jest.fn()

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -48,6 +48,21 @@ describe('resolvers/address/ens - lookupAddresses', () => {
     await expect(lookupAddresses([ADDRESS])).rejects.toBe(error);
   });
 
+  it('keeps a silenced gateway failure retryable when every lookup rejects', async () => {
+    const error = new Error('gateway failed');
+    jest.spyOn(universalResolver, 'isSilencedReverseError').mockReturnValue(true);
+    jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+      values: {},
+      errors: [{ address: ADDRESS, error }]
+    });
+
+    const result = (await lookupAddresses([ADDRESS])) as CacheResult;
+
+    expect(result).toEqual({});
+    expect(result[NON_CACHEABLE]).toEqual([ADDRESS]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
   it('keeps a fulfilled empty lookup separate from a rejected lookup', async () => {
     const error = new Error('transport failed');
     jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
@@ -83,7 +98,8 @@ describe('resolvers/address/ens - lookupAddresses', () => {
   });
 
   it('keeps a name without reporting a silenced rejected sibling', async () => {
-    const error = abortError();
+    const error = new Error('gateway failed');
+    jest.spyOn(universalResolver, 'isSilencedReverseError').mockReturnValue(true);
     jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
       values: { [ADDRESS]: HANDLE },
       errors: [{ address: OTHER_ADDRESS, error }]

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -1,6 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { getProvider } from '../../../../src/helpers/provider';
-import { resolveNames } from '../../../../src/resolvers/address/ens';
+import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address/ens';
+import * as universalResolver from '../../../../src/resolvers/address/universalResolver';
 import { jsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({
@@ -25,6 +26,22 @@ const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 function respondWith(body: any, status = 200) {
   mockedFetch.mockResolvedValue(jsonResponse(body, status));
 }
+
+describe('resolvers/address/ens - lookupAddresses', () => {
+  it('surfaces a transport failure when no address resolves', async () => {
+    const error = new Error('transport failed');
+    const reverseLookup = jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+      values: {},
+      errors: [error]
+    });
+
+    try {
+      await expect(lookupAddresses([ADDRESS])).rejects.toBe(error);
+    } finally {
+      reverseLookup.mockRestore();
+    }
+  });
+});
 
 describe('resolvers/address/ens - resolveNames', () => {
   it('reports the subgraph failure instead of a TypeError naming our own field', async () => {

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -1,5 +1,6 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { getProvider } from '../../../../src/helpers/provider';
+import { CacheResult, NON_CACHEABLE } from '../../../../src/resolvers/address/cache';
 import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address/ens';
 import * as universalResolver from '../../../../src/resolvers/address/universalResolver';
 import { jsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
@@ -22,24 +23,90 @@ const providerInstanceHeldByEns = (getProvider as jest.Mock).mock.results[0].val
 
 const HANDLE = 'test.eth';
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const OTHER_ADDRESS = '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1';
+
+function abortError() {
+  return Object.assign(new Error('aborted'), { name: 'AbortError' });
+}
 
 function respondWith(body: any, status = 200) {
   mockedFetch.mockResolvedValue(jsonResponse(body, status));
 }
 
 describe('resolvers/address/ens - lookupAddresses', () => {
-  it('surfaces a transport failure when no address resolves', async () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('surfaces a transport failure when every address lookup rejects', async () => {
     const error = new Error('transport failed');
-    const reverseLookup = jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+    jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
       values: {},
-      errors: [error]
+      errors: [{ address: ADDRESS, error }]
     });
 
-    try {
-      await expect(lookupAddresses([ADDRESS])).rejects.toBe(error);
-    } finally {
-      reverseLookup.mockRestore();
-    }
+    await expect(lookupAddresses([ADDRESS])).rejects.toBe(error);
+  });
+
+  it('keeps a fulfilled empty lookup separate from a rejected lookup', async () => {
+    const error = new Error('transport failed');
+    jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+      values: {},
+      errors: [{ address: OTHER_ADDRESS, error }]
+    });
+
+    const result = (await lookupAddresses([ADDRESS, OTHER_ADDRESS])) as CacheResult;
+
+    expect(result).toEqual({});
+    expect(result[NON_CACHEABLE]).toEqual([OTHER_ADDRESS]);
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Ens' },
+      contexts: { input: { lookupAddresses: [OTHER_ADDRESS] } }
+    });
+  });
+
+  it('keeps a name and reports its rejected sibling', async () => {
+    const error = new Error('contract response failed');
+    jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+      values: { [ADDRESS]: HANDLE },
+      errors: [{ address: OTHER_ADDRESS, error }]
+    });
+
+    const result = (await lookupAddresses([ADDRESS, OTHER_ADDRESS])) as CacheResult;
+
+    expect(result).toEqual({ [ADDRESS]: HANDLE });
+    expect(result[NON_CACHEABLE]).toEqual([OTHER_ADDRESS]);
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Ens' },
+      contexts: { input: { lookupAddresses: [OTHER_ADDRESS] } }
+    });
+  });
+
+  it('keeps a name without reporting a silenced rejected sibling', async () => {
+    const error = abortError();
+    jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+      values: { [ADDRESS]: HANDLE },
+      errors: [{ address: OTHER_ADDRESS, error }]
+    });
+
+    const result = (await lookupAddresses([ADDRESS, OTHER_ADDRESS])) as CacheResult;
+
+    expect(result).toEqual({ [ADDRESS]: HANDLE });
+    expect(result[NON_CACHEABLE]).toEqual([OTHER_ADDRESS]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an actionable error when every lookup rejects', async () => {
+    const actionable = new Error('invalid contract response');
+    jest.spyOn(universalResolver, 'reverseLookup').mockResolvedValue({
+      values: {},
+      errors: [
+        { address: ADDRESS, error: abortError() },
+        { address: OTHER_ADDRESS, error: actionable }
+      ]
+    });
+
+    await expect(lookupAddresses([ADDRESS, OTHER_ADDRESS])).rejects.toBe(actionable);
   });
 });
 

--- a/test/unit/resolvers/address/starknet-batch-guard.test.ts
+++ b/test/unit/resolvers/address/starknet-batch-guard.test.ts
@@ -4,6 +4,7 @@ jest.mock('@snapshot-labs/snapshot-sentry', () => ({ capture: jest.fn() }));
 
 // Run the resolver fan-out on every call, without a redis round trip.
 jest.mock('../../../../src/resolvers/address/cache', () => ({
+  ...jest.requireActual('../../../../src/resolvers/address/cache'),
   __esModule: true,
   default: (input: string[], callback: (input: string[]) => any) => callback(input),
   clear: jest.fn()

--- a/test/unit/resolvers/address/universalResolver.test.ts
+++ b/test/unit/resolvers/address/universalResolver.test.ts
@@ -2,6 +2,7 @@ import {
   Address,
   decodeFunctionData,
   encodeErrorResult,
+  encodeFunctionData,
   encodeFunctionResult,
   Hex,
   multicall3Abi,
@@ -10,13 +11,21 @@ import {
 } from 'viem';
 import * as deadline from '../../../../src/helpers/deadline';
 import { MAX_LOOKUP_ADDRESSES } from '../../../../src/resolvers/address';
-import { BatchError, reverseLookup } from '../../../../src/resolvers/address/universalResolver';
+import {
+  BatchError,
+  isSilencedReverseError,
+  reverseLookup
+} from '../../../../src/resolvers/address/universalResolver';
 
 const reverseAbi = parseAbi([
   'function reverseWithGateways(bytes reverseName, uint256 coinType, string[] gateways) view returns (string resolvedName, address resolver, address reverseResolver)'
 ]);
 const httpErrorAbi = parseAbi(['error HttpError(uint16 status, string message)']);
 const resolverErrorAbi = parseAbi(['error ResolverError(bytes errorData)']);
+const solidityErrorAbi = parseAbi(['error Error(string message)']);
+const batchGatewayAbi = parseAbi([
+  'function query((address sender, string[] urls, bytes data)[] queries) view returns (bool[] failures, bytes[] responses)'
+]);
 const UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe' as Address;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
 const ADDRESSES = Array.from(
@@ -28,11 +37,39 @@ const OFFCHAIN_LOOKUP = encodeErrorResult({
   errorName: 'OffchainLookup',
   args: [UNIVERSAL_RESOLVER, ['https://gateway.test/{data}'], '0x1234', '0x12345678', '0x']
 });
+const BATCH_QUERY = encodeFunctionData({
+  abi: batchGatewayAbi,
+  functionName: 'query',
+  args: [
+    [
+      {
+        sender: UNIVERSAL_RESOLVER,
+        urls: ['https://gateway.test/{data}'],
+        data: '0x1234'
+      }
+    ]
+  ]
+});
+const BATCH_OFFCHAIN_LOOKUP = encodeErrorResult({
+  abi: [offchainLookupAbiItem],
+  errorName: 'OffchainLookup',
+  args: [UNIVERSAL_RESOLVER, ['x-batch-gateway:true'], BATCH_QUERY, '0x12345678', '0x']
+});
+const ABORTED_ERROR = encodeErrorResult({
+  abi: solidityErrorAbi,
+  errorName: 'Error',
+  args: ['This operation was aborted']
+});
 
 const HTTP_ERROR = encodeErrorResult({
   abi: httpErrorAbi,
   errorName: 'HttpError',
   args: [503, 'gateway unavailable']
+});
+const BATCH_HTTP_ERROR = encodeErrorResult({
+  abi: httpErrorAbi,
+  errorName: 'HttpError',
+  args: [503, 'HTTP request failed.']
 });
 
 const RESOLVER_ERROR = encodeErrorResult({
@@ -214,7 +251,36 @@ describe('Universal Resolver reverse lookup', () => {
     expect(errors[0].address).toBe(address);
     expect(errors[0].error).toBeInstanceOf(Error);
     expect((errors[0].error as Error).message).toContain('gateway unavailable');
+    expect(isSilencedReverseError(errors[0].error)).toBe(false);
     expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it('silences a transient HTTP failure from the local batch gateway', async () => {
+    const address = ADDRESSES[0];
+    let callbackData = '';
+    let rpcCalls = 0;
+    jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      if (String(input).startsWith('https://gateway.test/')) {
+        return new Response('unavailable', { status: 503 });
+      }
+
+      const { id, calls } = decodeBatch(init);
+      rpcCalls += 1;
+      if (rpcCalls === 1) {
+        return rpcResponse(id, [{ success: false, returnData: BATCH_OFFCHAIN_LOOKUP }]);
+      }
+
+      callbackData = calls[0].callData;
+      return rpcResponse(id, [{ success: false, returnData: BATCH_HTTP_ERROR }]);
+    });
+
+    const { values, errors } = await reverseLookup([address]);
+
+    expect(values).toEqual({});
+    expect(errors[0].address).toBe(address);
+    expect(isSilencedReverseError(errors[0].error)).toBe(true);
+    expect(callbackData).toContain(BATCH_HTTP_ERROR.slice(2));
+    expect(rpcCalls).toBe(2);
   });
 
   it('returns a rejected offchain gateway request as an error', async () => {
@@ -234,6 +300,7 @@ describe('Universal Resolver reverse lookup', () => {
   it('bounds a stalled gateway while retaining a successful sibling', async () => {
     const addresses = ADDRESSES.slice(0, 2);
     const batchSizes: number[] = [];
+    let callbackData = '';
     const actualWithDeadline = deadline.withDeadline;
     jest.spyOn(deadline, 'withDeadline').mockImplementation(fn => actualWithDeadline(fn, 5));
     jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
@@ -247,19 +314,31 @@ describe('Universal Resolver reverse lookup', () => {
 
       const { id, calls } = decodeBatch(init);
       batchSizes.push(calls.length);
-      return rpcResponse(id, [
-        { success: false, returnData: OFFCHAIN_LOOKUP },
-        { success: true, returnData: encodeName('name1.eth') }
-      ]);
+      if (batchSizes.length === 1) {
+        return rpcResponse(id, [
+          { success: false, returnData: BATCH_OFFCHAIN_LOOKUP },
+          { success: true, returnData: encodeName('name1.eth') }
+        ]);
+      }
+
+      callbackData = calls[0].callData;
+      return rpcResponse(id, [{ success: false, returnData: ABORTED_ERROR }]);
     });
 
     const { values, errors } = await reverseLookup(addresses);
-    const root = (errors[0].error as any).walk();
+    const reverted = (errors[0].error as any).walk(
+      cause => cause instanceof Error && cause.name === 'ContractFunctionRevertedError'
+    );
 
     expect(values).toEqual({ [addresses[1]]: 'name1.eth' });
     expect(errors[0].address).toBe(addresses[0]);
-    expect(root.name).toBe('AbortError');
-    expect(batchSizes).toEqual([addresses.length]);
+    expect(reverted.data).toMatchObject({
+      errorName: 'Error',
+      args: ['This operation was aborted']
+    });
+    expect(isSilencedReverseError(errors[0].error)).toBe(true);
+    expect(callbackData).toContain(ABORTED_ERROR.slice(2));
+    expect(batchSizes).toEqual([addresses.length, 1]);
   });
 
   it('keeps a successful sibling when an offchain gateway request rejects', async () => {

--- a/test/unit/resolvers/address/universalResolver.test.ts
+++ b/test/unit/resolvers/address/universalResolver.test.ts
@@ -1,0 +1,181 @@
+import {
+  Address,
+  decodeFunctionData,
+  encodeErrorResult,
+  encodeFunctionResult,
+  Hex,
+  multicall3Abi,
+  offchainLookupAbiItem,
+  parseAbi
+} from 'viem';
+import { reverseLookup } from '../../../../src/resolvers/address/universalResolver';
+
+const reverseAbi = parseAbi([
+  'function reverseWithGateways(bytes reverseName, uint256 coinType, string[] gateways) view returns (string resolvedName, address resolver, address reverseResolver)'
+]);
+const UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe' as Address;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
+const ADDRESSES = Array.from(
+  { length: 50 },
+  (_, index) => `0x${(index + 1).toString(16).padStart(40, '0')}` as Address
+);
+const OFFCHAIN_LOOKUP = encodeErrorResult({
+  abi: [offchainLookupAbiItem],
+  errorName: 'OffchainLookup',
+  args: [UNIVERSAL_RESOLVER, ['https://gateway.test/{data}'], '0x1234', '0x12345678', '0x']
+});
+
+type MulticallResult = { success: boolean; returnData: Hex };
+
+function encodeName(name: string): Hex {
+  return encodeFunctionResult({
+    abi: reverseAbi,
+    functionName: 'reverseWithGateways',
+    result: [name, ZERO_ADDRESS, ZERO_ADDRESS]
+  });
+}
+
+function encodeBatch(results: MulticallResult[]): Hex {
+  return encodeFunctionResult({
+    abi: multicall3Abi,
+    functionName: 'aggregate3',
+    result: results
+  });
+}
+
+function decodeBatch(init?: RequestInit) {
+  const request = JSON.parse(String(init?.body));
+  const decoded = decodeFunctionData({
+    abi: multicall3Abi,
+    data: request.params[0].data
+  });
+
+  if (decoded.functionName !== 'aggregate3') throw new Error('Expected aggregate3');
+
+  return { id: request.id, calls: decoded.args[0] };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+function rpcResponse(id: number, results: MulticallResult[]): Response {
+  return jsonResponse({ jsonrpc: '2.0', id, result: encodeBatch(results) });
+}
+
+function mockRejectedGateway(results: MulticallResult[]) {
+  const batchSizes: number[] = [];
+  const gatewayError = new Error('gateway unavailable');
+  const transport = jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+    if (String(input).startsWith('https://gateway.test/')) throw gatewayError;
+
+    const { id, calls } = decodeBatch(init);
+    batchSizes.push(calls.length);
+    return rpcResponse(id, results);
+  });
+
+  return { batchSizes, transport };
+}
+
+function expectRejectedGateway(errors: unknown[]) {
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toBeInstanceOf(Error);
+  expect((errors[0] as Error).message).toContain('gateway unavailable');
+}
+
+describe('Universal Resolver reverse lookup', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends the maximum address batch in one eth_call', async () => {
+    const batchSizes: number[] = [];
+    let nameIndex = 0;
+    const transport = jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
+      const { id, calls } = decodeBatch(init);
+      batchSizes.push(calls.length);
+      return rpcResponse(
+        id,
+        calls.map(() => ({ success: true, returnData: encodeName(`name${nameIndex++}.eth`) }))
+      );
+    });
+
+    const { values, errors } = await reverseLookup(ADDRESSES);
+
+    expect(errors).toEqual([]);
+    expect(Object.keys(values)).toHaveLength(ADDRESSES.length);
+    expect(values[ADDRESSES[0]]).toBe('name0.eth');
+    expect(values[ADDRESSES[49]]).toBe('name49.eth');
+    expect(batchSizes).toEqual([ADDRESSES.length]);
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches one offchain entry without splitting the initial batch', async () => {
+    const addresses = ADDRESSES.slice(0, 3);
+    const batchSizes: number[] = [];
+    const gatewayRequests: string[] = [];
+
+    jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith('https://gateway.test/')) {
+        gatewayRequests.push(url);
+        return jsonResponse({ data: '0xabcd' });
+      }
+
+      const { id, calls } = decodeBatch(init);
+      batchSizes.push(calls.length);
+      if (batchSizes.length === 1) {
+        return rpcResponse(id, [
+          { success: true, returnData: encodeName('name0.eth') },
+          { success: false, returnData: OFFCHAIN_LOOKUP },
+          { success: true, returnData: encodeName('name2.eth') }
+        ]);
+      }
+
+      return rpcResponse(id, [{ success: true, returnData: encodeName('name1.eth') }]);
+    });
+
+    await expect(reverseLookup(addresses)).resolves.toEqual({
+      values: {
+        [addresses[0]]: 'name0.eth',
+        [addresses[1]]: 'name1.eth',
+        [addresses[2]]: 'name2.eth'
+      },
+      errors: []
+    });
+    expect(batchSizes).toEqual([addresses.length, 1]);
+    expect(gatewayRequests).toHaveLength(1);
+  });
+
+  it('returns a rejected offchain gateway request as an error', async () => {
+    const address = ADDRESSES[0];
+    const { batchSizes, transport } = mockRejectedGateway([
+      { success: false, returnData: OFFCHAIN_LOOKUP }
+    ]);
+
+    const { values, errors } = await reverseLookup([address]);
+
+    expect(values).toEqual({});
+    expectRejectedGateway(errors);
+    expect(batchSizes).toEqual([1]);
+    expect(transport).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a successful sibling when an offchain gateway request rejects', async () => {
+    const addresses = ADDRESSES.slice(0, 2);
+    const { batchSizes, transport } = mockRejectedGateway([
+      { success: false, returnData: OFFCHAIN_LOOKUP },
+      { success: true, returnData: encodeName('name1.eth') }
+    ]);
+
+    const { values, errors } = await reverseLookup(addresses);
+
+    expect(values).toEqual({ [addresses[1]]: 'name1.eth' });
+    expectRejectedGateway(errors);
+    expect(batchSizes).toEqual([addresses.length]);
+    expect(transport).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/unit/resolvers/address/universalResolver.test.ts
+++ b/test/unit/resolvers/address/universalResolver.test.ts
@@ -15,6 +15,8 @@ import { BatchError, reverseLookup } from '../../../../src/resolvers/address/uni
 const reverseAbi = parseAbi([
   'function reverseWithGateways(bytes reverseName, uint256 coinType, string[] gateways) view returns (string resolvedName, address resolver, address reverseResolver)'
 ]);
+const httpErrorAbi = parseAbi(['error HttpError(uint16 status, string message)']);
+const resolverErrorAbi = parseAbi(['error ResolverError(bytes errorData)']);
 const UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe' as Address;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
 const ADDRESSES = Array.from(
@@ -25,6 +27,18 @@ const OFFCHAIN_LOOKUP = encodeErrorResult({
   abi: [offchainLookupAbiItem],
   errorName: 'OffchainLookup',
   args: [UNIVERSAL_RESOLVER, ['https://gateway.test/{data}'], '0x1234', '0x12345678', '0x']
+});
+
+const HTTP_ERROR = encodeErrorResult({
+  abi: httpErrorAbi,
+  errorName: 'HttpError',
+  args: [503, 'gateway unavailable']
+});
+
+const RESOLVER_ERROR = encodeErrorResult({
+  abi: resolverErrorAbi,
+  errorName: 'ResolverError',
+  args: ['0x80b90f']
 });
 
 type MulticallResult = { success: boolean; returnData: Hex };
@@ -174,6 +188,33 @@ describe('Universal Resolver reverse lookup', () => {
     });
     expect(batchSizes).toEqual([addresses.length, 1]);
     expect(gatewayRequests).toHaveLength(1);
+  });
+
+  it('treats a ResolverError as an empty reverse lookup', async () => {
+    const address = ADDRESSES[0];
+    const transport = jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
+      const { id } = decodeBatch(init);
+      return rpcResponse(id, [{ success: false, returnData: RESOLVER_ERROR }]);
+    });
+
+    await expect(reverseLookup([address])).resolves.toEqual({ values: {}, errors: [] });
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a Universal Resolver HTTP failure as an error', async () => {
+    const address = ADDRESSES[0];
+    const transport = jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
+      const { id } = decodeBatch(init);
+      return rpcResponse(id, [{ success: false, returnData: HTTP_ERROR }]);
+    });
+
+    const { values, errors } = await reverseLookup([address]);
+
+    expect(values).toEqual({});
+    expect(errors[0].address).toBe(address);
+    expect(errors[0].error).toBeInstanceOf(Error);
+    expect((errors[0].error as Error).message).toContain('gateway unavailable');
+    expect(transport).toHaveBeenCalledTimes(1);
   });
 
   it('returns a rejected offchain gateway request as an error', async () => {

--- a/test/unit/resolvers/address/universalResolver.test.ts
+++ b/test/unit/resolvers/address/universalResolver.test.ts
@@ -8,7 +8,9 @@ import {
   offchainLookupAbiItem,
   parseAbi
 } from 'viem';
-import { reverseLookup } from '../../../../src/resolvers/address/universalResolver';
+import * as deadline from '../../../../src/helpers/deadline';
+import { MAX_LOOKUP_ADDRESSES } from '../../../../src/resolvers/address';
+import { BatchError, reverseLookup } from '../../../../src/resolvers/address/universalResolver';
 
 const reverseAbi = parseAbi([
   'function reverseWithGateways(bytes reverseName, uint256 coinType, string[] gateways) view returns (string resolvedName, address resolver, address reverseResolver)'
@@ -16,7 +18,7 @@ const reverseAbi = parseAbi([
 const UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe' as Address;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address;
 const ADDRESSES = Array.from(
-  { length: 50 },
+  { length: MAX_LOOKUP_ADDRESSES },
   (_, index) => `0x${(index + 1).toString(16).padStart(40, '0')}` as Address
 );
 const OFFCHAIN_LOOKUP = encodeErrorResult({
@@ -80,10 +82,11 @@ function mockRejectedGateway(results: MulticallResult[]) {
   return { batchSizes, transport };
 }
 
-function expectRejectedGateway(errors: unknown[]) {
+function expectRejectedGateway(errors: BatchError[], address: Address) {
   expect(errors).toHaveLength(1);
-  expect(errors[0]).toBeInstanceOf(Error);
-  expect((errors[0] as Error).message).toContain('gateway unavailable');
+  expect(errors[0].address).toBe(address);
+  expect(errors[0].error).toBeInstanceOf(Error);
+  expect((errors[0].error as Error).message).toContain('gateway unavailable');
 }
 
 describe('Universal Resolver reverse lookup', () => {
@@ -108,9 +111,32 @@ describe('Universal Resolver reverse lookup', () => {
     expect(errors).toEqual([]);
     expect(Object.keys(values)).toHaveLength(ADDRESSES.length);
     expect(values[ADDRESSES[0]]).toBe('name0.eth');
-    expect(values[ADDRESSES[49]]).toBe('name49.eth');
+    expect(values[ADDRESSES[MAX_LOOKUP_ADDRESSES - 1]]).toBe(`name${MAX_LOOKUP_ADDRESSES - 1}.eth`);
     expect(batchSizes).toEqual([ADDRESSES.length]);
     expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps batches shared by concurrent maximum-size lookups', async () => {
+    const batchSizes: number[] = [];
+    jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
+      const { id, calls } = decodeBatch(init);
+      batchSizes.push(calls.length);
+      return rpcResponse(
+        id,
+        calls.map(() => ({ success: true, returnData: encodeName('name.eth') }))
+      );
+    });
+
+    const results = await Promise.all([reverseLookup(ADDRESSES), reverseLookup(ADDRESSES)]);
+
+    expect(results.every(result => result.errors.length === 0)).toBe(true);
+    expect(results.map(result => Object.keys(result.values).length)).toEqual([
+      MAX_LOOKUP_ADDRESSES,
+      MAX_LOOKUP_ADDRESSES
+    ]);
+    expect(batchSizes).toHaveLength(2);
+    expect(batchSizes.reduce((sum, size) => sum + size, 0)).toBe(2 * MAX_LOOKUP_ADDRESSES);
+    expect(Math.max(...batchSizes)).toBeLessThanOrEqual(56);
   });
 
   it('fetches one offchain entry without splitting the initial batch', async () => {
@@ -159,9 +185,40 @@ describe('Universal Resolver reverse lookup', () => {
     const { values, errors } = await reverseLookup([address]);
 
     expect(values).toEqual({});
-    expectRejectedGateway(errors);
+    expectRejectedGateway(errors, address);
     expect(batchSizes).toEqual([1]);
     expect(transport).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds a stalled gateway while retaining a successful sibling', async () => {
+    const addresses = ADDRESSES.slice(0, 2);
+    const batchSizes: number[] = [];
+    const actualWithDeadline = deadline.withDeadline;
+    jest.spyOn(deadline, 'withDeadline').mockImplementation(fn => actualWithDeadline(fn, 5));
+    jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      if (String(input).startsWith('https://gateway.test/')) {
+        if (!init?.signal) throw new Error('Missing gateway deadline signal');
+
+        return new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+        });
+      }
+
+      const { id, calls } = decodeBatch(init);
+      batchSizes.push(calls.length);
+      return rpcResponse(id, [
+        { success: false, returnData: OFFCHAIN_LOOKUP },
+        { success: true, returnData: encodeName('name1.eth') }
+      ]);
+    });
+
+    const { values, errors } = await reverseLookup(addresses);
+    const root = (errors[0].error as any).walk();
+
+    expect(values).toEqual({ [addresses[1]]: 'name1.eth' });
+    expect(errors[0].address).toBe(addresses[0]);
+    expect(root.name).toBe('AbortError');
+    expect(batchSizes).toEqual([addresses.length]);
   });
 
   it('keeps a successful sibling when an offchain gateway request rejects', async () => {
@@ -174,7 +231,7 @@ describe('Universal Resolver reverse lookup', () => {
     const { values, errors } = await reverseLookup(addresses);
 
     expect(values).toEqual({ [addresses[1]]: 'name1.eth' });
-    expectRejectedGateway(errors);
+    expectRejectedGateway(errors, addresses[0]);
     expect(batchSizes).toEqual([addresses.length]);
     expect(transport).toHaveBeenCalledTimes(2);
   });

--- a/test/unit/resolvers/address/universalResolver.test.ts
+++ b/test/unit/resolvers/address/universalResolver.test.ts
@@ -227,14 +227,24 @@ describe('Universal Resolver reverse lookup', () => {
     expect(gatewayRequests).toHaveLength(1);
   });
 
-  it('treats a ResolverError as an empty reverse lookup', async () => {
+  it('returns a ResolverError as an error', async () => {
     const address = ADDRESSES[0];
     const transport = jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
       const { id } = decodeBatch(init);
       return rpcResponse(id, [{ success: false, returnData: RESOLVER_ERROR }]);
     });
 
-    await expect(reverseLookup([address])).resolves.toEqual({ values: {}, errors: [] });
+    const { values, errors } = await reverseLookup([address]);
+    const reverted = (errors[0].error as any).walk(
+      cause => cause instanceof Error && cause.name === 'ContractFunctionRevertedError'
+    );
+
+    expect(values).toEqual({});
+    expect(errors[0].address).toBe(address);
+    expect(reverted.data).toMatchObject({
+      errorName: 'ResolverError',
+      args: ['0x80b90f']
+    });
     expect(transport).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
ENS reverse resolution currently uses a legacy batch helper that cannot follow offchain names, then fans out through per-address fallbacks.

This replaces both paths with one viem Universal Resolver client. Onchain lookups share a Multicall3 request, while CCIP entries settle independently so one offchain lookup does not split or fail the rest.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
