### PR TITLE
fix(lookupDomains): drop a nameless ENS domain row instead of crashing

### DIFF
--- a/src/resolvers/lookupDomains/ens.ts
+++ b/src/resolvers/lookupDomains/ens.ts
@@ -85,7 +85,7 @@ export default async function lookupDomains(
   ].filter(domain => {
     const expiry = Number(domain.expiryDate ?? 0);
 
-    return (!expiry || expiry > now) && !domain.name.endsWith('.addr.reverse');
+    return domain.name && (!expiry || expiry > now) && !domain.name.endsWith('.addr.reverse');
   });
 
   return fetchDomainNames(domains, chainId);

--- a/test/unit/resolvers/lookupDomains/ens.test.ts
+++ b/test/unit/resolvers/lookupDomains/ens.test.ts
@@ -15,7 +15,7 @@ function graphQlResponse<T>(data: T) {
   return { data };
 }
 
-function accountResponse(domains: { name: string; expiryDate?: string }[]) {
+function accountResponse(domains: { name: string | null; expiryDate?: string | null }[]) {
   return graphQlResponse({ account: { domains, wrappedDomains: [] } });
 }
 
@@ -44,6 +44,14 @@ describe('lookupDomains/ens', () => {
       'subdomain.eth',
       'far-future.eth'
     ]);
+  });
+
+  it('drops a nameless row instead of throwing', async () => {
+    mockedGraphQlCall.mockResolvedValueOnce(
+      accountResponse([{ name: null, expiryDate: null }, { name: 'alice.eth' }])
+    );
+
+    await expect(lookupDomains(ADDRESS)).resolves.toEqual(['alice.eth']);
   });
 
   it('loads all hashed labels in one domains query', async () => {


### PR DESCRIPTION
The ENS subgraph can return an account `domains` row with `name: null` (reproducible today against `constants.ensSubgraph["1"]` for the ENS root-node owner). The expiry filter in `lookupDomains/ens.ts` dereferences `domain.name` unconditionally, so that one row throws `TypeError: Cannot read properties of null (reading 'endsWith')`, which discards every valid name for the address alongside it, not just the bad row. The dispatcher in `lookupDomains/index.ts` catches the throw, reports it to Sentry, and returns `[]`.

Guard the filter so a nameless row is dropped instead of crashing the whole batch. Optional chaining would be wrong here: `domain.name?.endsWith(...)` evaluates to `undefined`, which negates to `true`, so the nameless row would survive the filter and reach `fetchDomainNames`, moving the same crash to `getLabelHashes` instead of fixing it.

Closes #618
