### PR TITLE
fix(image): skip invalid user hub queries

### DIFF
--- a/src/resolvers/image/snapshot.ts
+++ b/src/resolvers/image/snapshot.ts
@@ -1,4 +1,5 @@
 import { getAddress } from '@ethersproject/address';
+import snapshot from '@snapshot-labs/snapshot.js';
 import { defaultOffchainNetwork, offchainNetworks } from '../../constants.json';
 import { graphQlCall } from '../../helpers/graphql';
 import { fetchHttpImage, getUrl, spaceIds } from '../../helpers/http';
@@ -101,7 +102,15 @@ async function getOnchainProperty(
   return spaces?.map(space => space.metadata?.[property]).filter(Boolean)[0];
 }
 
-function normalizeEvmAddress(value: string) {
+function normalizeUserId(value: string): string | null {
+  try {
+    return getAddress(value.trim());
+  } catch {
+    return value.startsWith('0x') && snapshot.utils.isStarknetAddress(value) ? value : null;
+  }
+}
+
+function normalizeSpaceId(value: string) {
   try {
     return getAddress(value.trim());
   } catch {
@@ -117,9 +126,12 @@ function createPropertyResolver(entity: Entity, property: Property) {
     if (!Object.keys(API_URLS).includes(networkId)) return false;
 
     if (offchainNetworks.includes(networkId) || entity === 'user') {
+      const id = entity === 'user' ? normalizeUserId(address) : normalizeSpaceId(address);
+      if (!id) return false;
+
       value = await getOffchainProperty(
         offchainNetworks.includes(networkId) ? networkId : defaultOffchainNetwork,
-        normalizeEvmAddress(address),
+        id,
         entity,
         property
       );

--- a/src/resolvers/image/snapshot.ts
+++ b/src/resolvers/image/snapshot.ts
@@ -103,10 +103,11 @@ async function getOnchainProperty(
 }
 
 function normalizeUserId(value: string): string | null {
+  const trimmed = value.trim();
   try {
-    return getAddress(value.trim());
+    return getAddress(trimmed);
   } catch {
-    return value.startsWith('0x') && snapshot.utils.isStarknetAddress(value) ? value : null;
+    return trimmed.startsWith('0x') && snapshot.utils.isStarknetAddress(trimmed) ? trimmed : null;
   }
 }
 

--- a/test/unit/resolvers/image/noData.test.ts
+++ b/test/unit/resolvers/image/noData.test.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import nodeFetch from 'node-fetch';
 import farcaster from '../../../../src/resolvers/image/farcaster';
-import { resolveSpaceAvatar, resolveSpaceLogo } from '../../../../src/resolvers/image/snapshot';
+import {
+  resolveSpaceAvatar,
+  resolveSpaceLogo,
+  resolveUserAvatar
+} from '../../../../src/resolvers/image/snapshot';
 import { resolveAvatar as resolveSxAvatar } from '../../../../src/resolvers/image/space-sx';
 import starknet from '../../../../src/resolvers/image/starknet';
 
@@ -30,8 +34,11 @@ function loadCoingecko() {
 }
 
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const STARKNET_ADDRESS = '0x07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
+const UNPADDED_STARKNET_ADDRESS = `0x${STARKNET_ADDRESS.slice(3)}`;
 const NOT_AN_ADDRESS = '0x00006ba9855965EeEc09B5D43B113944c27F45aD3Ce';
 
+const entry = (found: any) => ({ status: 200, data: { data: { entry: found } } });
 const spaces = (found: any[]) => ({ status: 200, data: { data: { spaces: found } } });
 
 describe('resolvers answer false rather than throwing when there is no data', () => {
@@ -69,6 +76,39 @@ describe('resolvers answer false rather than throwing when there is no data', ()
   });
 
   describe('snapshot', () => {
+    it.each(['vitalik.eth', 'foo.lens', 'foo.stark', '1'])(
+      'answers false for invalid user id %s without asking',
+      async id => {
+        await expect(resolveUserAvatar(id)).resolves.toBe(false);
+        expect(mockedAxios).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each([
+      ['EVM', ADDRESS.toLowerCase(), ADDRESS],
+      ['Starknet', STARKNET_ADDRESS, STARKNET_ADDRESS],
+      ['unpadded Starknet', UNPADDED_STARKNET_ADDRESS, UNPADDED_STARKNET_ADDRESS]
+    ])('normalizes a valid %s user id', async (_type, id, expected) => {
+      mockedAxios.mockResolvedValue(entry({ avatar: null }));
+
+      await expect(resolveUserAvatar(id)).resolves.toBe(false);
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ variables: { id: expected } }) })
+      );
+    });
+
+    it.each([
+      ['slug', 'ens.eth', 'ens.eth'],
+      ['EVM address', ADDRESS.toLowerCase(), ADDRESS]
+    ])('preserves an offchain space %s', async (_type, id, expected) => {
+      mockedAxios.mockResolvedValue(entry({ avatar: null }));
+
+      await expect(resolveSpaceAvatar(id, 1, 's')).resolves.toBe(false);
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ variables: { id: expected } }) })
+      );
+    });
+
     it('answers false for a space id that is not an address, without asking', async () => {
       await expect(resolveSpaceAvatar('ens.eth', 1, 'eth')).resolves.toBe(false);
       expect(mockedAxios).not.toHaveBeenCalled();

--- a/test/unit/resolvers/image/noData.test.ts
+++ b/test/unit/resolvers/image/noData.test.ts
@@ -85,9 +85,9 @@ describe('resolvers answer false rather than throwing when there is no data', ()
     );
 
     it.each([
-      ['EVM', ADDRESS.toLowerCase(), ADDRESS],
-      ['Starknet', STARKNET_ADDRESS, STARKNET_ADDRESS],
-      ['unpadded Starknet', UNPADDED_STARKNET_ADDRESS, UNPADDED_STARKNET_ADDRESS]
+      ['EVM', ` ${ADDRESS.toLowerCase()} `, ADDRESS],
+      ['Starknet', ` ${STARKNET_ADDRESS} `, STARKNET_ADDRESS],
+      ['unpadded Starknet', ` ${UNPADDED_STARKNET_ADDRESS} `, UNPADDED_STARKNET_ADDRESS]
     ])('normalizes a valid %s user id', async (_type, id, expected) => {
       mockedAxios.mockResolvedValue(entry({ avatar: null }));
 


### PR DESCRIPTION
## Summary

- stop invalid user ids before they reach Snapshot Hub
- preserve EVM checksumming, Starknet user ids, and offchain space ids

Fixes #563
