### PR TITLE
refactor(ens): batch forward lookup through universal resolver

### DIFF
--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -2,17 +2,12 @@ import { ens_normalize } from '@adraffy/ens-normalize';
 import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { markNonCacheable } from './cache';
-import { isSilencedReverseError, reverseLookup } from './universalResolver';
-import constants from '../../constants.json';
+import { forwardLookup, isSilencedReverseError, reverseLookup } from './universalResolver';
 import { isEvmAddress } from '../../helpers/address';
-import { isSilencedError, isTransportFailure } from '../../helpers/errors';
-import { graphQlCall } from '../../helpers/graphql';
-import { getProvider } from '../../helpers/provider';
+import { isSilencedError } from '../../helpers/errors';
 import { Address, Handle } from '../../helpers/types';
 
 export const NAME = 'Ens';
-const NETWORK = '1';
-const provider = getProvider(NETWORK);
 
 function normalizeEns(names: Handle[]): Handle[] {
   return names.map(name => {
@@ -76,59 +71,23 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
 
   if (normalizedHandles.length === 0) return {};
 
-  const results = {};
+  const { values, errors } = await forwardLookup(normalizedHandles);
 
-  try {
-    const {
-      data: { domains: items }
-    } = await graphQlCall(
-      constants.ensSubgraph[NETWORK],
-      `query Domains($handles: [String!]!) {
-        domains(where: {name_in: $handles}) {
-          name
-          resolvedAddress {
-            id
-          }
-        }
-      }`,
-      { handles: normalizedHandles }
-    );
-
-    for (const item of items) {
-      try {
-        results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
-      } catch (err) {
-        if (!isSilencedError(err)) {
-          capture(err, { input: { handles: normalizedHandles } });
-        }
-      }
+  errors.forEach(({ name, error }) => {
+    if (!isSilencedLookupError(error)) {
+      capture(error, {
+        tags: { provider: NAME },
+        contexts: { input: { resolveNames: [name] } }
+      });
     }
-  } catch (err) {
-    if (!isSilencedError(err) && !isTransportFailure(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-  }
+  });
 
-  const unresolvedHandles = normalizedHandles.filter(handle => !results[handle]);
+  const result = Object.fromEntries(
+    Object.entries(values).map(([handle, address]) => [handle, getAddress(address)])
+  );
 
-  if (unresolvedHandles.length === 0) return results;
-
-  try {
-    const providerResults = await Promise.allSettled(
-      unresolvedHandles.map(handle => provider.resolveName(handle))
-    );
-
-    unresolvedHandles.forEach((handle, index) => {
-      const result = providerResults[index];
-      if (result.status === 'fulfilled' && result.value) {
-        results[handle] = getAddress(result.value);
-      }
-    });
-  } catch (err) {
-    if (!isSilencedError(err) && !isTransportFailure(err)) {
-      capture(err, { input: { handles: normalizedHandles } });
-    }
-  }
-
-  return results;
+  return markNonCacheable(
+    result,
+    errors.map(({ name }) => name)
+  );
 }

--- a/src/resolvers/address/universalResolver.ts
+++ b/src/resolvers/address/universalResolver.ts
@@ -12,12 +12,12 @@ import { withDeadline } from '../../helpers/deadline';
 import { getProviderOptions } from '../../helpers/provider';
 
 const rpcUrl = `${getProviderOptions().broviderUrl}/${mainnet.id}`;
-const EMPTY_REVERSE_ERRORS = new Set([
+const EMPTY_FORWARD_ERRORS = new Set([
   'ResolverNotContract',
   'ResolverNotFound',
-  'ReverseAddressMismatch',
   'UnsupportedResolverProfile'
 ]);
+const EMPTY_REVERSE_ERRORS = new Set([...EMPTY_FORWARD_ERRORS, 'ReverseAddressMismatch']);
 const TRANSIENT_GATEWAY_ERRORS = new Set(['This operation was aborted', 'HTTP request failed.']);
 
 function getRevertedError(error: unknown): ContractFunctionRevertedError | undefined {
@@ -29,6 +29,10 @@ function getRevertedError(error: unknown): ContractFunctionRevertedError | undef
 
 function isEmptyReverseError(error: unknown): boolean {
   return EMPTY_REVERSE_ERRORS.has(getRevertedError(error)?.data?.errorName || '');
+}
+
+function isEmptyForwardError(error: unknown): boolean {
+  return EMPTY_FORWARD_ERRORS.has(getRevertedError(error)?.data?.errorName || '');
 }
 
 export function isSilencedReverseError(error: unknown): boolean {
@@ -96,14 +100,16 @@ export async function reverseLookup(addresses: string[]): Promise<BatchResult> {
 }
 
 export async function forwardLookup(names: string[]): Promise<ForwardBatchResult> {
-  const settled = await Promise.allSettled(names.map(name => client.getEnsAddress({ name })));
+  const settled = await Promise.allSettled(
+    names.map(name => client.getEnsAddress({ name, strict: true }))
+  );
   const values: Record<string, string> = {};
   const errors: ForwardBatchError[] = [];
 
   settled.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       if (result.value) values[names[index]] = result.value;
-    } else {
+    } else if (!isEmptyForwardError(result.reason)) {
       errors.push({ name: names[index], error: result.reason });
     }
   });

--- a/src/resolvers/address/universalResolver.ts
+++ b/src/resolvers/address/universalResolver.ts
@@ -71,6 +71,11 @@ const client = createPublicClient({
 
 export type BatchError = { address: string; error: unknown };
 export type BatchResult = { values: Record<string, string>; errors: BatchError[] };
+export type ForwardBatchError = { name: string; error: unknown };
+export type ForwardBatchResult = {
+  values: Record<string, string>;
+  errors: ForwardBatchError[];
+};
 
 export async function reverseLookup(addresses: string[]): Promise<BatchResult> {
   const settled = await Promise.allSettled(
@@ -84,6 +89,22 @@ export async function reverseLookup(addresses: string[]): Promise<BatchResult> {
       if (result.value) values[addresses[index]] = result.value;
     } else if (!isEmptyReverseError(result.reason)) {
       errors.push({ address: addresses[index], error: result.reason });
+    }
+  });
+
+  return { values, errors };
+}
+
+export async function forwardLookup(names: string[]): Promise<ForwardBatchResult> {
+  const settled = await Promise.allSettled(names.map(name => client.getEnsAddress({ name })));
+  const values: Record<string, string> = {};
+  const errors: ForwardBatchError[] = [];
+
+  settled.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      if (result.value) values[names[index]] = result.value;
+    } else {
+      errors.push({ name: names[index], error: result.reason });
     }
   });
 

--- a/test/integration/resolvers/address/ens.test.ts
+++ b/test/integration/resolvers/address/ens.test.ts
@@ -13,6 +13,13 @@ testAddressResolver({
 });
 
 describe('ENS address resolver: CCIP-Read', () => {
+  it('resolves onchain and offchain names while omitting a missing resolver', async () => {
+    await expect(resolveNames(['sdntestens.eth', 'jesse.base.eth', 'foo.lens'])).resolves.toEqual({
+      'sdntestens.eth': '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC',
+      'jesse.base.eth': '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9'
+    });
+  }, 15e3);
+
   it('resolves a name served by an offchain resolver', async () => {
     const address = '0x2211d1D0020DAEA8039E46Cf1367962070d77DA9';
     await expect(lookupAddresses([address])).resolves.toEqual({

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -1,25 +1,11 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
-import { getProvider } from '../../../../src/helpers/provider';
 import { CacheResult, NON_CACHEABLE } from '../../../../src/resolvers/address/cache';
 import { lookupAddresses, resolveNames } from '../../../../src/resolvers/address/ens';
 import * as universalResolver from '../../../../src/resolvers/address/universalResolver';
-import { jsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
 
 jest.mock('@snapshot-labs/snapshot-sentry', () => ({
   capture: jest.fn()
 }));
-
-jest.mock('../../../../src/helpers/provider', () => ({
-  ...jest.requireActual('../../../../src/helpers/provider'),
-  getProvider: jest.fn(() => ({
-    resolveName: jest.fn().mockResolvedValue(null),
-    lookupAddress: jest.fn().mockResolvedValue(null)
-  }))
-}));
-
-const mockedFetch = mockGlobalFetch();
-
-const providerInstanceHeldByEns = (getProvider as jest.Mock).mock.results[0].value;
 
 const HANDLE = 'test.eth';
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
@@ -27,10 +13,6 @@ const OTHER_ADDRESS = '0x0C67A201b93cf58D4a5e8D4E970093f0FB4bb0D1';
 
 function abortError() {
   return Object.assign(new Error('aborted'), { name: 'AbortError' });
-}
-
-function respondWith(body: any, status = 200) {
-  mockedFetch.mockResolvedValue(jsonResponse(body, status));
 }
 
 describe('resolvers/address/ens - lookupAddresses', () => {
@@ -127,62 +109,35 @@ describe('resolvers/address/ens - lookupAddresses', () => {
 });
 
 describe('resolvers/address/ens - resolveNames', () => {
-  it('reports the subgraph failure instead of a TypeError naming our own field', async () => {
-    respondWith({ errors: [{ message: 'bad indexers' }], data: null });
-
-    await expect(resolveNames([HANDLE])).resolves.toEqual({});
-
-    expect(capture).toHaveBeenCalledWith(
-      expect.objectContaining({ message: '[subgrapher.snapshot.org] bad indexers' }),
-      { input: { handles: [HANDLE] } }
-    );
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
-  it('resolves from the subgraph and reports nothing when it answers', async () => {
-    respondWith({
-      data: { domains: [{ name: HANDLE, resolvedAddress: { id: ADDRESS.toLowerCase() } }] }
+  it('resolves normalized handles through the Universal Resolver', async () => {
+    const lookup = jest.spyOn(universalResolver, 'forwardLookup').mockResolvedValue({
+      values: { [HANDLE]: ADDRESS.toLowerCase() },
+      errors: []
     });
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({ [HANDLE]: ADDRESS });
+    expect(lookup).toHaveBeenCalledWith([HANDLE]);
     expect(capture).not.toHaveBeenCalled();
   });
 
-  it('does not report a subgraph host that no longer resolves', async () => {
-    mockedFetch.mockRejectedValue(
-      Object.assign(new TypeError('fetch failed'), { cause: { code: 'ENOTFOUND' } })
-    );
-
-    await expect(resolveNames([HANDLE])).resolves.toEqual({});
-    expect(capture).not.toHaveBeenCalled();
-  });
-
-  it('still reports a subgraph host answering with a 4xx', async () => {
-    respondWith({}, 404);
-
-    await expect(resolveNames([HANDLE])).resolves.toEqual({});
-    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }), {
-      input: { handles: [HANDLE] }
-    });
-  });
-
-  it('still reports a malformed address returned by the subgraph itself', async () => {
-    respondWith({
-      data: { domains: [{ name: HANDLE, resolvedAddress: { id: 'not-a-valid-address' } }] }
+  it('keeps rejected names retryable and reports the failure', async () => {
+    const error = new Error('transport failed');
+    jest.spyOn(universalResolver, 'forwardLookup').mockResolvedValue({
+      values: {},
+      errors: [{ name: HANDLE, error }]
     });
 
-    await expect(resolveNames([HANDLE])).resolves.toEqual({});
-    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_ARGUMENT' }), {
-      input: { handles: [HANDLE] }
-    });
-  });
+    const result = (await resolveNames([HANDLE])) as CacheResult;
 
-  it('still reports a malformed address returned by the provider fallback', async () => {
-    respondWith({ data: { domains: [] } });
-    providerInstanceHeldByEns.resolveName.mockResolvedValueOnce('not-a-valid-address');
-
-    await expect(resolveNames([HANDLE])).resolves.toEqual({});
-    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_ARGUMENT' }), {
-      input: { handles: [HANDLE] }
+    expect(result).toEqual({});
+    expect(result[NON_CACHEABLE]).toEqual([HANDLE]);
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Ens' },
+      contexts: { input: { resolveNames: [HANDLE] } }
     });
   });
 });

--- a/test/unit/resolvers/address/universalResolver.test.ts
+++ b/test/unit/resolvers/address/universalResolver.test.ts
@@ -10,9 +10,10 @@ import {
   parseAbi
 } from 'viem';
 import * as deadline from '../../../../src/helpers/deadline';
-import { MAX_LOOKUP_ADDRESSES } from '../../../../src/resolvers/address';
+import { MAX_LOOKUP_ADDRESSES, MAX_RESOLVE_NAMES } from '../../../../src/resolvers/address';
 import {
   BatchError,
+  forwardLookup,
   isSilencedReverseError,
   reverseLookup
 } from '../../../../src/resolvers/address/universalResolver';
@@ -20,6 +21,11 @@ import {
 const reverseAbi = parseAbi([
   'function reverseWithGateways(bytes reverseName, uint256 coinType, string[] gateways) view returns (string resolvedName, address resolver, address reverseResolver)'
 ]);
+const forwardAbi = parseAbi([
+  'function resolveWithGateways(bytes name, bytes data, string[] gateways) view returns (bytes result, address resolver)'
+]);
+const addressAbi = parseAbi(['function addr(bytes32 node) view returns (address)']);
+const resolverNotFoundAbi = parseAbi(['error ResolverNotFound(bytes name)']);
 const httpErrorAbi = parseAbi(['error HttpError(uint16 status, string message)']);
 const resolverErrorAbi = parseAbi(['error ResolverError(bytes errorData)']);
 const solidityErrorAbi = parseAbi(['error Error(string message)']);
@@ -32,6 +38,12 @@ const ADDRESSES = Array.from(
   { length: MAX_LOOKUP_ADDRESSES },
   (_, index) => `0x${(index + 1).toString(16).padStart(40, '0')}` as Address
 );
+const NAMES = Array.from({ length: MAX_RESOLVE_NAMES }, (_, index) => `name${index}.eth`);
+const RESOLVER_NOT_FOUND = encodeErrorResult({
+  abi: resolverNotFoundAbi,
+  errorName: 'ResolverNotFound',
+  args: ['0x03666f6f046c656e7300']
+});
 const OFFCHAIN_LOOKUP = encodeErrorResult({
   abi: [offchainLookupAbiItem],
   errorName: 'OffchainLookup',
@@ -85,6 +97,20 @@ function encodeName(name: string): Hex {
     abi: reverseAbi,
     functionName: 'reverseWithGateways',
     result: [name, ZERO_ADDRESS, ZERO_ADDRESS]
+  });
+}
+
+function encodeAddress(address: Address): Hex {
+  const result = encodeFunctionResult({
+    abi: addressAbi,
+    functionName: 'addr',
+    result: address
+  });
+
+  return encodeFunctionResult({
+    abi: forwardAbi,
+    functionName: 'resolveWithGateways',
+    result: [result, ZERO_ADDRESS]
   });
 }
 
@@ -364,5 +390,68 @@ describe('Universal Resolver reverse lookup', () => {
     expectRejectedGateway(errors, addresses[0]);
     expect(batchSizes).toEqual([addresses.length]);
     expect(transport).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Universal Resolver forward lookup', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends the maximum name batch in one eth_call and omits a missing resolver', async () => {
+    const names = [...NAMES.slice(0, -1), 'foo.lens'];
+    const batchSizes: number[] = [];
+    let resultIndex = 0;
+    const transport = jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
+      const { id, calls } = decodeBatch(init);
+      batchSizes.push(calls.length);
+      return rpcResponse(
+        id,
+        calls.map(() => {
+          const index = resultIndex++;
+          return index === names.length - 1
+            ? { success: false, returnData: RESOLVER_NOT_FOUND }
+            : { success: true, returnData: encodeAddress(ADDRESSES[index]) };
+        })
+      );
+    });
+
+    const { values, errors } = await forwardLookup(names);
+
+    expect(errors).toEqual([]);
+    expect(values).toEqual(
+      Object.fromEntries(NAMES.slice(0, -1).map((name, index) => [name, ADDRESSES[index]]))
+    );
+    expect(batchSizes).toEqual([MAX_RESOLVE_NAMES]);
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves an offchain name without splitting the initial batch', async () => {
+    const name = 'jesse.base.eth';
+    const gatewayRequests: string[] = [];
+    const batchSizes: number[] = [];
+
+    jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.startsWith('https://gateway.test/')) {
+        gatewayRequests.push(url);
+        return jsonResponse({ data: '0xabcd' });
+      }
+
+      const { id, calls } = decodeBatch(init);
+      batchSizes.push(calls.length);
+      return rpcResponse(id, [
+        batchSizes.length === 1
+          ? { success: false, returnData: OFFCHAIN_LOOKUP }
+          : { success: true, returnData: encodeAddress(ADDRESSES[0]) }
+      ]);
+    });
+
+    await expect(forwardLookup([name])).resolves.toEqual({
+      values: { [name]: ADDRESSES[0] },
+      errors: []
+    });
+    expect(batchSizes).toEqual([1, 1]);
+    expect(gatewayRequests).toHaveLength(1);
   });
 });

--- a/test/unit/resolvers/address/universalResolver.test.ts
+++ b/test/unit/resolvers/address/universalResolver.test.ts
@@ -399,7 +399,8 @@ describe('Universal Resolver forward lookup', () => {
   });
 
   it('sends the maximum name batch in one eth_call and omits a missing resolver', async () => {
-    const names = [...NAMES.slice(0, -1), 'foo.lens'];
+    const resolvableNames = NAMES.slice(0, -1);
+    const names = [...resolvableNames, 'foo.lens'];
     const batchSizes: number[] = [];
     let resultIndex = 0;
     const transport = jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
@@ -420,7 +421,7 @@ describe('Universal Resolver forward lookup', () => {
 
     expect(errors).toEqual([]);
     expect(values).toEqual(
-      Object.fromEntries(NAMES.slice(0, -1).map((name, index) => [name, ADDRESSES[index]]))
+      Object.fromEntries(resolvableNames.map((name, index) => [name, ADDRESSES[index]]))
     );
     expect(batchSizes).toEqual([MAX_RESOLVE_NAMES]);
     expect(transport).toHaveBeenCalledTimes(1);
@@ -428,13 +429,13 @@ describe('Universal Resolver forward lookup', () => {
 
   it('resolves an offchain name without splitting the initial batch', async () => {
     const name = 'jesse.base.eth';
-    const gatewayRequests: string[] = [];
+    let gatewayRequestCount = 0;
     const batchSizes: number[] = [];
 
     jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
       const url = String(input);
       if (url.startsWith('https://gateway.test/')) {
-        gatewayRequests.push(url);
+        gatewayRequestCount += 1;
         return jsonResponse({ data: '0xabcd' });
       }
 
@@ -452,6 +453,40 @@ describe('Universal Resolver forward lookup', () => {
       errors: []
     });
     expect(batchSizes).toEqual([1, 1]);
-    expect(gatewayRequests).toHaveLength(1);
+    expect(gatewayRequestCount).toBe(1);
+  });
+
+  it('keeps a successful sibling when an offchain gateway returns a transient failure', async () => {
+    const names = NAMES.slice(0, 2);
+    const batchSizes: number[] = [];
+
+    jest.spyOn(global, 'fetch').mockImplementation(async (_input, init) => {
+      const { id, calls } = decodeBatch(init);
+      batchSizes.push(calls.length);
+      if (batchSizes.length === 1) {
+        return rpcResponse(id, [
+          { success: false, returnData: BATCH_OFFCHAIN_LOOKUP },
+          { success: true, returnData: encodeAddress(ADDRESSES[1]) }
+        ]);
+      }
+
+      return rpcResponse(id, [{ success: false, returnData: BATCH_HTTP_ERROR }]);
+    });
+
+    const { values, errors } = await forwardLookup(names);
+
+    expect(errors).toHaveLength(1);
+    const reverted = (errors[0].error as any).walk(
+      cause => cause instanceof Error && cause.name === 'ContractFunctionRevertedError'
+    );
+
+    expect(values).toEqual({ [names[1]]: ADDRESSES[1] });
+    expect(errors[0].name).toBe(names[0]);
+    expect(reverted.data).toMatchObject({
+      errorName: 'HttpError',
+      args: [503, 'HTTP request failed.']
+    });
+    expect(isSilencedReverseError(errors[0].error)).toBe(true);
+    expect(batchSizes).toEqual([names.length, 1]);
   });
 });


### PR DESCRIPTION
ENS forward resolution still depends on a hosted subgraph and an ethers fallback for names the subgraph misses.

This extends the Universal Resolver client from #568 with batched forward lookups and routes ENS name resolution through it. Entries settle independently, and failed lookups remain retryable instead of caching a transient miss.

Depends on #568.
Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)
