### PR TITLE
perf: batch Basename resolver calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@ethersproject/abi": "^5.7.0",
     "@snapshot-labs/eslint-config": "^0.1.1",
     "@snapshot-labs/prettier-config": "^0.1.0",
     "@types/express": "^4.17.11",

--- a/src/resolvers/address/basename.ts
+++ b/src/resolvers/address/basename.ts
@@ -4,7 +4,7 @@ import { namehash } from '@ethersproject/hash';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { EMPTY_ADDRESS, isEvmAddress } from '../../helpers/address';
 import { getUrl } from '../../helpers/http';
-import { getProvider } from '../../helpers/provider';
+import { batchContractCalls, getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
 
 export const NAME = 'Basename';
@@ -41,26 +41,55 @@ function normalizeBasename(name: Handle): Handle {
   }
 }
 
-async function collect(
-  items: string[],
-  query: (item: string) => Promise<[string, string]>
-): Promise<Record<string, string>> {
-  const entries = await Promise.all(items.map(query));
-  return Object.fromEntries(entries.filter(([, value]) => value));
-}
-
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {
-  return collect(addresses.filter(isEvmAddress), async address => [
-    address,
-    normalizeBasename(await call('name', [reverseNode(address)]))
-  ]);
+  const pairs = addresses
+    .filter(isEvmAddress)
+    .map(address => [address, reverseNode(address)] as const);
+
+  if (pairs.length === 0) return {};
+
+  const names: Record<string, Handle> = await batchContractCalls(
+    NETWORK,
+    provider,
+    ABI,
+    pairs.map(([, node]) => node),
+    new Array(pairs.length).fill(RESOLVER),
+    'name'
+  );
+
+  const results: Record<Address, Handle> = {};
+  pairs.forEach(([address, node]) => {
+    const name = normalizeBasename(names[node]);
+    if (name) results[address] = name;
+  });
+
+  return results;
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
-  return collect(handles.map(normalizeBasename).filter(Boolean), async handle => {
-    const address = await call('addr', [namehash(handle)]);
-    return [handle, address && address !== EMPTY_ADDRESS ? getAddress(address) : ''];
+  const pairs = handles
+    .map(normalizeBasename)
+    .filter(Boolean)
+    .map(handle => [handle, namehash(handle)] as const);
+
+  if (pairs.length === 0) return {};
+
+  const addresses: Record<string, Address> = await batchContractCalls(
+    NETWORK,
+    provider,
+    ABI,
+    pairs.map(([, node]) => node),
+    new Array(pairs.length).fill(RESOLVER),
+    'addr'
+  );
+
+  const results: Record<Handle, Address> = {};
+  pairs.forEach(([handle, node]) => {
+    const address = addresses[node];
+    if (address && address !== EMPTY_ADDRESS) results[handle] = getAddress(address);
   });
+
+  return results;
 }
 
 // Avatar text record, used by the avatar resolver. Resolves the name against

--- a/test/unit/resolvers/address/basename.test.ts
+++ b/test/unit/resolvers/address/basename.test.ts
@@ -1,0 +1,77 @@
+import { Interface } from '@ethersproject/abi';
+import { namehash } from '@ethersproject/hash';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address/basename';
+
+const ADDRESS_WITH_NAME = '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9';
+const ADDRESS_WITHOUT_NAME = '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1';
+const HANDLE = 'jesse.base.eth';
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+const COIN_TYPE = '80002105';
+const RESOLVER_ABI = [
+  'function name(bytes32 node) view returns (string)',
+  'function addr(bytes32 node) view returns (address)'
+];
+const MULTICALL_ABI = [
+  'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)'
+];
+
+const resolverInterface = new Interface(RESOLVER_ABI);
+const multicallInterface = new Interface(MULTICALL_ABI);
+const reverseNode = (address: string) =>
+  namehash(`${address.toLowerCase().slice(2)}.${COIN_TYPE}.reverse`);
+
+function resolverResponse(data: string): string {
+  const transaction = resolverInterface.parseTransaction({ data });
+
+  if (transaction.name === 'name') {
+    const name = transaction.args.node === reverseNode(ADDRESS_WITH_NAME) ? HANDLE : '';
+    return resolverInterface.encodeFunctionResult('name', [name]);
+  }
+
+  const address = transaction.args.node === namehash(HANDLE) ? ADDRESS_WITH_NAME : EMPTY_ADDRESS;
+  return resolverInterface.encodeFunctionResult('addr', [address]);
+}
+
+function rpcResponse(data: string): string {
+  try {
+    const calls = multicallInterface.decodeFunctionData('aggregate', data).calls;
+    return multicallInterface.encodeFunctionResult('aggregate', [
+      1,
+      calls.map(call => resolverResponse(call.callData))
+    ]);
+  } catch {
+    return resolverResponse(data);
+  }
+}
+
+describe('resolvers/address/basename batching', () => {
+  let send: jest.SpyInstance;
+
+  beforeEach(() => {
+    send = jest
+      .spyOn(StaticJsonRpcProvider.prototype, 'send')
+      .mockImplementation(async (method, params) => {
+        if (method !== 'eth_call') throw new Error(`Unexpected RPC method: ${method}`);
+        return rpcResponse(params[0].data);
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('looks up multiple addresses in one RPC call', async () => {
+    await expect(lookupAddresses([ADDRESS_WITH_NAME, ADDRESS_WITHOUT_NAME])).resolves.toEqual({
+      [ADDRESS_WITH_NAME]: HANDLE
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves multiple names in one RPC call', async () => {
+    await expect(resolveNames([HANDLE, 'unknown.base.eth'])).resolves.toEqual({
+      [HANDLE]: ADDRESS_WITH_NAME
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/resolvers/address/basename.test.ts
+++ b/test/unit/resolvers/address/basename.test.ts
@@ -4,8 +4,10 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address/basename';
 
 const ADDRESS_WITH_NAME = '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9';
+const SECOND_ADDRESS_WITH_NAME = '0x5b76f5B8fc9D700624F78208132f91AD4e61a1f0';
 const ADDRESS_WITHOUT_NAME = '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1';
 const HANDLE = 'jesse.base.eth';
+const SECOND_HANDLE = 'barmstrong.base.eth';
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 const COIN_TYPE = '80002105';
 const RESOLVER_ABI = [
@@ -25,11 +27,21 @@ function resolverResponse(data: string): string {
   const transaction = resolverInterface.parseTransaction({ data });
 
   if (transaction.name === 'name') {
-    const name = transaction.args.node === reverseNode(ADDRESS_WITH_NAME) ? HANDLE : '';
+    const name =
+      transaction.args.node === reverseNode(ADDRESS_WITH_NAME)
+        ? HANDLE
+        : transaction.args.node === reverseNode(SECOND_ADDRESS_WITH_NAME)
+          ? SECOND_HANDLE
+          : '';
     return resolverInterface.encodeFunctionResult('name', [name]);
   }
 
-  const address = transaction.args.node === namehash(HANDLE) ? ADDRESS_WITH_NAME : EMPTY_ADDRESS;
+  const address =
+    transaction.args.node === namehash(HANDLE)
+      ? ADDRESS_WITH_NAME
+      : transaction.args.node === namehash(SECOND_HANDLE)
+        ? SECOND_ADDRESS_WITH_NAME
+        : EMPTY_ADDRESS;
   return resolverInterface.encodeFunctionResult('addr', [address]);
 }
 
@@ -62,15 +74,19 @@ describe('resolvers/address/basename batching', () => {
   });
 
   it('looks up multiple addresses in one RPC call', async () => {
-    await expect(lookupAddresses([ADDRESS_WITH_NAME, ADDRESS_WITHOUT_NAME])).resolves.toEqual({
-      [ADDRESS_WITH_NAME]: HANDLE
+    await expect(
+      lookupAddresses([ADDRESS_WITH_NAME, SECOND_ADDRESS_WITH_NAME, ADDRESS_WITHOUT_NAME])
+    ).resolves.toEqual({
+      [ADDRESS_WITH_NAME]: HANDLE,
+      [SECOND_ADDRESS_WITH_NAME]: SECOND_HANDLE
     });
     expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('resolves multiple names in one RPC call', async () => {
-    await expect(resolveNames([HANDLE, 'unknown.base.eth'])).resolves.toEqual({
-      [HANDLE]: ADDRESS_WITH_NAME
+    await expect(resolveNames([HANDLE, SECOND_HANDLE, 'unknown.base.eth'])).resolves.toEqual({
+      [HANDLE]: ADDRESS_WITH_NAME,
+      [SECOND_HANDLE]: SECOND_ADDRESS_WITH_NAME
     });
     expect(send).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

Basename reverse and forward lookup previously issued one `eth_call` per valid input. For a non-empty resolver batch of N inputs, that meant N requests.

The resolver now batches those reads through Base Multicall, reducing the same batch to 1 `eth_call` and saving N - 1 requests. For example, 2 inputs go from 2 requests to 1. Input validation, name normalization, and empty-result filtering remain unchanged.

Closes #561
