### PR TITLE
test: reshape the fixtures that still describe axios

### DIFF
--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -37,6 +37,9 @@ const RESOLVERS = [
 ];
 
 const ADDRESS = '0xE6D0Dd18C6C3a9Af8C2FaB57d6e6A38E29d513cC';
+const ETHERS_504 =
+  'bad response (status=504, headers={}, body="error code: 504", code=SERVER_ERROR, version=web/5.7.1)';
+const LENS_503 = '[api.lens.xyz] status code 503: Service Unavailable';
 
 beforeEach(() => {
   RESOLVERS.forEach(resolver => {
@@ -77,25 +80,21 @@ describe('address resolvers - resolver failures', () => {
   });
 
   it('does not capture a silenced error', async () => {
-    jest
-      .spyOn(ens, 'lookupAddresses')
-      .mockRejectedValue(new Error('Request failed with status=504, no body'));
+    jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(new Error(ETHERS_504));
 
     await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
     expect(capture).not.toHaveBeenCalled();
   });
 
   it('does not capture an error listed in the resolver MUTED_ERRORS', async () => {
-    jest
-      .spyOn(lens, 'lookupAddresses')
-      .mockRejectedValue(new Error('Request failed with status code 503'));
+    jest.spyOn(lens, 'lookupAddresses').mockRejectedValue(new Error(LENS_503));
 
     await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
     expect(capture).not.toHaveBeenCalled();
   });
 
   it('applies MUTED_ERRORS only to the resolver exporting it', async () => {
-    const error = new Error('Request failed with status code 503');
+    const error = new Error(LENS_503);
     jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);
 
     await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});

--- a/test/unit/resolvers/image/failureContract.test.ts
+++ b/test/unit/resolvers/image/failureContract.test.ts
@@ -57,15 +57,18 @@ const UNRESIZED = [
   ['space-cover-sx', resolveCover]
 ] as const;
 
-const UPSTREAM_404 = Object.assign(new Error('Request failed with status code 404'), {
-  response: { status: 404 }
-});
+const NOT_FOUND = '[metadata.ens.domains] Not Found';
 
 const NOT_REPORTED = [
-  ['an upstream 404', UPSTREAM_404],
+  [
+    'a 404 carried on error.response',
+    Object.assign(new Error(NOT_FOUND), {
+      response: { status: 404 }
+    })
+  ],
   [
     'a 404 carried on the error itself',
-    Object.assign(new Error('[trustwallet] Not Found'), {
+    Object.assign(new Error(NOT_FOUND), {
       status: 404
     })
   ],


### PR DESCRIPTION
## What

Four fixtures in two files still spell their errors the way `axios` did, in files that PR does not otherwise touch.

`axios` is gone from `package.json` and from `yarn.lock`, and nothing in the tree produces `Request failed with status code N` anymore. A GraphQL non-2xx now reads `[host] status code N: Reason`, a plain fetch non-2xx reads `[host] Reason`, and a transient ethers 504 arrives as `bad response (status=504, ...)`. Each message is swapped for the one its own path now produces. The old `[trustwallet] Not Found` was wrong for a second reason: trustwallet fetches through `fetchHttpImage`, so the host in that message is never the resolver name.

The assertions are unchanged. The two 404 cases in the image failure contract are renamed for the slot each one pins, `error.response.status` and `error.status`, since that is the only thing telling them apart. Each carries one slot rather than both, the same one-slot-per-case shape `test/integration/helpers/errors.test.ts` uses. `httpError` sets both, so neither of those two is a literal copy of an error it produces.

Same class as the fixture comment on #457, which reshaped `test/unit/api.test.ts` and `test/integration/helpers/errors.test.ts` and left these two out of that diff.
