### PR TITLE
fix(resolvers): skip sibling TLD names

### DIFF
--- a/src/helpers/address.ts
+++ b/src/helpers/address.ts
@@ -6,6 +6,13 @@ import { Address, Handle } from './types';
 
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
+const OWNED_TLDS = ['.lens', '.bnb', '.stark', '.gwei', '.shib'];
+
+export function hasOwnedTld(handle: Handle): boolean {
+  const normalizedHandle = handle.toLowerCase();
+  return OWNED_TLDS.some(tld => normalizedHandle.endsWith(tld));
+}
+
 export function isEvmAddress(address: Address): boolean {
   return /^0x[a-fA-F0-9]{40}$/.test(address);
 }

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -3,7 +3,7 @@ import { getAddress } from '@ethersproject/address';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import constants from '../../constants.json';
-import { isEvmAddress } from '../../helpers/address';
+import { hasOwnedTld, isEvmAddress } from '../../helpers/address';
 import { isSilencedError, isTransportFailure } from '../../helpers/errors';
 import { graphQlCall } from '../../helpers/graphql';
 import { getProvider } from '../../helpers/provider';
@@ -28,7 +28,7 @@ function normalizeAddresses(addresses: Address[]): Address[] {
 }
 
 function normalizeHandles(names: Handle[]): Handle[] {
-  return normalizeEns(names).filter(h => h);
+  return normalizeEns(names).filter(h => h && !hasOwnedTld(h));
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {

--- a/src/resolvers/address/unstoppableDomains.ts
+++ b/src/resolvers/address/unstoppableDomains.ts
@@ -1,7 +1,7 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import Resolution, { NamingServiceName } from '@unstoppabledomains/resolution';
-import { isEvmAddress } from '../../helpers/address';
+import { hasOwnedTld, isEvmAddress } from '../../helpers/address';
 import { isSilencedError, isTransportFailure } from '../../helpers/errors';
 import { withoutEmptyValues } from '../../helpers/object';
 import { batchContractCalls, getProvider } from '../../helpers/provider';
@@ -21,7 +21,7 @@ function normalizeAddresses(addresses: Address[]): Address[] {
 }
 
 function normalizeHandles(handles: Handle[]): Handle[] {
-  return handles.map(h => (/^[.a-z0-9-]+$/.test(h) ? h : '')).filter(h => h);
+  return handles.filter(h => /^[.a-z0-9-]+$/.test(h) && !hasOwnedTld(h));
 }
 
 export async function lookupAddresses(addresses: Address[]): Promise<Record<Address, Handle>> {

--- a/src/resolvers/image/ens.ts
+++ b/src/resolvers/image/ens.ts
@@ -1,6 +1,7 @@
 import { ens_normalize } from '@adraffy/ens-normalize';
 import { isAddress } from '@ethersproject/address';
 import snapshot from '@snapshot-labs/snapshot.js';
+import { hasOwnedTld } from '../../helpers/address';
 import { fetchHttpImage, isHttpUrl } from '../../helpers/http';
 import { getProviderOptions } from '../../helpers/provider';
 import { lookupAddresses } from '../address';
@@ -13,7 +14,8 @@ async function castToEnsName(nameOrAddress: string): Promise<string | undefined>
   if (!name?.includes('.')) return undefined;
 
   try {
-    return ens_normalize(name);
+    const ensName = ens_normalize(name);
+    return hasOwnedTld(ensName) ? undefined : ensName;
   } catch {
     return undefined;
   }

--- a/test/integration/resolvers/address/ens.test.ts
+++ b/test/integration/resolvers/address/ens.test.ts
@@ -28,6 +28,12 @@ describe('ENS address resolver: CCIP-Read fallback', () => {
     });
   }, 15e3);
 
+  it('resolves a .base.eth name served only through ENS', async () => {
+    await expect(resolveNames(['bridge.base.eth'])).resolves.toEqual({
+      'bridge.base.eth': '0x3154Cf16ccdb4C6d922629664174b904d80F2C35'
+    });
+  }, 15e3);
+
   it('falls back to per-address lookups when the batch reverse call reverts', async () => {
     const ccipAddress = '0x3a872f8FED4421E7d5BE5c98Ab5Ea0e0245169A0';
     const goodAddress = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';

--- a/test/integration/resolvers/image/ens.test.ts
+++ b/test/integration/resolvers/image/ens.test.ts
@@ -1,4 +1,5 @@
 import testResolverImageSnapshots from './helper';
+import resolve from '../../../../src/resolvers/image/ens';
 import {
   NO_AVATAR_ADDRESS,
   noAvatarInputs,
@@ -10,3 +11,7 @@ testResolverImageSnapshots({
   withAvatar: [remoteSnapshotInputs.ens],
   withoutAvatar: [noAvatarInputs.ensAvatarNotSet, NO_AVATAR_ADDRESS, noAvatarInputs.ensInvalidName]
 });
+
+it('resolves a .base.eth avatar served only through ENS', async () => {
+  await expect(resolve('mint.base.eth')).resolves.toBeInstanceOf(Buffer);
+}, 30e3);

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../../../src/helpers/provider', () => ({
 }));
 
 const mockedFetch = mockGlobalFetch();
+const mockedProvider = (getProvider as jest.Mock).mock.results[0].value;
 
 const providerInstanceHeldByEns = (getProvider as jest.Mock).mock.results[0].value;
 
@@ -26,7 +27,14 @@ function respondWith(body: any, status = 200) {
   mockedFetch.mockResolvedValue(jsonResponse(body, status));
 }
 
+const sentVariables = () => JSON.parse(mockedFetch.mock.calls[0][1].body).variables;
+
 describe('resolvers/address/ens - resolveNames', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedProvider.resolveName.mockReset().mockResolvedValue(null);
+  });
+
   it('reports the subgraph failure instead of a TypeError naming our own field', async () => {
     respondWith({ errors: [{ message: 'bad indexers' }], data: null });
 
@@ -84,5 +92,39 @@ describe('resolvers/address/ens - resolveNames', () => {
     expect(capture).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_ARGUMENT' }), {
       input: { handles: [HANDLE] }
     });
+  });
+
+  it('skips names owned by sibling resolvers before querying ENS', async () => {
+    const names = ['foo.lens', 'foo.bnb', 'foo.stark', 'foo.gwei', 'foo.shib'];
+
+    await expect(resolveNames(names)).resolves.toEqual({});
+
+    expect(mockedFetch).not.toHaveBeenCalled();
+    expect(mockedProvider.resolveName).not.toHaveBeenCalled();
+  });
+
+  it('keeps ENS and DNS names in their original fallback order', async () => {
+    respondWith({
+      data: { domains: [{ name: HANDLE, resolvedAddress: { id: ADDRESS.toLowerCase() } }] }
+    });
+    mockedProvider.resolveName.mockResolvedValue(ADDRESS);
+
+    await expect(
+      resolveNames(['foo.lens', HANDLE, 'foo.xyz', 'api.lens.xyz', 'bridge.base.eth'])
+    ).resolves.toEqual({
+      [HANDLE]: ADDRESS,
+      'foo.xyz': ADDRESS,
+      'api.lens.xyz': ADDRESS,
+      'bridge.base.eth': ADDRESS
+    });
+
+    expect(sentVariables()).toEqual({
+      handles: [HANDLE, 'foo.xyz', 'api.lens.xyz', 'bridge.base.eth']
+    });
+    expect(mockedProvider.resolveName.mock.calls).toEqual([
+      ['foo.xyz'],
+      ['api.lens.xyz'],
+      ['bridge.base.eth']
+    ]);
   });
 });

--- a/test/unit/resolvers/address/unstoppableDomains.test.ts
+++ b/test/unit/resolvers/address/unstoppableDomains.test.ts
@@ -8,15 +8,20 @@ jest.mock('@snapshot-labs/snapshot-sentry', () => ({
 
 const HANDLE = 'test.crypto';
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const mockedCall = jest.spyOn(snapshot.utils, 'call');
 
-afterEach(() => {
-  jest.restoreAllMocks();
+afterAll(() => {
+  mockedCall.mockRestore();
+});
+
+beforeEach(() => {
+  mockedCall.mockResolvedValue(ADDRESS);
 });
 
 describe('resolvers/address/unstoppableDomains - resolveNames', () => {
   it('reports a resolver failure', async () => {
     const error = new Error('boom');
-    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+    mockedCall.mockRejectedValue(error);
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({});
     expect(capture).toHaveBeenCalledWith(error, { input: { handles: [HANDLE] } });
@@ -32,7 +37,7 @@ describe('resolvers/address/unstoppableDomains - resolveNames', () => {
       Object.assign(new TypeError('fetch failed'), { cause: { code: 'CERT_HAS_EXPIRED' } })
     ]
   ] as const)('does not capture a transport failure (%s)', async (_label, error) => {
-    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+    mockedCall.mockRejectedValue(error);
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({});
     expect(capture).not.toHaveBeenCalled();
@@ -40,16 +45,33 @@ describe('resolvers/address/unstoppableDomains - resolveNames', () => {
 
   it('still reports a plain upstream 4xx from the fixed contract endpoint', async () => {
     const error = Object.assign(new Error('not found'), { status: 404 });
-    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+    mockedCall.mockRejectedValue(error);
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({});
     expect(capture).toHaveBeenCalledWith(error, { input: { handles: [HANDLE] } });
   });
 
   it('resolves successfully and reports nothing', async () => {
-    jest.spyOn(snapshot.utils, 'call').mockResolvedValue(ADDRESS);
-
     await expect(resolveNames([HANDLE])).resolves.toEqual({ [HANDLE]: ADDRESS });
     expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('skips names owned by sibling resolvers before querying UNS', async () => {
+    const names = ['foo.lens', 'foo.bnb', 'foo.stark', 'foo.gwei', 'foo.shib'];
+
+    await expect(resolveNames(names)).resolves.toEqual({});
+
+    expect(mockedCall).not.toHaveBeenCalled();
+  });
+
+  it('keeps supported UNS names and existing unsupported-name handling', async () => {
+    await expect(
+      resolveNames(['foo.lens', 'foo.crypto', 'api.lens.crypto', 'vitalik.eth', 'foo.xyz'])
+    ).resolves.toEqual({
+      'foo.crypto': ADDRESS,
+      'api.lens.crypto': ADDRESS
+    });
+
+    expect(mockedCall).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/unit/resolvers/image/ens.test.ts
+++ b/test/unit/resolvers/image/ens.test.ts
@@ -11,11 +11,23 @@ jest.mock('../../../../src/resolvers/address', () => ({ lookupAddresses: jest.fn
 
 const EVM_ADDRESS = '0x0000000000000000000000000000000000000001';
 const STARKNET_ADDRESS = '0x0779ba6e4e227947acbbdfb978a292c401339027eeb3d768f5d12cd2e818265a';
-const INVALID_NAMES = [STARKNET_ADDRESS, 'nodot', 'a..b', '../avatar/vitalik.eth'];
+const INVALID_NAMES = [
+  STARKNET_ADDRESS,
+  'nodot',
+  'a..b',
+  '../avatar/vitalik.eth',
+  'foo.lens',
+  'foo.bnb',
+  'foo.stark',
+  'foo.gwei',
+  'foo.shib'
+];
 const VALID_NAMES = [
   ['vitalik.eth', 'vitalik.eth'],
   ['foo.xyz', 'foo.xyz'],
-  ['ⓥⓘⓣⓐⓛⓘⓚ.eth', 'vitalik.eth']
+  ['ⓥⓘⓣⓐⓛⓘⓚ.eth', 'vitalik.eth'],
+  ['mint.base.eth', 'mint.base.eth'],
+  ['api.lens.xyz', 'api.lens.xyz']
 ] as const;
 
 const mockTransportRequest = jest.fn();
@@ -79,6 +91,20 @@ describe('resolvers/image/ens', () => {
     expect(mockTransportRequest).not.toHaveBeenCalled();
     expect(mockedFetchHttpImage).not.toHaveBeenCalled();
   });
+
+  it.each(['foo.BNB', `foo.le${String.fromCodePoint(0x200b)}ns`])(
+    'skips a sibling-resolver reverse result %s',
+    async reverseName => {
+      mockedLookupAddresses.mockResolvedValue({ [EVM_ADDRESS]: reverseName });
+      const getEnsTextRecord = jest.spyOn(snapshot.utils, 'getEnsTextRecord');
+
+      await expect(resolve(EVM_ADDRESS)).resolves.toBe(false);
+
+      expect(getEnsTextRecord).not.toHaveBeenCalled();
+      expect(mockTransportRequest).not.toHaveBeenCalled();
+      expect(mockedFetchHttpImage).not.toHaveBeenCalled();
+    }
+  );
 
   it('normalizes a valid reverse result before lookup and fallback', async () => {
     mockedLookupAddresses.mockResolvedValue({ [EVM_ADDRESS]: 'VITALIK.eth' });


### PR DESCRIPTION
Open-ended ENS and Unstoppable Domains lookups currently accept terminal names owned by dedicated sibling resolvers. The ENS image resolver can also send those names to mainnet after direct input or reverse lookup.

This introduces a shared, case-insensitive terminal-suffix check and applies it before those address and avatar requests. Embedded suffix text continues through the existing resolver, and `.base.eth` remains eligible for ENS because CCIP can be the only successful route for some names.

Closes #566