### PR TITLE
fix(image): skip getResolver for non-ENS inputs

### DIFF
--- a/src/resolvers/image/ens.ts
+++ b/src/resolvers/image/ens.ts
@@ -1,3 +1,4 @@
+import { ens_normalize } from '@adraffy/ens-normalize';
 import { isAddress } from '@ethersproject/address';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { fetchHttpImage } from '../../helpers/http';
@@ -9,7 +10,13 @@ async function castToEnsName(nameOrAddress: string): Promise<string | undefined>
     return (await lookupAddresses([nameOrAddress]))[nameOrAddress];
   }
 
-  return nameOrAddress;
+  if (!nameOrAddress.includes('.')) return undefined;
+
+  try {
+    return ens_normalize(nameOrAddress);
+  } catch {
+    return undefined;
+  }
 }
 
 export default async function resolve(nameOrAddress: string) {

--- a/test/unit/resolvers/image/ens.test.ts
+++ b/test/unit/resolvers/image/ens.test.ts
@@ -1,0 +1,41 @@
+import { getProvider } from '../../../../src/helpers/provider';
+import resolve from '../../../../src/resolvers/image/ens';
+
+jest.mock('../../../../src/helpers/provider', () => ({ getProvider: jest.fn() }));
+jest.mock('../../../../src/resolvers/address', () => ({ lookupAddresses: jest.fn() }));
+
+const STARKNET_ADDRESS = '0x0779ba6e4e227947acbbdfb978a292c401339027eeb3d768f5d12cd2e818265a';
+const INVALID_NAMES = [STARKNET_ADDRESS, 'nodot', 'a..b'];
+const VALID_NAMES = [
+  ['vitalik.eth', 'vitalik.eth'],
+  ['foo.xyz', 'foo.xyz'],
+  ['ⓥⓘⓣⓐⓛⓘⓚ.eth', 'vitalik.eth']
+] as const;
+
+const getResolver = jest.fn();
+
+beforeEach(() => {
+  getResolver.mockReset();
+  (getProvider as jest.Mock).mockReturnValue({ getResolver });
+});
+
+describe('ens image resolver', () => {
+  it.each(INVALID_NAMES)('skips the provider for %s', async input => {
+    await expect(resolve(input)).resolves.toBe(false);
+    expect(getResolver).not.toHaveBeenCalled();
+  });
+
+  it.each(VALID_NAMES)('asks the provider for %s', async (input, normalized) => {
+    getResolver.mockResolvedValue(null);
+
+    await expect(resolve(input)).resolves.toBe(false);
+    expect(getResolver).toHaveBeenCalledWith(normalized);
+  });
+
+  it('preserves provider failures for the outer failure contract', async () => {
+    const error = new Error('provider unavailable');
+    getResolver.mockRejectedValue(error);
+
+    await expect(resolve('vitalik.eth')).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

Non-address avatar inputs went to the mainnet ENS resolver even when they could not be an ENS name.

`ens_normalize` accepts single-label strings, so require a dot and successful normalization before the resolver call. Valid equivalents are passed through in normalized form, while EVM addresses keep their reverse lookup path.

Closes #565
