### PR TITLE
refactor(lookupDomains): drop the dead labelName field

### DIFF
--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -8,7 +8,6 @@ export const CHAIN_IDS = Object.keys(constants.ensSubgraph);
 
 type Domain = {
   name: string;
-  labelName?: string;
   expiryDate?: number;
 };
 


### PR DESCRIPTION
`Domain.labelName` in `src/resolvers/lookupDomains/ens.ts` had exactly one consumer — `Pick<Domain, 'labelName'>` in the `Registration` type — and #600 deleted `Registration` when the batched lookup moved from `registrations(id_in:)` to `domains(labelhash_in:)`. Its replacement `ResolvedLabel` declares its own `labelName`, and the account query selects only `name` and `expiryDate`, so the field is neither read nor populated any more.

One line, no behavior change. `tsc --noEmit` confirms no remaining reader; `yarn lint` clean; the 20 unit tests in `ens.test.ts` + `graphqlEnvelope.test.ts` pass unchanged.
