### PR TITLE
fix(image): validate Starknet profile addresses

### DIFF
--- a/src/helpers/address.ts
+++ b/src/helpers/address.ts
@@ -15,6 +15,14 @@ export function isStarknetAddress(address: Address): boolean {
   return /^0x[a-fA-F0-9]{64}$/.test(address) && snapshot.utils.isStarknetAddress(address);
 }
 
+export function isStarknetFelt(address: Address): boolean {
+  return (
+    /^0x[a-fA-F0-9]+$/.test(address) &&
+    !isEvmAddress(address) &&
+    snapshot.utils.isStarknetAddress(address)
+  );
+}
+
 // StarknetID's encoder skips characters outside its alphabet instead of rejecting them, so
 // `a!b.stark` encodes exactly like `ab.stark` and would resolve to that owner. Every label has
 // to match, subdomains included. The alphabet is starknet.js's `basicAlphabet` plus the two

--- a/src/helpers/address.ts
+++ b/src/helpers/address.ts
@@ -17,7 +17,7 @@ export function isStarknetAddress(address: Address): boolean {
 
 export function isStarknetFelt(address: Address): boolean {
   return (
-    /^0x[a-fA-F0-9]+$/.test(address) &&
+    /^0x[a-fA-F0-9]{1,64}$/.test(address) &&
     !isEvmAddress(address) &&
     snapshot.utils.isStarknetAddress(address)
   );

--- a/src/resolvers/image/snapshot.ts
+++ b/src/resolvers/image/snapshot.ts
@@ -1,6 +1,6 @@
 import { getAddress } from '@ethersproject/address';
-import snapshot from '@snapshot-labs/snapshot.js';
 import { defaultOffchainNetwork, offchainNetworks } from '../../constants.json';
+import { isStarknetFelt } from '../../helpers/address';
 import { graphQlCall } from '../../helpers/graphql';
 import { fetchHttpImage, getUrl, spaceIds } from '../../helpers/http';
 
@@ -107,7 +107,7 @@ function normalizeUserId(value: string): string | null {
   try {
     return getAddress(trimmed);
   } catch {
-    return trimmed.startsWith('0x') && snapshot.utils.isStarknetAddress(trimmed) ? trimmed : null;
+    return isStarknetFelt(trimmed) ? trimmed : null;
   }
 }
 

--- a/src/resolvers/image/starknet.ts
+++ b/src/resolvers/image/starknet.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { isStarkDomain, isStarknetAddress } from '../../helpers/address';
+import { isStarkDomain, isStarknetFelt } from '../../helpers/address';
 import { axiosDefaultParams, fetchHttpImage, getUrl } from '../../helpers/http';
 import { getProvider } from '../../helpers/provider';
 
@@ -15,7 +15,7 @@ async function getStarknetAddress(domain: string): Promise<string | null> {
 async function getImage(domainOrAddress: string): Promise<string | null> {
   const address = isStarkDomain(domainOrAddress)
     ? await getStarknetAddress(domainOrAddress)
-    : isStarknetAddress(domainOrAddress)
+    : isStarknetFelt(domainOrAddress)
       ? domainOrAddress
       : null;
 

--- a/src/resolvers/image/starknet.ts
+++ b/src/resolvers/image/starknet.ts
@@ -1,14 +1,10 @@
 import axios from 'axios';
-import { isStarkDomain } from '../../helpers/address';
+import { isStarkDomain, isStarknetAddress } from '../../helpers/address';
 import { axiosDefaultParams, fetchHttpImage, getUrl } from '../../helpers/http';
 import { getProvider } from '../../helpers/provider';
 
 const DEFAULT_IMG_URL = 'https://starknet.id/api/identicons/0';
 const provider = getProvider('0x534e5f4d41494e');
-
-function normalizeAddress(address: string): string | null {
-  return /^(0x)?[0-9a-fA-F]{64}$/.test(address) ? address : null;
-}
 
 async function getStarknetAddress(domain: string): Promise<string | null> {
   const address = await provider.getAddressFromStarkName(domain);
@@ -19,7 +15,9 @@ async function getStarknetAddress(domain: string): Promise<string | null> {
 async function getImage(domainOrAddress: string): Promise<string | null> {
   const address = isStarkDomain(domainOrAddress)
     ? await getStarknetAddress(domainOrAddress)
-    : normalizeAddress(domainOrAddress);
+    : isStarknetAddress(domainOrAddress)
+      ? domainOrAddress
+      : null;
 
   if (!address) return null;
 

--- a/test/integration/helpers/address.test.ts
+++ b/test/integration/helpers/address.test.ts
@@ -1,5 +1,7 @@
+import snapshot from '@snapshot-labs/snapshot.js';
 import {
   isStarknetAddress,
+  isStarknetFelt,
   normalizeAddresses,
   normalizeHandles,
   withoutEmptyAddress
@@ -39,6 +41,30 @@ describe('address helpers', () => {
       const offType = [undefined, null, 1, true, [], {}, ''] as unknown as string[];
 
       offType.forEach(value => expect(isStarknetAddress(value)).toBe(false));
+    });
+  });
+
+  describe('isStarknetFelt', () => {
+    const UNPADDED = '0xa00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c';
+    const EVM = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+
+    it('accepts a felt whether or not it is zero-padded', () => {
+      expect(isStarknetFelt(UNPADDED)).toBe(true);
+      expect(isStarknetFelt(`0x${UNPADDED.slice(2).padStart(64, '0')}`)).toBe(true);
+      expect(isStarknetFelt('0x1')).toBe(true);
+    });
+
+    it('rejects an EVM address, which the felt range accepts', () => {
+      expect(snapshot.utils.isStarknetAddress(EVM)).toBe(true);
+      expect(isStarknetFelt(EVM)).toBe(false);
+    });
+
+    it('rejects values outside the felt range, and anything not 0x-prefixed hex', () => {
+      expect(isStarknetFelt(UPPER_BOUND)).toBe(false);
+      expect(isStarknetFelt(PROPOSAL_ID)).toBe(false);
+      expect(isStarknetFelt(UNPADDED.slice(2))).toBe(false);
+      const offType = [undefined, null, 1, true, [], {}, ''] as unknown as string[];
+      offType.forEach(value => expect(isStarknetFelt(value)).toBe(false));
     });
   });
 

--- a/test/integration/helpers/address.test.ts
+++ b/test/integration/helpers/address.test.ts
@@ -59,11 +59,20 @@ describe('address helpers', () => {
       expect(isStarknetFelt(EVM)).toBe(false);
     });
 
-    it('rejects values outside the felt range, and anything not 0x-prefixed hex', () => {
+    it('rejects values outside the address bound, and anything not 0x-prefixed hex', () => {
       expect(isStarknetFelt(UPPER_BOUND)).toBe(false);
       expect(isStarknetFelt(PROPOSAL_ID)).toBe(false);
       expect(isStarknetFelt(UNPADDED.slice(2))).toBe(false);
+    });
+
+    it('rejects padding wider than the 32 bytes an address occupies', () => {
+      expect(isStarknetFelt(`0x${'0'.repeat(63)}1`)).toBe(true);
+      expect(isStarknetFelt(`0x${'0'.repeat(64)}1`)).toBe(false);
+    });
+
+    it('rejects non-string input without throwing', () => {
       const offType = [undefined, null, 1, true, [], {}, ''] as unknown as string[];
+
       offType.forEach(value => expect(isStarknetFelt(value)).toBe(false));
     });
   });

--- a/test/unit/resolvers/image/starknet.test.ts
+++ b/test/unit/resolvers/image/starknet.test.ts
@@ -8,13 +8,26 @@ import starknet from '../../../../src/resolvers/image/starknet';
 
 const OVER_PRIME_ADDRESS = '0x2121212121212121212121212121212121212121212121212121212121212121';
 const UNPREFIXED_ADDRESS = '07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
+const EVM_ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const UNPADDED_ADDRESS = '0xa00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c';
 
 describe('Starknet image resolver', () => {
-  it.each([OVER_PRIME_ADDRESS, UNPREFIXED_ADDRESS])(
-    'does not query a profile for invalid address %s',
+  beforeEach(() => {
+    mockGetStarkProfile.mockReset();
+  });
+
+  it.each([OVER_PRIME_ADDRESS, UNPREFIXED_ADDRESS, EVM_ADDRESS])(
+    'does not query a profile for %s, which is not a Starknet address',
     async address => {
       await expect(starknet(address)).resolves.toBe(false);
       expect(mockGetStarkProfile).not.toHaveBeenCalled();
     }
   );
+
+  it('queries a profile for an address that is not zero-padded', async () => {
+    mockGetStarkProfile.mockResolvedValue({ profilePicture: null });
+
+    await expect(starknet(UNPADDED_ADDRESS)).resolves.toBe(false);
+    expect(mockGetStarkProfile).toHaveBeenCalledWith(UNPADDED_ADDRESS);
+  });
 });

--- a/test/unit/resolvers/image/starknet.test.ts
+++ b/test/unit/resolvers/image/starknet.test.ts
@@ -1,0 +1,20 @@
+const mockGetStarkProfile = jest.fn();
+
+jest.mock('../../../../src/helpers/provider', () => ({
+  getProvider: () => ({ getStarkProfile: mockGetStarkProfile })
+}));
+
+import starknet from '../../../../src/resolvers/image/starknet';
+
+const OVER_PRIME_ADDRESS = '0x2121212121212121212121212121212121212121212121212121212121212121';
+const UNPREFIXED_ADDRESS = '07ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d';
+
+describe('Starknet image resolver', () => {
+  it.each([OVER_PRIME_ADDRESS, UNPREFIXED_ADDRESS])(
+    'does not query a profile for invalid address %s',
+    async address => {
+      await expect(starknet(address)).resolves.toBe(false);
+      expect(mockGetStarkProfile).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/test/unit/resolvers/image/starknet.test.ts
+++ b/test/unit/resolvers/image/starknet.test.ts
@@ -12,10 +12,6 @@ const EVM_ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 const UNPADDED_ADDRESS = '0xa00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c';
 
 describe('Starknet image resolver', () => {
-  beforeEach(() => {
-    mockGetStarkProfile.mockReset();
-  });
-
   it.each([OVER_PRIME_ADDRESS, UNPREFIXED_ADDRESS, EVM_ADDRESS])(
     'does not query a profile for %s, which is not a Starknet address',
     async address => {

--- a/test/unit/resolvers/image/starknet.test.ts
+++ b/test/unit/resolvers/image/starknet.test.ts
@@ -13,7 +13,7 @@ const UNPADDED_ADDRESS = '0xa00373a00352aa367058555149b573322910d54fcdf3a926e3e5
 
 describe('Starknet image resolver', () => {
   it.each([OVER_PRIME_ADDRESS, UNPREFIXED_ADDRESS, EVM_ADDRESS])(
-    'does not query a profile for %s, which is not a Starknet address',
+    'does not query a profile for %s',
     async address => {
       await expect(starknet(address)).resolves.toBe(false);
       expect(mockGetStarkProfile).not.toHaveBeenCalled();


### PR DESCRIPTION
The Starknet image resolver took any 64-digit hex string for an address, so over-prime values such as transaction hashes and proposal ids reached `getStarkProfile` and came back as RPC errors that `isSilencedError` does not silence, which means they were captured rather than merely wasteful. At the same time an address written without its leading zeros was rejected outright and fell through to the blockie. `getAddressFromStarkName` returns addresses in exactly that unpadded form, so the resolver disagreed with itself: the domain branch fed `getStarkProfile` a shape the address branch refused.

Shape is not the invariant here, the address bound is. `helpers/address.ts` gains a predicate that accepts an unpadded id, excludes EVM addresses because they are valid felts too, and caps the input at the 32 bytes an address occupies so one identity cannot be spelled an unbounded number of ways. Both image resolvers now use it, `image/starknet.ts` for the behaviour and `image/snapshot.ts` to drop an inline copy of the same rule.

The trade-off is that short values such as `0x1` now reach `getStarkProfile`, which answers with the default identicon that `resolve` already maps to no image; the 64-digit rule blocked those, at the cost of every address that arrives unpadded.

Domain resolution is unchanged, and so is the strict `isStarknetAddress` that `helpers/http.ts` and the Starknet address resolver depend on to keep EVM addresses out.

Closes #505

#585 was closed as a duplicate.
