### PR TITLE
fix(lookupDomains): resolve every hashed label in multi-level ENS names

### DIFF
--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -17,11 +17,14 @@ type ResolvedLabel = {
   labelName: string;
 };
 
-const HASHED_LABEL = /\[(.*?)\]/g;
+const HASHED_LABEL = /\[([0-9a-f]{64})\]/g;
+// A labelhash isn't unique across domains, so the row count isn't bounded by
+// the number of hashes queried; 1000 is what every indexer in the subgraph's
+// pool accepts, not a value derived from the query itself.
 const DOMAINS_PAGE_SIZE = 1000;
 
 function getLabelHashes(domain: Domain) {
-  return [...domain.name.matchAll(HASHED_LABEL)].map(([, hash]) => hash).filter(Boolean);
+  return [...domain.name.matchAll(HASHED_LABEL)].map(([, hash]) => hash);
 }
 
 async function fetchDomainNames(domains: Domain[], chainId: string): Promise<Handle[]> {

--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -12,15 +12,16 @@ type Domain = {
   expiryDate?: number;
 };
 
-type Registration = {
-  id: string;
-  domain?: Pick<Domain, 'labelName'>;
+type ResolvedLabel = {
+  labelhash: string;
+  labelName: string;
 };
 
 const HASHED_LABEL = /\[(.*?)\]/g;
+const DOMAINS_PAGE_SIZE = 1000;
 
 function getLabelHashes(domain: Domain) {
-  return [...domain.name.matchAll(HASHED_LABEL)].map(([, hash]) => hash);
+  return [...domain.name.matchAll(HASHED_LABEL)].map(([, hash]) => hash).filter(Boolean);
 }
 
 async function fetchDomainNames(domains: Domain[], chainId: string): Promise<Handle[]> {
@@ -28,23 +29,21 @@ async function fetchDomainNames(domains: Domain[], chainId: string): Promise<Han
 
   if (!hashes.length) return domains.map(domain => domain.name);
 
-  const { data } = await graphQlCall<{ registrations: Registration[] }>(
+  const { data } = await graphQlCall<{ domains: ResolvedLabel[] }>(
     constants.ensSubgraph[chainId],
-    `query Registrations($ids: [String!]!, $first: Int!) {
-      registrations(first: $first, where: { id_in: $ids }) {
-        id
-        domain {
-          labelName
-        }
+    `query Labels($hashes: [Bytes!]!, $first: Int!) {
+      domains(first: $first, where: { labelhash_in: $hashes, labelName_not: null }) {
+        labelhash
+        labelName
       }
     }`,
     {
-      ids: hashes.map(hash => `0x${hash}`),
-      first: hashes.length
+      hashes: hashes.map(hash => `0x${hash}`),
+      first: DOMAINS_PAGE_SIZE
     }
   );
   const labelNames = new Map(
-    data.registrations.map(registration => [registration.id, registration.domain?.labelName])
+    data.domains.map(({ labelhash, labelName }) => [labelhash, labelName])
   );
 
   return domains.map(domain =>

--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -17,14 +17,14 @@ type Registration = {
   domain?: Pick<Domain, 'labelName'>;
 };
 
-function getLabelHash(domain: Domain) {
-  return domain.name.match(/\[(.*?)\]/)?.[1];
+const HASHED_LABEL = /\[(.*?)\]/g;
+
+function getLabelHashes(domain: Domain) {
+  return [...domain.name.matchAll(HASHED_LABEL)].map(([, hash]) => hash);
 }
 
 async function fetchDomainNames(domains: Domain[], chainId: string): Promise<Handle[]> {
-  const hashes = [
-    ...new Set(domains.map(getLabelHash).filter((hash): hash is string => Boolean(hash)))
-  ];
+  const hashes = [...new Set(domains.flatMap(getLabelHashes))];
 
   if (!hashes.length) return domains.map(domain => domain.name);
 
@@ -47,12 +47,9 @@ async function fetchDomainNames(domains: Domain[], chainId: string): Promise<Han
     data.registrations.map(registration => [registration.id, registration.domain?.labelName])
   );
 
-  return domains.map(domain => {
-    const hash = getLabelHash(domain);
-    const labelName = hash ? labelNames.get(`0x${hash}`) : undefined;
-
-    return labelName ? domain.name.replace(`[${hash}]`, () => labelName) : domain.name;
-  });
+  return domains.map(domain =>
+    domain.name.replace(HASHED_LABEL, (label, hash) => labelNames.get(`0x${hash}`) || label)
+  );
 }
 
 export default async function lookupDomains(

--- a/test/unit/helpers/graphqlEnvelope.test.ts
+++ b/test/unit/helpers/graphqlEnvelope.test.ts
@@ -21,6 +21,7 @@ const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 const IMAGE_URL = 'https://example.com/avatar.png';
 
 const ENS_SUBGRAPH = '[subgrapher.snapshot.org]';
+const ENS_HASH = 'e691d0079f79eca4304219d11ee5e5ff3df65a87c2595597cc15b4efd1dfda2b';
 
 function respondWith(body: any, status = 200) {
   mockedFetch.mockResolvedValue(jsonResponse(body, status));
@@ -66,7 +67,7 @@ describe('graphQlCall callers surface an envelope failure', () => {
   describe('src/resolvers/lookupDomains/ens.ts - registration', () => {
     const hashedDomain = {
       data: {
-        account: { domains: [{ name: '[7f3a].eth' }], wrappedDomains: [] }
+        account: { domains: [{ name: `[${ENS_HASH}].eth` }], wrappedDomains: [] }
       }
     };
 
@@ -78,7 +79,7 @@ describe('graphQlCall callers surface an envelope failure', () => {
 
     it('decodes the label when the subgraph answers', async () => {
       answerWith({
-        data: { domains: [{ labelhash: '0x7f3a', labelName: 'vitalik' }] }
+        data: { domains: [{ labelhash: `0x${ENS_HASH}`, labelName: 'vitalik' }] }
       });
 
       await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['vitalik.eth']);
@@ -87,7 +88,7 @@ describe('graphQlCall callers surface an envelope failure', () => {
     it('keeps the hashed name when the label is genuinely unknown', async () => {
       answerWith({ data: { domains: [] } });
 
-      await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['[7f3a].eth']);
+      await expect(ensLookupDomains(ADDRESS)).resolves.toEqual([`[${ENS_HASH}].eth`]);
     });
 
     it('rejects rather than returning the undecoded name when the subgraph fails', async () => {

--- a/test/unit/helpers/graphqlEnvelope.test.ts
+++ b/test/unit/helpers/graphqlEnvelope.test.ts
@@ -78,14 +78,14 @@ describe('graphQlCall callers surface an envelope failure', () => {
 
     it('decodes the label when the subgraph answers', async () => {
       answerWith({
-        data: { registrations: [{ id: '0x7f3a', domain: { labelName: 'vitalik' } }] }
+        data: { domains: [{ labelhash: '0x7f3a', labelName: 'vitalik' }] }
       });
 
       await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['vitalik.eth']);
     });
 
     it('keeps the hashed name when the label is genuinely unknown', async () => {
-      answerWith({ data: { registrations: [] } });
+      answerWith({ data: { domains: [] } });
 
       await expect(ensLookupDomains(ADDRESS)).resolves.toEqual(['[7f3a].eth']);
     });

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -7,6 +7,9 @@ jest.mock('../../../../src/helpers/graphql', () => ({
 
 const mockedGraphQlCall = graphQlCall as jest.Mock;
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+const HASH_A = '9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0';
+const HASH_B = '3e744b9dc39389baf0c5a0660589b8402f3dbb49b89b3e75f2c9355852a3c677';
+const HASH_C = '64daa44ad493ff28a96effab6e77f1732a3d97d83241581b37dbd70a7a4900fe';
 
 function graphQlResponse<T>(data: T) {
   return { data };
@@ -24,13 +27,17 @@ describe('lookupDomains/ens', () => {
   it('loads all hashed labels in one domains query', async () => {
     mockedGraphQlCall
       .mockResolvedValueOnce(
-        accountResponse([{ name: '[aaa].eth' }, { name: 'plain.eth' }, { name: '[bbb].eth' }])
+        accountResponse([
+          { name: `[${HASH_A}].eth` },
+          { name: 'plain.eth' },
+          { name: `[${HASH_B}].eth` }
+        ])
       )
       .mockResolvedValue(
         graphQlResponse({
           domains: [
-            { labelhash: '0xbbb', labelName: '$&' },
-            { labelhash: '0xaaa', labelName: 'alice' }
+            { labelhash: `0x${HASH_B}`, labelName: '$&' },
+            { labelhash: `0x${HASH_A}`, labelName: 'alice' }
           ]
         })
       );
@@ -45,18 +52,18 @@ describe('lookupDomains/ens', () => {
       expect.stringContaining(
         'domains(first: $first, where: { labelhash_in: $hashes, labelName_not: null })'
       ),
-      { hashes: ['0xaaa', '0xbbb'], first: 1000 }
+      { hashes: [`0x${HASH_A}`, `0x${HASH_B}`], first: 1000 }
     );
   });
 
   it('resolves a label from duplicate rows sharing one labelhash', async () => {
     mockedGraphQlCall
-      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].sub.eth' }]))
+      .mockResolvedValueOnce(accountResponse([{ name: `[${HASH_A}].sub.eth` }]))
       .mockResolvedValueOnce(
         graphQlResponse({
           domains: [
-            { labelhash: '0xaaa', labelName: 'alice' },
-            { labelhash: '0xaaa', labelName: 'alice' }
+            { labelhash: `0x${HASH_A}`, labelName: 'alice' },
+            { labelhash: `0x${HASH_A}`, labelName: 'alice' }
           ]
         })
       );
@@ -67,29 +74,34 @@ describe('lookupDomains/ens', () => {
   it('resolves every hashed label of a multi-level name', async () => {
     mockedGraphQlCall
       .mockResolvedValueOnce(
-        accountResponse([{ name: '[aaa].[bbb].[ccc].eth' }, { name: '[ccc].eth' }])
+        accountResponse([
+          { name: `[${HASH_A}].[${HASH_B}].[${HASH_C}].eth` },
+          { name: `[${HASH_C}].eth` }
+        ])
       )
       .mockResolvedValueOnce(
         graphQlResponse({
           domains: [
-            { labelhash: '0xaaa', labelName: 'alice' },
-            { labelhash: '0xccc', labelName: 'aragonid' }
+            { labelhash: `0x${HASH_A}`, labelName: 'alice' },
+            { labelhash: `0x${HASH_C}`, labelName: 'aragonid' }
           ]
         })
       );
 
     await expect(lookupDomains(ADDRESS)).resolves.toEqual([
-      'alice.[bbb].aragonid.eth',
+      `alice.[${HASH_B}].aragonid.eth`,
       'aragonid.eth'
     ]);
     expect(mockedGraphQlCall.mock.calls[1][2]).toEqual({
-      hashes: ['0xaaa', '0xbbb', '0xccc'],
+      hashes: [`0x${HASH_A}`, `0x${HASH_B}`, `0x${HASH_C}`],
       first: 1000
     });
   });
 
   it('requests a fixed page size regardless of how many hashes are looked up', async () => {
-    const domains = Array.from({ length: 1500 }, (_, index) => ({ name: `[${index}].eth` }));
+    const domains = Array.from({ length: 1500 }, (_, index) => ({
+      name: `[${String(index).padStart(64, '0')}].eth`
+    }));
     mockedGraphQlCall
       .mockResolvedValueOnce(accountResponse(domains))
       .mockResolvedValueOnce(graphQlResponse({ domains: [] }));
@@ -113,9 +125,22 @@ describe('lookupDomains/ens', () => {
     expect(mockedGraphQlCall).toHaveBeenCalledTimes(1);
   });
 
+  it('leaves a bracket that is not a 64-hex labelhash untouched instead of sending it to the subgraph', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(
+      accountResponse([{ name: 'a[bbb].c.eth' }, { name: '[AAA].eth' }, { name: '[[aaa]].eth' }])
+    );
+
+    await expect(lookupDomains(ADDRESS)).resolves.toEqual([
+      'a[bbb].c.eth',
+      '[AAA].eth',
+      '[[aaa]].eth'
+    ]);
+    expect(mockedGraphQlCall).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects when the domains list is null', async () => {
     mockedGraphQlCall
-      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].eth' }]))
+      .mockResolvedValueOnce(accountResponse([{ name: `[${HASH_A}].eth` }]))
       .mockResolvedValueOnce(graphQlResponse({ domains: null }));
 
     await expect(lookupDomains(ADDRESS)).rejects.toThrow();
@@ -123,7 +148,7 @@ describe('lookupDomains/ens', () => {
 
   it('rejects when the domains response has no data envelope', async () => {
     mockedGraphQlCall
-      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].eth' }]))
+      .mockResolvedValueOnce(accountResponse([{ name: `[${HASH_A}].eth` }]))
       .mockResolvedValueOnce({ data: {} });
 
     await expect(lookupDomains(ADDRESS)).rejects.toThrow();

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -47,6 +47,25 @@ describe('lookupDomains/ens', () => {
     );
   });
 
+  it('resolves every hashed label of a multi-level name', async () => {
+    mockedGraphQlCall
+      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].[bbb].[ccc].eth' }]))
+      .mockResolvedValueOnce(
+        graphQlResponse({
+          registrations: [
+            { id: '0xaaa', domain: { labelName: 'alice' } },
+            { id: '0xccc', domain: { labelName: 'aragonid' } }
+          ]
+        })
+      );
+
+    await expect(lookupDomains(ADDRESS)).resolves.toEqual(['alice.[bbb].aragonid.eth']);
+    expect(mockedGraphQlCall.mock.calls[1][2]).toEqual({
+      ids: ['0xaaa', '0xbbb', '0xccc'],
+      first: 3
+    });
+  });
+
   it('requests every registration beyond the subgraph default page size', async () => {
     const domains = Array.from({ length: 101 }, (_, index) => ({ name: `[${index}].eth` }));
     mockedGraphQlCall

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -49,7 +49,9 @@ describe('lookupDomains/ens', () => {
 
   it('resolves every hashed label of a multi-level name', async () => {
     mockedGraphQlCall
-      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].[bbb].[ccc].eth' }]))
+      .mockResolvedValueOnce(
+        accountResponse([{ name: '[aaa].[bbb].[ccc].eth' }, { name: '[ccc].eth' }])
+      )
       .mockResolvedValueOnce(
         graphQlResponse({
           registrations: [
@@ -59,7 +61,10 @@ describe('lookupDomains/ens', () => {
         })
       );
 
-    await expect(lookupDomains(ADDRESS)).resolves.toEqual(['alice.[bbb].aragonid.eth']);
+    await expect(lookupDomains(ADDRESS)).resolves.toEqual([
+      'alice.[bbb].aragonid.eth',
+      'aragonid.eth'
+    ]);
     expect(mockedGraphQlCall.mock.calls[1][2]).toEqual({
       ids: ['0xaaa', '0xbbb', '0xccc'],
       first: 3

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -21,16 +21,16 @@ describe('lookupDomains/ens', () => {
     mockedGraphQlCall.mockReset();
   });
 
-  it('loads all hashed labels in one registration query', async () => {
+  it('loads all hashed labels in one domains query', async () => {
     mockedGraphQlCall
       .mockResolvedValueOnce(
         accountResponse([{ name: '[aaa].eth' }, { name: 'plain.eth' }, { name: '[bbb].eth' }])
       )
       .mockResolvedValue(
         graphQlResponse({
-          registrations: [
-            { id: '0xbbb', domain: { labelName: '$&' } },
-            { id: '0xaaa', domain: { labelName: 'alice' } }
+          domains: [
+            { labelhash: '0xbbb', labelName: '$&' },
+            { labelhash: '0xaaa', labelName: 'alice' }
           ]
         })
       );
@@ -42,9 +42,26 @@ describe('lookupDomains/ens', () => {
     expect(mockedGraphQlCall).toHaveBeenNthCalledWith(
       2,
       expect.any(String),
-      expect.stringContaining('registrations(first: $first, where: { id_in: $ids })'),
-      { ids: ['0xaaa', '0xbbb'], first: 2 }
+      expect.stringContaining(
+        'domains(first: $first, where: { labelhash_in: $hashes, labelName_not: null })'
+      ),
+      { hashes: ['0xaaa', '0xbbb'], first: 1000 }
     );
+  });
+
+  it('resolves a label from duplicate rows sharing one labelhash', async () => {
+    mockedGraphQlCall
+      .mockResolvedValueOnce(accountResponse([{ name: '[aaa].sub.eth' }]))
+      .mockResolvedValueOnce(
+        graphQlResponse({
+          domains: [
+            { labelhash: '0xaaa', labelName: 'alice' },
+            { labelhash: '0xaaa', labelName: 'alice' }
+          ]
+        })
+      );
+
+    await expect(lookupDomains(ADDRESS)).resolves.toEqual(['alice.sub.eth']);
   });
 
   it('resolves every hashed label of a multi-level name', async () => {
@@ -54,9 +71,9 @@ describe('lookupDomains/ens', () => {
       )
       .mockResolvedValueOnce(
         graphQlResponse({
-          registrations: [
-            { id: '0xaaa', domain: { labelName: 'alice' } },
-            { id: '0xccc', domain: { labelName: 'aragonid' } }
+          domains: [
+            { labelhash: '0xaaa', labelName: 'alice' },
+            { labelhash: '0xccc', labelName: 'aragonid' }
           ]
         })
       );
@@ -66,40 +83,45 @@ describe('lookupDomains/ens', () => {
       'aragonid.eth'
     ]);
     expect(mockedGraphQlCall.mock.calls[1][2]).toEqual({
-      ids: ['0xaaa', '0xbbb', '0xccc'],
-      first: 3
+      hashes: ['0xaaa', '0xbbb', '0xccc'],
+      first: 1000
     });
   });
 
-  it('requests every registration beyond the subgraph default page size', async () => {
-    const domains = Array.from({ length: 101 }, (_, index) => ({ name: `[${index}].eth` }));
+  it('requests a fixed page size regardless of how many hashes are looked up', async () => {
+    const domains = Array.from({ length: 1500 }, (_, index) => ({ name: `[${index}].eth` }));
     mockedGraphQlCall
       .mockResolvedValueOnce(accountResponse(domains))
-      .mockResolvedValueOnce(graphQlResponse({ registrations: [] }));
+      .mockResolvedValueOnce(graphQlResponse({ domains: [] }));
 
     await lookupDomains(ADDRESS);
 
-    expect(mockedGraphQlCall.mock.calls[1][2]).toEqual(
-      expect.objectContaining({ first: domains.length })
-    );
+    expect(mockedGraphQlCall.mock.calls[1][2]).toEqual(expect.objectContaining({ first: 1000 }));
   });
 
-  it('does not query registrations when no name has a hashed label', async () => {
+  it('does not query domains when no name has a hashed label', async () => {
     mockedGraphQlCall.mockResolvedValueOnce(accountResponse([{ name: 'plain.eth' }]));
 
     await expect(lookupDomains(ADDRESS)).resolves.toEqual(['plain.eth']);
     expect(mockedGraphQlCall).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects when the registration list is null', async () => {
+  it('leaves an empty bracket untouched instead of querying the subgraph for it', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(accountResponse([{ name: '[].eth' }]));
+
+    await expect(lookupDomains(ADDRESS)).resolves.toEqual(['[].eth']);
+    expect(mockedGraphQlCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when the domains list is null', async () => {
     mockedGraphQlCall
       .mockResolvedValueOnce(accountResponse([{ name: '[aaa].eth' }]))
-      .mockResolvedValueOnce(graphQlResponse({ registrations: null }));
+      .mockResolvedValueOnce(graphQlResponse({ domains: null }));
 
     await expect(lookupDomains(ADDRESS)).rejects.toThrow();
   });
 
-  it('rejects when the registration response has no data envelope', async () => {
+  it('rejects when the domains response has no data envelope', async () => {
     mockedGraphQlCall
       .mockResolvedValueOnce(accountResponse([{ name: '[aaa].eth' }]))
       .mockResolvedValueOnce({ data: {} });


### PR DESCRIPTION
`getLabelHash` read only the first bracketed segment of a subgraph name, and the substitution replaced only that one `[hash]`. Every other hashed label in the name was left alone, so a label the subgraph does know still came back hashed whenever it was not the first one.

Collect every bracketed hash per name and resolve them in one batched query against every domain the subgraph has a label for, not just labels that were independently registered as their own `.eth` 2LD name. A labelhash is a function of the label alone, so it decodes the same wherever in the name it sits, including a subdomain-only or DNS-imported label that never had its own registration. A hash the subgraph has never seen is left as it is, as before.

Fixes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)