### PR TITLE
fix: isolate invalid Space ID labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "starknet": ">=6.21.0 <6.21.2",
     "ts-node": "^10.8.1",
     "typescript": "~5.5.3",
+    "viem": "^2.55.11",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/resolvers/address/spaceId.ts
+++ b/src/resolvers/address/spaceId.ts
@@ -82,16 +82,24 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 }
 
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
-  const normalizedHandles = normalizeHandles(handles);
+  const pairs = normalizeHandles(handles).flatMap(handle => {
+    try {
+      return [[handle, namehash(handle)] as const];
+    } catch {
+      return [];
+    }
+  });
 
-  if (normalizedHandles.length === 0) return {};
+  if (pairs.length === 0) return {};
 
-  const namehashes = normalizedHandles.map(namehash);
-  const addresses: Record<string, Address> = await resolveNameHashes(namehashes, 'addr');
+  const addresses: Record<string, Address> = await resolveNameHashes(
+    pairs.map(([, hash]) => hash),
+    'addr'
+  );
   const results = {};
 
   Object.entries(addresses).forEach(([hash, addr]) => {
-    const handle = normalizedHandles[namehashes.indexOf(hash)];
+    const handle = pairs.find(([, pairHash]) => pairHash === hash)?.[0];
     if (handle) results[handle] = addr;
   });
 

--- a/src/resolvers/address/spaceId.ts
+++ b/src/resolvers/address/spaceId.ts
@@ -1,5 +1,4 @@
-import { ens_normalize } from '@adraffy/ens-normalize';
-import { namehash } from '@ethersproject/hash';
+import { namehash, normalize } from 'viem/ens';
 import { EMPTY_ADDRESS, isEvmAddress } from '../../helpers/address';
 import { batchContractCalls, getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
@@ -68,8 +67,8 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  const reverseNamehashes = normalizedAddresses.map(addr => {
-    return namehash(`${addr.slice(2)}.addr.reverse`);
+  const reverseNamehashes: string[] = normalizedAddresses.map(addr => {
+    return namehash(normalize(`${addr.slice(2)}.addr.reverse`));
   });
   const names: Record<string, Handle> = await resolveNameHashes(reverseNamehashes, 'name');
   const results = {};
@@ -85,7 +84,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
   const pairs = normalizeHandles(handles).flatMap(handle => {
     try {
-      if (ens_normalize(handle) !== handle) return [];
+      if (normalize(handle) !== handle) return [];
       return [[handle, namehash(handle)] as const];
     } catch {
       return [];

--- a/src/resolvers/address/spaceId.ts
+++ b/src/resolvers/address/spaceId.ts
@@ -1,3 +1,4 @@
+import { ens_normalize } from '@adraffy/ens-normalize';
 import { namehash } from '@ethersproject/hash';
 import { EMPTY_ADDRESS, isEvmAddress } from '../../helpers/address';
 import { batchContractCalls, getProvider } from '../../helpers/provider';
@@ -84,6 +85,7 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Address>> {
   const pairs = normalizeHandles(handles).flatMap(handle => {
     try {
+      if (ens_normalize(handle) !== handle) return [];
       return [[handle, namehash(handle)] as const];
     } catch {
       return [];
@@ -100,7 +102,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   Object.entries(addresses).forEach(([hash, addr]) => {
     const handle = pairs.find(([, pairHash]) => pairHash === hash)?.[0];
-    if (handle) results[handle] = addr;
+    if (handle && addr !== EMPTY_ADDRESS) results[handle] = addr;
   });
 
   return results;

--- a/src/resolvers/address/spaceId.ts
+++ b/src/resolvers/address/spaceId.ts
@@ -67,9 +67,9 @@ export async function lookupAddresses(addresses: Address[]): Promise<Record<Addr
 
   if (normalizedAddresses.length === 0) return {};
 
-  const reverseNamehashes: string[] = normalizedAddresses.map(addr => {
-    return namehash(normalize(`${addr.slice(2)}.addr.reverse`));
-  });
+  const reverseNamehashes: string[] = normalizedAddresses.map(addr =>
+    namehash(`${addr.slice(2).toLowerCase()}.addr.reverse`)
+  );
   const names: Record<string, Handle> = await resolveNameHashes(reverseNamehashes, 'name');
   const results = {};
 

--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -1,5 +1,7 @@
+import { namehash } from '@ethersproject/hash';
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { lookupAddresses } from '../../../src/resolvers/address';
+import * as provider from '../../../src/helpers/provider';
+import { lookupAddresses, resolveNames } from '../../../src/resolvers/address';
 import * as basename from '../../../src/resolvers/address/basename';
 import * as ens from '../../../src/resolvers/address/ens';
 import * as gwei from '../../../src/resolvers/address/gwei';
@@ -123,5 +125,53 @@ describe('address resolvers - resolver failures', () => {
     jest.spyOn(shibarium, 'lookupAddresses').mockResolvedValue({ [ADDRESS]: 'boorger.shib' });
 
     await expect(lookupAddresses([ADDRESS])).resolves.toEqual({ [ADDRESS]: 'boorger.shib' });
+  });
+});
+
+describe('address resolvers - invalid Space ID labels', () => {
+  const HANDLE = 'boorger.bnb';
+  const INVALID_HANDLES = ['foo!.bnb', 'a..bnb', '.bnb', 'foo_bar.bnb'];
+  const HASH = namehash(HANDLE);
+  const RESOLVER = '0x4444444444444444444444444444444444444444';
+  const RESOLVED_ADDRESS = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
+
+  beforeEach(() => {
+    RESOLVERS.filter(resolver => resolver !== spaceId).forEach(resolver => {
+      jest.spyOn(resolver, 'resolveNames').mockResolvedValue({});
+    });
+  });
+
+  it('isolates an invalid BNB label from a valid sibling', async () => {
+    const batch = jest
+      .spyOn(provider, 'batchContractCalls')
+      .mockResolvedValueOnce({ [HASH]: RESOLVER })
+      .mockResolvedValueOnce({ [HASH]: RESOLVED_ADDRESS });
+
+    await expect(resolveNames([INVALID_HANDLES[0], HANDLE])).resolves.toEqual({
+      [HANDLE]: RESOLVED_ADDRESS
+    });
+    expect(batch).toHaveBeenCalledTimes(2);
+    expect(batch.mock.calls[0][3]).toEqual([HASH]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('returns no results or RPC calls for only invalid BNB labels', async () => {
+    const batch = jest.spyOn(provider, 'batchContractCalls');
+
+    await expect(resolveNames(INVALID_HANDLES)).resolves.toEqual({});
+    expect(batch).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('keeps reporting Space ID RPC failures', async () => {
+    const error = new Error('rpc unavailable');
+    jest.spyOn(provider, 'batchContractCalls').mockRejectedValueOnce(error);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Space ID' },
+      contexts: { input: { resolveNames: [HANDLE] } }
+    });
   });
 });

--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -1,5 +1,6 @@
 import { namehash } from '@ethersproject/hash';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { EMPTY_ADDRESS } from '../../../src/helpers/address';
 import * as provider from '../../../src/helpers/provider';
 import { lookupAddresses, resolveNames } from '../../../src/resolvers/address';
 import * as basename from '../../../src/resolvers/address/basename';
@@ -130,7 +131,7 @@ describe('address resolvers - resolver failures', () => {
 
 describe('address resolvers - invalid Space ID labels', () => {
   const HANDLE = 'boorger.bnb';
-  const INVALID_HANDLES = ['foo!.bnb', 'a..bnb', '.bnb', 'foo_bar.bnb'];
+  const INVALID_HANDLES = ['foo!.bnb', 'a..bnb', '.bnb', 'foo_bar.bnb', 'ｆｏｏ.bnb'];
   const HASH = namehash(HANDLE);
   const RESOLVER = '0x4444444444444444444444444444444444444444';
   const RESOLVED_ADDRESS = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
@@ -156,10 +157,21 @@ describe('address resolvers - invalid Space ID labels', () => {
   });
 
   it('returns no results or RPC calls for only invalid BNB labels', async () => {
-    const batch = jest.spyOn(provider, 'batchContractCalls');
+    const batch = jest.spyOn(provider, 'batchContractCalls').mockResolvedValue({});
 
     await expect(resolveNames(INVALID_HANDLES)).resolves.toEqual({});
     expect(batch).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('drops a zero address result', async () => {
+    const batch = jest
+      .spyOn(provider, 'batchContractCalls')
+      .mockResolvedValueOnce({ [HASH]: RESOLVER })
+      .mockResolvedValueOnce({ [HASH]: EMPTY_ADDRESS });
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(batch).toHaveBeenCalledTimes(2);
     expect(capture).not.toHaveBeenCalled();
   });
 

--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -138,6 +138,13 @@ describe('address resolvers - invalid Space ID labels', () => {
   const RESOLVER = '0x4444444444444444444444444444444444444444';
   const RESOLVED_ADDRESS = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
 
+  function mockNameResolution(hash: string, address: string) {
+    return jest
+      .spyOn(provider, 'batchContractCalls')
+      .mockResolvedValueOnce({ [hash]: RESOLVER })
+      .mockResolvedValueOnce({ [hash]: address });
+  }
+
   beforeEach(() => {
     RESOLVERS.filter(resolver => resolver !== spaceId).forEach(resolver => {
       jest.spyOn(resolver, 'resolveNames').mockResolvedValue({});
@@ -145,10 +152,7 @@ describe('address resolvers - invalid Space ID labels', () => {
   });
 
   it('isolates an invalid BNB label from a valid sibling', async () => {
-    const batch = jest
-      .spyOn(provider, 'batchContractCalls')
-      .mockResolvedValueOnce({ [HASH]: RESOLVER })
-      .mockResolvedValueOnce({ [HASH]: RESOLVED_ADDRESS });
+    const batch = mockNameResolution(HASH, RESOLVED_ADDRESS);
 
     await expect(resolveNames([INVALID_HANDLES[0], HANDLE])).resolves.toEqual({
       [HANDLE]: RESOLVED_ADDRESS
@@ -167,10 +171,7 @@ describe('address resolvers - invalid Space ID labels', () => {
   });
 
   it('resolves a normalized emoji label', async () => {
-    const batch = jest
-      .spyOn(provider, 'batchContractCalls')
-      .mockResolvedValueOnce({ [EMOJI_HASH]: RESOLVER })
-      .mockResolvedValueOnce({ [EMOJI_HASH]: RESOLVED_ADDRESS });
+    const batch = mockNameResolution(EMOJI_HASH, RESOLVED_ADDRESS);
 
     await expect(resolveNames([EMOJI_HANDLE])).resolves.toEqual({
       [EMOJI_HANDLE]: RESOLVED_ADDRESS
@@ -181,10 +182,7 @@ describe('address resolvers - invalid Space ID labels', () => {
   });
 
   it('drops a zero address result', async () => {
-    const batch = jest
-      .spyOn(provider, 'batchContractCalls')
-      .mockResolvedValueOnce({ [HASH]: RESOLVER })
-      .mockResolvedValueOnce({ [HASH]: EMPTY_ADDRESS });
+    const batch = mockNameResolution(HASH, EMPTY_ADDRESS);
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({});
     expect(batch).toHaveBeenCalledTimes(2);

--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -1,5 +1,5 @@
-import { namehash } from '@ethersproject/hash';
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { namehash } from 'viem/ens';
 import { EMPTY_ADDRESS } from '../../../src/helpers/address';
 import * as provider from '../../../src/helpers/provider';
 import { lookupAddresses, resolveNames } from '../../../src/resolvers/address';
@@ -131,8 +131,10 @@ describe('address resolvers - resolver failures', () => {
 
 describe('address resolvers - invalid Space ID labels', () => {
   const HANDLE = 'boorger.bnb';
+  const EMOJI_HANDLE = '🩷🩷🩷.bnb';
   const INVALID_HANDLES = ['foo!.bnb', 'a..bnb', '.bnb', 'foo_bar.bnb', 'ｆｏｏ.bnb'];
   const HASH = namehash(HANDLE);
+  const EMOJI_HASH = namehash(EMOJI_HANDLE);
   const RESOLVER = '0x4444444444444444444444444444444444444444';
   const RESOLVED_ADDRESS = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
 
@@ -161,6 +163,20 @@ describe('address resolvers - invalid Space ID labels', () => {
 
     await expect(resolveNames(INVALID_HANDLES)).resolves.toEqual({});
     expect(batch).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('resolves a normalized emoji label', async () => {
+    const batch = jest
+      .spyOn(provider, 'batchContractCalls')
+      .mockResolvedValueOnce({ [EMOJI_HASH]: RESOLVER })
+      .mockResolvedValueOnce({ [EMOJI_HASH]: RESOLVED_ADDRESS });
+
+    await expect(resolveNames([EMOJI_HANDLE])).resolves.toEqual({
+      [EMOJI_HANDLE]: RESOLVED_ADDRESS
+    });
+    expect(batch).toHaveBeenCalledTimes(2);
+    expect(batch.mock.calls[0][3]).toEqual([EMOJI_HASH]);
     expect(capture).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Invalid, noncanonical, or unsupported `.bnb` names could disrupt Space ID batches or produce missing or misleading results for otherwise valid requests.

Validate and hash Space ID names consistently, isolate invalid inputs, and discard empty records while preserving valid sibling and reverse-resolution results.

Closes #564