### PR TITLE
fix(http): data: profile pictures are rewritten to the IPFS gateway and rejected

### DIFF
--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -35,6 +35,8 @@ export function fetchHttpImage(url: string): Promise<Buffer> {
 }
 
 export function getUrl(url) {
+  if (url.startsWith('data:')) return url;
+
   const gateway: string = process.env.IPFS_GATEWAY || 'cloudflare-ipfs.com';
   return snapshot.utils.getUrl(url, gateway);
 }

--- a/test/unit/resolvers/image/starknet.test.ts
+++ b/test/unit/resolvers/image/starknet.test.ts
@@ -5,7 +5,7 @@ jest.mock('../../../../src/helpers/provider', () => ({
 }));
 
 import starknet from '../../../../src/resolvers/image/starknet';
-import { incompleteJsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
+import { incompleteJsonResponse, jsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
 
 const mockedFetch = mockGlobalFetch();
 
@@ -57,5 +57,20 @@ describe('Starknet image resolver', () => {
     await expect(starknet(ADDRESS)).rejects.toMatchObject({
       name: 'AbortError'
     });
+  });
+
+  it('fetches a data: URI profile picture directly rather than through the IPFS gateway', async () => {
+    const metadataUri =
+      'data:application/json;base64,eyJpbWFnZSI6ImRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5In0=';
+    const imageUri = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0i';
+    mockGetStarkProfile.mockResolvedValue({ profilePicture: metadataUri });
+    mockedFetch
+      .mockResolvedValueOnce(jsonResponse({ image: imageUri }))
+      .mockResolvedValueOnce(new Response('svg-bytes'));
+
+    await expect(starknet(ADDRESS)).resolves.toBeInstanceOf(Buffer);
+
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, metadataUri, expect.anything());
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, imageUri, expect.anything());
   });
 });


### PR DESCRIPTION
## Problem

`getUrl` (`src/helpers/http.ts`) treats any URL that isn't `ipfs://`, `ipns://`, `http://`, or `https://` as a bare CID and rewrites it onto the IPFS gateway path. A Starknet `getStarkProfile().profilePicture` for an on-chain-metadata NFT (Blobert, Realms, ...) is a `data:` URI, not a CID, so it gets concatenated onto the gateway path (`.../ipfs/data:application/json;base64,...`) and the gateway answers 400. The resolver reports the failure and falls back to a blockie; the real avatar never renders for these identities.

## Fix

Short-circuit `getUrl` for `data:` URIs: they carry their own bytes and need no gateway.

Closes #609.