### PR TITLE
fix(http): bound image response reads by size, not just deadline

### DIFF
--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -30,8 +30,35 @@ export function fetchWithDeadline<T>(
   }, 5e3);
 }
 
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+export async function readBoundedImage(url: string, response: Response): Promise<Buffer> {
+  const host = new URL(url).host;
+  const declared = Number(response.headers.get('content-length'));
+  if (declared > MAX_IMAGE_BYTES) {
+    await response.body?.cancel();
+    throw httpError(host, 404, `image too large: ${declared} bytes`);
+  }
+
+  if (!response.body) return Buffer.from(await response.arrayBuffer());
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for await (const chunk of response.body) {
+    total += chunk.length;
+    if (total > MAX_IMAGE_BYTES) {
+      throw httpError(host, 404, `image too large: over ${MAX_IMAGE_BYTES} bytes`);
+    }
+
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks);
+}
+
 export function fetchHttpImage(url: string): Promise<Buffer> {
-  return fetchWithDeadline(url, async response => Buffer.from(await response.arrayBuffer()));
+  return fetchWithDeadline(url, response => readBoundedImage(url, response));
 }
 
 export function getUrl(url: string): string | null {

--- a/src/resolvers/image/starknet.ts
+++ b/src/resolvers/image/starknet.ts
@@ -1,7 +1,7 @@
 import { byteArray, CallData, constants, shortString, starknetId } from 'starknet';
 import { isStarkDomain, isStarknetFelt } from '../../helpers/address';
 import { untilAborted, withDeadline } from '../../helpers/deadline';
-import { fetchHttpImage, fetchWithDeadline, getUrl } from '../../helpers/http';
+import { fetchHttpImage, fetchWithDeadline, getUrl, readBoundedImage } from '../../helpers/http';
 import { getProvider } from '../../helpers/provider';
 
 const DEFAULT_IMG_URL = 'https://starknet.id/api/identicons/0';
@@ -119,7 +119,7 @@ function fetchImageOrMetadata(url: string): Promise<Buffer | { image?: string }>
   return fetchWithDeadline(url, async response =>
     response.headers.get('content-type')?.includes('application/json')
       ? await response.json()
-      : Buffer.from(await response.arrayBuffer())
+      : readBoundedImage(url, response)
   );
 }
 

--- a/test/integration/helpers/http.test.ts
+++ b/test/integration/helpers/http.test.ts
@@ -1,21 +1,58 @@
 import http from 'http';
 import { AddressInfo, Socket } from 'net';
 import { isSilencedError } from '../../../src/helpers/errors';
-import { fetchHttpImage } from '../../../src/helpers/http';
+import { fetchHttpImage, MAX_IMAGE_BYTES } from '../../../src/helpers/http';
 
 const BODY = Buffer.from('as much of an image as the fetch cares about');
+const CHUNK = Buffer.alloc(1024 * 1024, 'x');
 
 let server: http.Server;
 let url: string;
 let missingUrl: string;
 let neverEndingUrl: string;
+let oversizedDeclaredUrl: string;
+let oversizedStreamedUrl: string;
+let closed: Promise<void>;
+let resolveClosed: () => void = () => {};
 const sockets = new Set<Socket>();
+
+function closesWithin(ms: number): Promise<boolean> {
+  return Promise.race([
+    closed.then(() => true),
+    new Promise<boolean>(resolve => setTimeout(() => resolve(false), ms))
+  ]);
+}
 
 beforeAll(async () => {
   server = http.createServer((req, res) => {
     if (req.url === '/missing.png') {
       res.writeHead(404, { 'Content-Type': 'text/html' });
       return res.end('<html><body>not found</body></html>');
+    }
+
+    if (req.url === '/oversized-declared.png') {
+      res.writeHead(200, {
+        'Content-Type': 'image/png',
+        'Content-Length': String(MAX_IMAGE_BYTES + 1)
+      });
+      res.on('close', () => resolveClosed());
+      return res.write('x');
+    }
+
+    if (req.url === '/oversized-streamed.png') {
+      res.writeHead(200, { 'Content-Type': 'image/png' });
+      let clientGone = false;
+      res.on('close', () => {
+        clientGone = true;
+        resolveClosed();
+      });
+      let sent = 0;
+      const write = () => {
+        if (clientGone || sent > MAX_IMAGE_BYTES + CHUNK.length) return res.end();
+        sent += CHUNK.length;
+        res.write(CHUNK, () => write());
+      };
+      return write();
     }
 
     res.writeHead(200, { 'Content-Type': 'image/png' });
@@ -35,6 +72,8 @@ beforeAll(async () => {
   url = `${origin}/image.png`;
   missingUrl = `${origin}/missing.png`;
   neverEndingUrl = `${origin}/never-ends.png`;
+  oversizedDeclaredUrl = `${origin}/oversized-declared.png`;
+  oversizedStreamedUrl = `${origin}/oversized-streamed.png`;
 });
 
 afterAll(async () => {
@@ -49,6 +88,30 @@ describe('fetchHttpImage', () => {
 
   it('raises rather than returning the body of a non-2xx', async () => {
     await expect(fetchHttpImage(missingUrl)).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rejects a declared length over the cap without reading the body', async () => {
+    closed = new Promise<void>(resolve => {
+      resolveClosed = resolve;
+    });
+
+    await expect(fetchHttpImage(oversizedDeclaredUrl)).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringContaining('image too large')
+    });
+    await expect(closesWithin(1000)).resolves.toBe(true);
+  });
+
+  it('rejects a body that crosses the cap while streaming, with no declared length', async () => {
+    closed = new Promise<void>(resolve => {
+      resolveClosed = resolve;
+    });
+
+    await expect(fetchHttpImage(oversizedStreamedUrl)).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringContaining('image too large')
+    });
+    await expect(closesWithin(1000)).resolves.toBe(true);
   });
 
   it('raises a silenced abort against an upstream that never stops sending', async () => {

--- a/test/integration/helpers/http.test.ts
+++ b/test/integration/helpers/http.test.ts
@@ -23,6 +23,12 @@ function closesWithin(ms: number): Promise<boolean> {
   ]);
 }
 
+function armClosedWatcher(): void {
+  closed = new Promise<void>(resolve => {
+    resolveClosed = resolve;
+  });
+}
+
 beforeAll(async () => {
   server = http.createServer((req, res) => {
     if (req.url === '/missing.png') {
@@ -91,9 +97,7 @@ describe('fetchHttpImage', () => {
   });
 
   it('rejects a declared length over the cap without reading the body', async () => {
-    closed = new Promise<void>(resolve => {
-      resolveClosed = resolve;
-    });
+    armClosedWatcher();
 
     await expect(fetchHttpImage(oversizedDeclaredUrl)).rejects.toMatchObject({
       status: 404,
@@ -103,9 +107,7 @@ describe('fetchHttpImage', () => {
   });
 
   it('rejects a body that crosses the cap while streaming, with no declared length', async () => {
-    closed = new Promise<void>(resolve => {
-      resolveClosed = resolve;
-    });
+    armClosedWatcher();
 
     await expect(fetchHttpImage(oversizedStreamedUrl)).rejects.toMatchObject({
       status: 404,

--- a/test/unit/resolvers/image/starknet.test.ts
+++ b/test/unit/resolvers/image/starknet.test.ts
@@ -8,6 +8,7 @@ jest.mock('../../../../src/helpers/provider', () => ({
   })
 }));
 
+import { MAX_IMAGE_BYTES } from '../../../../src/helpers/http';
 import starknet from '../../../../src/resolvers/image/starknet';
 import { incompleteJsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
 
@@ -72,6 +73,19 @@ describe('Starknet image resolver', () => {
       message: '[example.com] Not Found',
       status: 404,
       response: { status: 404 }
+    });
+  });
+
+  it('rejects a profile picture over the size cap', async () => {
+    mockedFetch.mockResolvedValue(
+      new Response(new Uint8Array(MAX_IMAGE_BYTES + 1), {
+        headers: { 'Content-Type': 'image/png' }
+      })
+    );
+
+    await expect(starknet(ADDRESS)).rejects.toMatchObject({
+      status: 404,
+      message: expect.stringContaining('image too large')
     });
   });
 


### PR DESCRIPTION
## Problem

Every image resolver reads its response through `fetchHttpImage`, or the sibling read in the Starknet resolver's own `fetchImageOrMetadata`, both of which buffered `Buffer.from(await response.arrayBuffer())` with no size limit, only the 5s fetch deadline. A fast upstream can deliver an arbitrarily large body well inside that budget, and several of the URLs involved are attacker-chosen by design (ENS avatar record, Lens picture, Starknet profile picture, and so on).

## Fix

Both read sites now go through `readBoundedImage` in `src/helpers/http.ts`. It rejects a declared `Content-Length` over `MAX_IMAGE_BYTES` before transferring anything, and otherwise counts bytes as the body streams, aborting once the running total crosses the cap, so an upstream that omits or lies about `Content-Length` (or uses chunked transfer encoding) is still bounded. Either path raises the same `httpError(host, 404, ...)` used elsewhere in this file, landing as a routine miss like a non-2xx or an empty body already do, and releases the upstream connection rather than leaving it open.

`MAX_IMAGE_BYTES` is 10MB, comfortably above any legitimate avatar or cover image (`constants.json` caps rendered output at 500x500 / 1500x1500).

Closes #607.

## Scope

The JSON metadata branch of the Starknet resolver's fetch (NFT `token_uri` lookups) is a separate, much smaller surface and is left unbounded here to keep this change scoped to the image-byte read the issue describes.

This is independent of the in-flight #598, which also rewrites `fetchHttpImage`'s read step, for a different reason (content-type gating). Whichever of the two lands second will need a small rebase.