### PR TITLE
refactor(api): clean up image route id parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cdn.stamp.fyi/**token**/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e
 
 ### Identifier
 
-The identifier can be an address (case insensitive), ENS name, Basename, CAIP-10, EIP-3770, DID or Starknet domain.
+The identifier can be an address (case insensitive), ENS name, Basename, CAIP-10, EIP-3770 or Starknet domain.
 
 #### Examples
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -58,7 +58,7 @@ router.get(`/clear/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
     if (type === 'address' || type === 'name') {
       result = await clearCache(id, type);
     } else {
-      const { address, network, w, h, fallback, cb, fit } = await parseQuery(id, type, {
+      const { address, network, w, h, fallback, cb, fit } = parseQuery(id, type, {
         s: constants.max,
         fb: req.query.fb,
         cb: req.query.cb,
@@ -76,17 +76,11 @@ router.get(`/clear/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
 
 router.get(`/:type(${TYPE_CONSTRAINTS})/:id`, async (req, res) => {
   const { type, id } = req.params as { type: ResolverType; id: string };
-  let address, network, networkId, w, h, fallback, cb, resolver, fit;
-
-  try {
-    ({ address, network, networkId, w, h, fallback, cb, resolver, fit } = await parseQuery(
-      id,
-      type,
-      req.query
-    ));
-  } catch {
-    return res.status(500).json({ status: 'error', error: 'failed to load content' });
-  }
+  const { address, network, networkId, w, h, fallback, cb, resolver, fit } = parseQuery(
+    id,
+    type,
+    req.query
+  );
 
   const disableCache = !!resolver;
 

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -10,10 +10,11 @@ export function sha256(str) {
 }
 
 export function parseQuery(id: string, type: ResolverType, query) {
+  id = id.trim().toLowerCase();
   let address = id;
   let network = '1';
   let networkId: string | undefined = undefined;
-  const chunks = id.split(':');
+  const chunks = id.split(':').map(chunk => chunk.trim());
   if (chunks.length === 2) {
     address = chunks[1];
     networkId = chunks[0];
@@ -24,7 +25,7 @@ export function parseQuery(id: string, type: ResolverType, query) {
     networkId = chainIdToShortName(network) || 'eth';
   }
 
-  address = address.trim().toLowerCase();
+  address = address.toLowerCase();
   const size = 64;
   const maxSize = type.includes('-cover') ? constants.maxCover : constants.max;
   let s = query.s ? parseInt(query.s) : size;

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -9,7 +9,7 @@ export function sha256(str) {
   return createHash('sha256').update(str).digest('hex');
 }
 
-export async function parseQuery(id: string, type: ResolverType, query) {
+export function parseQuery(id: string, type: ResolverType, query) {
   let address = id;
   let network = '1';
   let networkId: string | undefined = undefined;
@@ -22,11 +22,9 @@ export async function parseQuery(id: string, type: ResolverType, query) {
     address = chunks[2];
     network = chunks[1];
     networkId = chainIdToShortName(network) || 'eth';
-  } else if (id.startsWith('did:')) {
-    address = id.slice(4);
   }
 
-  address = address.toLowerCase();
+  address = address.trim().toLowerCase();
   const size = 64;
   const maxSize = type.includes('-cover') ? constants.maxCover : constants.max;
   let s = query.s ? parseInt(query.s) : size;

--- a/src/resolvers/image/snapshot.ts
+++ b/src/resolvers/image/snapshot.ts
@@ -99,16 +99,17 @@ async function getOnchainProperty(
 }
 
 function normalizeUserId(value: string): string | null {
+  const trimmed = value.trim();
   try {
-    return getAddress(value);
+    return getAddress(trimmed);
   } catch {
-    return isStarknetFelt(value) ? value : null;
+    return isStarknetFelt(trimmed) ? trimmed : null;
   }
 }
 
 function normalizeSpaceId(value: string) {
   try {
-    return getAddress(value);
+    return getAddress(value.trim());
   } catch {
     return value;
   }

--- a/src/resolvers/image/snapshot.ts
+++ b/src/resolvers/image/snapshot.ts
@@ -99,17 +99,16 @@ async function getOnchainProperty(
 }
 
 function normalizeUserId(value: string): string | null {
-  const trimmed = value.trim();
   try {
-    return getAddress(trimmed);
+    return getAddress(value);
   } catch {
-    return isStarknetFelt(trimmed) ? trimmed : null;
+    return isStarknetFelt(value) ? value : null;
   }
 }
 
 function normalizeSpaceId(value: string) {
   try {
-    return getAddress(value.trim());
+    return getAddress(value);
   } catch {
     return value;
   }

--- a/test/unit/helpers/api.test.ts
+++ b/test/unit/helpers/api.test.ts
@@ -25,14 +25,34 @@ describe('parseQuery()', () => {
       { address: '0xabc', network: '999999999999', networkId: 'eth' }
     ],
     [
-      'did: is treated as a shortName, not stripped',
-      'did:0xABC',
-      { address: '0xabc', network: '1', networkId: 'did' }
+      'multi-segment did is treated as an opaque id, not stripped',
+      'did:pkh:eip155:1:0xABC',
+      { address: 'did:pkh:eip155:1:0xabc', network: '1', networkId: undefined }
     ],
     [
       'whitespace around the id is trimmed',
       '  0xABC  ',
       { address: '0xabc', network: '1', networkId: undefined }
+    ],
+    [
+      'whitespace-padded shortName:address still resolves the network',
+      ' matic:0xABC',
+      { address: '0xabc', network: '137', networkId: 'matic' }
+    ],
+    [
+      'whitespace inside a shortName:address id is trimmed per chunk',
+      'matic :0xABC',
+      { address: '0xabc', network: '137', networkId: 'matic' }
+    ],
+    [
+      'whitespace inside a chainId:network:address id is trimmed per chunk',
+      '1: 137 :0xABC',
+      { address: '0xabc', network: '137', networkId: 'matic' }
+    ],
+    [
+      'uppercase shortName:address is normalized before the network lookup',
+      'MATIC:0xABC',
+      { address: '0xabc', network: '137', networkId: 'matic' }
     ]
   ])('%s', (_name, id, expected) => {
     const result = parseQuery(id, 'avatar', {});

--- a/test/unit/helpers/api.test.ts
+++ b/test/unit/helpers/api.test.ts
@@ -1,0 +1,43 @@
+import { parseQuery } from '../../../src/helpers/api';
+
+describe('parseQuery()', () => {
+  it('is synchronous', () => {
+    const result = parseQuery('0xabc', 'avatar', {});
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+
+  it.each([
+    ['plain address', '0xABC', { address: '0xabc', network: '1', networkId: undefined }],
+    ['shortName:address', 'matic:0xABC', { address: '0xabc', network: '137', networkId: 'matic' }],
+    [
+      'unknown shortName:address falls back to mainnet',
+      'bogus:0xABC',
+      { address: '0xabc', network: '1', networkId: 'bogus' }
+    ],
+    [
+      'chainId:network:address',
+      '1:137:0xABC',
+      { address: '0xabc', network: '137', networkId: 'matic' }
+    ],
+    [
+      'unknown chainId:network:address falls back to eth',
+      '1:999999999999:0xABC',
+      { address: '0xabc', network: '999999999999', networkId: 'eth' }
+    ],
+    [
+      'did: is treated as a shortName, not stripped',
+      'did:0xABC',
+      { address: '0xabc', network: '1', networkId: 'did' }
+    ],
+    [
+      'whitespace around the id is trimmed',
+      '  0xABC  ',
+      { address: '0xabc', network: '1', networkId: undefined }
+    ]
+  ])('%s', (_name, id, expected) => {
+    const result = parseQuery(id, 'avatar', {});
+    expect(result.address).toBe(expected.address);
+    expect(result.network).toBe(expected.network);
+    expect(result.networkId).toBe(expected.networkId);
+  });
+});


### PR DESCRIPTION
Fixes #601

`parseQuery` (`src/helpers/api.ts`) is the single entry point for every image route id. It normalized case but never trimmed whitespace, so every resolver reached via the route (`ens`, `starknet`, `lens`, ...) except `snapshot.ts` got the raw string, and a padded vs unpadded id landed as two separate cache entries since `getCacheKey` hashes the address.

It also carried a `did:` branch that never produced a usable id (`id.slice(4)` still leaves the remaining colons in the address, and the only other thing it set was never returned), and it was `async` with nothing inside it to `await`, so both call sites in `src/api.ts` awaited a value that never needed it, and the route handler wrapped the call in a try/catch whose only job was to catch a throw the function cannot produce.

- Trim and lowercase the id once, up front, per colon-separated chunk, so a padded or differently-cased shortName/network segment resolves the same network as its clean equivalent, not just the address.
- Delete the `did:` branch: it only ran for 4+ colon-segment ids and never resolved anything, so removing it changes the fallback identicon and cache key for that shape, not behaviour anyone relied on.
- Make `parseQuery` synchronous, drop the dead try/catch in `src/api.ts` and both `await`s.
- Add a unit test table over `parseQuery`'s id shapes (plain, shortName:address, chainId:network:address, multi-segment did, whitespace in various positions, mixed case), its first unit coverage; previously only e2e touched it.
- Drop `DID` from the identifier list in `README.md`, since no code path has resolved one since the resolver's own DID handling was removed years ago.

`snapshot.ts`'s own two trims stay: `normalizeUserId`/`normalizeSpaceId` are called directly by `test/unit/resolvers/image/noData.test.ts` with padded input, bypassing `parseQuery` entirely, so they're load-bearing for a caller that skips the route layer, not dead code. Trimming twice on the route path is a no-op.
