### PR TITLE
fix(lookupDomains): bound the ENS account domains query at 1000

### DIFF
--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -1,3 +1,4 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import constants from '../../constants.json';
 import { graphQlCall } from '../../helpers/graphql';
 import { Address, Handle } from '../../helpers/types';
@@ -5,6 +6,8 @@ import { Address, Handle } from '../../helpers/types';
 export const NAME = 'Ens';
 export const DEFAULT_CHAIN_ID = '1';
 export const CHAIN_IDS = Object.keys(constants.ensSubgraph);
+
+const ACCOUNT_DOMAINS_LIMIT = 1000;
 
 type Domain = {
   name: string;
@@ -53,36 +56,49 @@ async function fetchDomainNames(domains: Domain[], chainId: string): Promise<Han
   );
 }
 
+async function fetchOwnedDomains(address: Address, chainId: string): Promise<Domain[]> {
+  const {
+    data: { account }
+  } = await graphQlCall(
+    constants.ensSubgraph[chainId],
+    `query Domain($id: String!, $first: Int!) {
+      account(id: $id) {
+        domains(first: $first) {
+          name
+          expiryDate
+        }
+        wrappedDomains(first: $first) {
+          name
+          expiryDate
+        }
+      }
+    }`,
+    { id: address.toLowerCase(), first: ACCOUNT_DOMAINS_LIMIT }
+  );
+
+  const domains: Domain[] = account?.domains || [];
+  const wrappedDomains: Domain[] = account?.wrappedDomains || [];
+
+  if (domains.length === ACCOUNT_DOMAINS_LIMIT || wrappedDomains.length === ACCOUNT_DOMAINS_LIMIT) {
+    capture(new Error('ENS account has more domains than the request limit allows'), {
+      contexts: {
+        input: { address, chainId, returned: domains.length + wrappedDomains.length }
+      }
+    });
+  }
+
+  return [...domains, ...wrappedDomains];
+}
+
 export default async function lookupDomains(
   address: Address,
   chainId = DEFAULT_CHAIN_ID
 ): Promise<Handle[]> {
   if (!constants.ensSubgraph[chainId]) return [];
 
-  const {
-    data: { account }
-  } = await graphQlCall(
-    constants.ensSubgraph[chainId],
-    `query Domain($id: String!) {
-      account(id: $id) {
-        domains {
-          name
-          expiryDate
-        }
-        wrappedDomains {
-          name
-          expiryDate
-        }
-      }
-    }`,
-    { id: address.toLowerCase() }
-  );
-
+  const owned = await fetchOwnedDomains(address, chainId);
   const now = Date.now() / 1000;
-  const domains: Domain[] = [
-    ...(account?.domains || []),
-    ...(account?.wrappedDomains || [])
-  ].filter(domain => {
+  const domains: Domain[] = owned.filter(domain => {
     const expiry = Number(domain.expiryDate ?? 0);
 
     return domain.name && (!expiry || expiry > now) && !domain.name.endsWith('.addr.reverse');

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -1,11 +1,17 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
 import { graphQlCall } from '../../../../src/helpers/graphql';
 import lookupDomains from '../../../../src/resolvers/lookupDomains/ens';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
 
 jest.mock('../../../../src/helpers/graphql', () => ({
   graphQlCall: jest.fn()
 }));
 
 const mockedGraphQlCall = graphQlCall as jest.Mock;
+const mockedCapture = capture as jest.Mock;
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 const HASH_A = '9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0';
 const HASH_B = '3e744b9dc39389baf0c5a0660589b8402f3dbb49b89b3e75f2c9355852a3c677';
@@ -15,13 +21,21 @@ function graphQlResponse<T>(data: T) {
   return { data };
 }
 
-function accountResponse(domains: { name: string | null; expiryDate?: string | null }[]) {
-  return graphQlResponse({ account: { domains, wrappedDomains: [] } });
+function accountResponse(
+  domains: { name: string | null; expiryDate?: string | null }[],
+  wrappedDomains: { name: string | null; expiryDate?: string | null }[] = []
+) {
+  return graphQlResponse({ account: { domains, wrappedDomains } });
+}
+
+function namedDomains(count: number, prefix: string) {
+  return Array.from({ length: count }, (_, index) => ({ name: `${prefix}${index}.eth` }));
 }
 
 describe('lookupDomains/ens', () => {
   beforeEach(() => {
     mockedGraphQlCall.mockReset();
+    mockedCapture.mockReset();
   });
 
   afterEach(() => {
@@ -52,6 +66,49 @@ describe('lookupDomains/ens', () => {
     );
 
     await expect(lookupDomains(ADDRESS)).resolves.toEqual(['alice.eth']);
+  });
+
+  it('requests both nested domain lists in a single call bounded by the limit', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(accountResponse([{ name: 'plain.eth' }]));
+
+    await lookupDomains(ADDRESS);
+
+    const [, query, variables] = mockedGraphQlCall.mock.calls[0];
+    expect(query).toContain('domains(first: $first)');
+    expect(query).toContain('wrappedDomains(first: $first)');
+    expect(variables).toEqual({ id: ADDRESS.toLowerCase(), first: 1000 });
+    expect(mockedGraphQlCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('combines both nested lists into one result', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(
+      accountResponse(namedDomains(2, 'a'), namedDomains(3, 'w'))
+    );
+
+    const result = await lookupDomains(ADDRESS);
+
+    expect(result).toHaveLength(5);
+    expect(result).toContain('a0.eth');
+    expect(result).toContain('w0.eth');
+  });
+
+  it('reports the account whose list hit the request limit', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(accountResponse(namedDomains(1000, 'a')));
+
+    await lookupDomains(ADDRESS);
+
+    expect(mockedCapture).toHaveBeenCalledTimes(1);
+    expect(mockedCapture.mock.calls[0][1]).toEqual({
+      contexts: { input: { address: ADDRESS, chainId: '1', returned: 1000 } }
+    });
+  });
+
+  it('stays quiet when a list is one short of the request limit', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(accountResponse(namedDomains(999, 'a')));
+
+    await lookupDomains(ADDRESS);
+
+    expect(mockedCapture).not.toHaveBeenCalled();
   });
 
   it('loads all hashed labels in one domains query', async () => {


### PR DESCRIPTION
`lookupDomains/ens` asked the ENS subgraph for `account(id) { domains, wrappedDomains }` with no `first`, so graph-node applied its default nested page size (100) to each list and the overflow was dropped before any label decoding happened. An address holding more than 100 names in either list silently lost the rest.

Both nested lists now carry `first: 1000`. That's the subgraph's own ceiling, not a chosen round number: `first: 5000` against this endpoint is rejected outright (`The 'first' argument must be between 0 and 1000`), so 1000 is the most it will ever hand back in one call. An account past that per list is treated as an edge case rather than something this resolver walks through with cursor pagination; this stays a single request. When either list comes back exactly at the cap, `capture` records the address and how many names it did return, so a truncated answer stays visible instead of merely plausible.

Closes #575
