### PR TITLE
perf(lookupDomains): batch ENS registration lookups

### DIFF
--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -14,9 +14,7 @@ type Domain = {
 
 type Registration = {
   id: string;
-  domain?: {
-    labelName?: string;
-  };
+  domain?: Pick<Domain, 'labelName'>;
 };
 
 function getLabelHash(domain: Domain) {
@@ -48,10 +46,7 @@ async function fetchDomainData(domains: Domain[], chainId: string): Promise<Doma
     }
   );
   const labelNames = new Map(
-    (data.registrations || []).map(registration => [
-      registration.id,
-      registration.domain?.labelName
-    ])
+    data.registrations.map(registration => [registration.id, registration.domain?.labelName])
   );
 
   return domains.map(domain => {
@@ -60,7 +55,7 @@ async function fetchDomainData(domains: Domain[], chainId: string): Promise<Doma
 
     return {
       ...domain,
-      name: labelName ? domain.name.replace(`[${hash}]`, labelName) : domain.name
+      name: labelName ? domain.name.replace(`[${hash}]`, () => labelName) : domain.name
     };
   });
 }

--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -21,12 +21,12 @@ function getLabelHash(domain: Domain) {
   return domain.name.match(/\[(.*?)\]/)?.[1];
 }
 
-async function fetchDomainData(domains: Domain[], chainId: string): Promise<Domain[]> {
+async function fetchDomainNames(domains: Domain[], chainId: string): Promise<Handle[]> {
   const hashes = [
     ...new Set(domains.map(getLabelHash).filter((hash): hash is string => Boolean(hash)))
   ];
 
-  if (!hashes.length) return domains;
+  if (!hashes.length) return domains.map(domain => domain.name);
 
   const {
     data: { data }
@@ -53,10 +53,7 @@ async function fetchDomainData(domains: Domain[], chainId: string): Promise<Doma
     const hash = getLabelHash(domain);
     const labelName = hash ? labelNames.get(`0x${hash}`) : undefined;
 
-    return {
-      ...domain,
-      name: labelName ? domain.name.replace(`[${hash}]`, () => labelName) : domain.name
-    };
+    return labelName ? domain.name.replace(`[${hash}]`, () => labelName) : domain.name;
   });
 }
 
@@ -97,5 +94,5 @@ export default async function lookupDomains(
       !domain.name.endsWith('.addr.reverse')
   );
 
-  return (await fetchDomainData(domains, chainId)).map(domain => domain.name);
+  return fetchDomainNames(domains, chainId);
 }

--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -12,33 +12,57 @@ type Domain = {
   expiryDate?: number;
 };
 
-async function fetchDomainData(domain: Domain, chainId: string): Promise<Domain> {
-  const hash = domain.name.match(/\[(.*?)\]/)?.[1];
+type Registration = {
+  id: string;
+  domain?: {
+    labelName?: string;
+  };
+};
 
-  if (!hash) return domain;
+function getLabelHash(domain: Domain) {
+  return domain.name.match(/\[(.*?)\]/)?.[1];
+}
+
+async function fetchDomainData(domains: Domain[], chainId: string): Promise<Domain[]> {
+  const hashes = [
+    ...new Set(domains.map(getLabelHash).filter((hash): hash is string => Boolean(hash)))
+  ];
+
+  if (!hashes.length) return domains;
 
   const {
     data: { data }
-  } = await graphQlCall(
+  } = await graphQlCall<{ registrations: Registration[] }>(
     constants.ensSubgraph[chainId],
-    `query Registration($id: String!) {
-      registration(id: $id) {
+    `query Registrations($ids: [String!]!, $first: Int!) {
+      registrations(first: $first, where: { id_in: $ids }) {
+        id
         domain {
-          name
           labelName
         }
       }
     }`,
-    { id: `0x${hash}` }
+    {
+      ids: hashes.map(hash => `0x${hash}`),
+      first: hashes.length
+    }
   );
-  // Not `data?.`: swallowing a missing envelope here serves the raw `[hash]`
-  // label as though the subgraph had simply not indexed it.
-  const labelName = data.registration?.domain?.labelName;
+  const labelNames = new Map(
+    (data.registrations || []).map(registration => [
+      registration.id,
+      registration.domain?.labelName
+    ])
+  );
 
-  return {
-    ...domain,
-    name: labelName ? domain.name.replace(`[${hash}]`, labelName) : domain.name
-  };
+  return domains.map(domain => {
+    const hash = getLabelHash(domain);
+    const labelName = hash ? labelNames.get(`0x${hash}`) : undefined;
+
+    return {
+      ...domain,
+      name: labelName ? domain.name.replace(`[${hash}]`, labelName) : domain.name
+    };
+  });
 }
 
 export default async function lookupDomains(
@@ -78,9 +102,5 @@ export default async function lookupDomains(
       !domain.name.endsWith('.addr.reverse')
   );
 
-  return (
-    (await Promise.all(domains.map(domain => fetchDomainData(domain, chainId)))).map(
-      domain => domain.name
-    ) || []
-  );
+  return (await fetchDomainData(domains, chainId)).map(domain => domain.name);
 }

--- a/test/integration/resolvers/lookupDomains.test.ts
+++ b/test/integration/resolvers/lookupDomains.test.ts
@@ -9,6 +9,12 @@ describe('lookupDomains', () => {
     expect(result[0]).toContain('.eth');
   });
 
+  it('should decode hashed parent labels on subdomains', async () => {
+    const result = await lookupDomains('0x279489452dd8035f82326c8036f81d7bd1c65e6c');
+
+    expect(result).toContain('global.aragonid.eth');
+  });
+
   it('should return an array of addresses on sepolia', async () => {
     const result = await lookupDomains('0x24F15402C6Bb870554489b2fd2049A85d75B982f', '11155111');
 

--- a/test/unit/helpers/graphqlEnvelope.test.ts
+++ b/test/unit/helpers/graphqlEnvelope.test.ts
@@ -72,13 +72,15 @@ describe('graphQlCall callers surface an envelope failure', () => {
     }
 
     it('decodes the label when the subgraph answers', async () => {
-      answerWith({ data: { registration: { domain: { labelName: 'vitalik' } } } });
+      answerWith({
+        data: { registrations: [{ id: '0x7f3a', domain: { labelName: 'vitalik' } }] }
+      });
 
       await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['vitalik.eth']);
     });
 
     it('keeps the hashed name when the label is genuinely unknown', async () => {
-      answerWith({ data: { registration: null } });
+      answerWith({ data: { registrations: [] } });
 
       await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['[7f3a].eth']);
     });

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -8,14 +8,12 @@ jest.mock('../../../../src/helpers/graphql', () => ({
 const mockedGraphQlCall = graphQlCall as jest.Mock;
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 
+function graphQlResponse<T>(data: T) {
+  return { data: { data } };
+}
+
 function accountResponse(domains: { name: string }[]) {
-  return {
-    data: {
-      data: {
-        account: { domains, wrappedDomains: [] }
-      }
-    }
-  };
+  return graphQlResponse({ account: { domains, wrappedDomains: [] } });
 }
 
 describe('lookupDomains/ens', () => {
@@ -28,16 +26,14 @@ describe('lookupDomains/ens', () => {
       .mockResolvedValueOnce(
         accountResponse([{ name: '[aaa].eth' }, { name: 'plain.eth' }, { name: '[bbb].eth' }])
       )
-      .mockResolvedValue({
-        data: {
-          data: {
-            registrations: [
-              { id: '0xbbb', domain: { labelName: '$&' } },
-              { id: '0xaaa', domain: { labelName: 'alice' } }
-            ]
-          }
-        }
-      });
+      .mockResolvedValue(
+        graphQlResponse({
+          registrations: [
+            { id: '0xbbb', domain: { labelName: '$&' } },
+            { id: '0xaaa', domain: { labelName: 'alice' } }
+          ]
+        })
+      );
 
     const result = await lookupDomains(ADDRESS);
 
@@ -55,7 +51,7 @@ describe('lookupDomains/ens', () => {
     const domains = Array.from({ length: 101 }, (_, index) => ({ name: `[${index}].eth` }));
     mockedGraphQlCall
       .mockResolvedValueOnce(accountResponse(domains))
-      .mockResolvedValueOnce({ data: { data: { registrations: [] } } });
+      .mockResolvedValueOnce(graphQlResponse({ registrations: [] }));
 
     await lookupDomains(ADDRESS);
 
@@ -74,7 +70,7 @@ describe('lookupDomains/ens', () => {
   it('rejects when the registration list is null', async () => {
     mockedGraphQlCall
       .mockResolvedValueOnce(accountResponse([{ name: '[aaa].eth' }]))
-      .mockResolvedValueOnce({ data: { data: { registrations: null } } });
+      .mockResolvedValueOnce(graphQlResponse({ registrations: null }));
 
     await expect(lookupDomains(ADDRESS)).rejects.toThrow();
   });

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -32,7 +32,7 @@ describe('lookupDomains/ens', () => {
         data: {
           data: {
             registrations: [
-              { id: '0xbbb', domain: { labelName: 'bob' } },
+              { id: '0xbbb', domain: { labelName: '$&' } },
               { id: '0xaaa', domain: { labelName: 'alice' } }
             ]
           }
@@ -42,7 +42,7 @@ describe('lookupDomains/ens', () => {
     const result = await lookupDomains(ADDRESS);
 
     expect(mockedGraphQlCall).toHaveBeenCalledTimes(2);
-    expect(result).toEqual(['alice.eth', 'plain.eth', 'bob.eth']);
+    expect(result).toEqual(['alice.eth', 'plain.eth', '$&.eth']);
     expect(mockedGraphQlCall).toHaveBeenNthCalledWith(
       2,
       expect.any(String),
@@ -69,6 +69,14 @@ describe('lookupDomains/ens', () => {
 
     await expect(lookupDomains(ADDRESS)).resolves.toEqual(['plain.eth']);
     expect(mockedGraphQlCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when the registration list is null', async () => {
+    mockedGraphQlCall
+      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].eth' }]))
+      .mockResolvedValueOnce({ data: { data: { registrations: null } } });
+
+    await expect(lookupDomains(ADDRESS)).rejects.toThrow();
   });
 
   it('rejects when the registration response has no data envelope', async () => {

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -1,0 +1,81 @@
+import { graphQlCall } from '../../../../src/helpers/graphql';
+import lookupDomains from '../../../../src/resolvers/lookupDomains/ens';
+
+jest.mock('../../../../src/helpers/graphql', () => ({
+  graphQlCall: jest.fn()
+}));
+
+const mockedGraphQlCall = graphQlCall as jest.Mock;
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+
+function accountResponse(domains: { name: string }[]) {
+  return {
+    data: {
+      data: {
+        account: { domains, wrappedDomains: [] }
+      }
+    }
+  };
+}
+
+describe('lookupDomains/ens', () => {
+  beforeEach(() => {
+    mockedGraphQlCall.mockReset();
+  });
+
+  it('loads all hashed labels in one registration query', async () => {
+    mockedGraphQlCall
+      .mockResolvedValueOnce(
+        accountResponse([{ name: '[aaa].eth' }, { name: 'plain.eth' }, { name: '[bbb].eth' }])
+      )
+      .mockResolvedValue({
+        data: {
+          data: {
+            registrations: [
+              { id: '0xbbb', domain: { labelName: 'bob' } },
+              { id: '0xaaa', domain: { labelName: 'alice' } }
+            ]
+          }
+        }
+      });
+
+    const result = await lookupDomains(ADDRESS);
+
+    expect(mockedGraphQlCall).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(['alice.eth', 'plain.eth', 'bob.eth']);
+    expect(mockedGraphQlCall).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.stringContaining('registrations(first: $first, where: { id_in: $ids })'),
+      { ids: ['0xaaa', '0xbbb'], first: 2 }
+    );
+  });
+
+  it('requests every registration beyond the subgraph default page size', async () => {
+    const domains = Array.from({ length: 101 }, (_, index) => ({ name: `[${index}].eth` }));
+    mockedGraphQlCall
+      .mockResolvedValueOnce(accountResponse(domains))
+      .mockResolvedValueOnce({ data: { data: { registrations: [] } } });
+
+    await lookupDomains(ADDRESS);
+
+    expect(mockedGraphQlCall.mock.calls[1][2]).toEqual(
+      expect.objectContaining({ first: domains.length })
+    );
+  });
+
+  it('does not query registrations when no name has a hashed label', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(accountResponse([{ name: 'plain.eth' }]));
+
+    await expect(lookupDomains(ADDRESS)).resolves.toEqual(['plain.eth']);
+    expect(mockedGraphQlCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when the registration response has no data envelope', async () => {
+    mockedGraphQlCall
+      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].eth' }]))
+      .mockResolvedValueOnce({ data: {} });
+
+    await expect(lookupDomains(ADDRESS)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Batch ENS hashed-label registration resolution into one subgraph query sized for all requested IDs. Responses are joined by registration ID, while missing registrations preserve the hashed name and addresses without hashed labels skip the registration query.

Closes #562