### PR TITLE
fix(errors): share the image path's routine-miss classifier with address/lookupDomains resolvers

### DIFF
--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -56,3 +56,29 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
     )
   );
 }
+
+export const ROUTINE_NETWORK_ERROR_CODES = [
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'CERT_HAS_EXPIRED',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'DEPTH_ZERO_SELF_SIGNED_CERT'
+];
+
+// 401/402/403 stay out of the routine band: they are how a dead or rotated
+// credential shows up on a resolver's own authenticated call, and silencing
+// them would hide that outage as a routine miss.
+const AUTH_STATUS_CODES = [401, 402, 403];
+
+export function isRoutineMiss(error: any): boolean {
+  const status = Number(error?.status ?? error?.response?.status);
+  const code = error?.cause?.code ?? error?.code;
+
+  return (
+    (status >= 400 && status < 500 && !AUTH_STATUS_CODES.includes(status)) ||
+    ROUTINE_NETWORK_ERROR_CODES.includes(code) ||
+    error?.code === 'INVALID_ARGUMENT'
+  );
+}

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -57,7 +57,7 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
   );
 }
 
-export const ROUTINE_NETWORK_ERROR_CODES = [
+const ROUTINE_NETWORK_ERROR_CODES = [
   'ENOTFOUND',
   'EAI_AGAIN',
   'ECONNREFUSED',

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -93,7 +93,13 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
     );
 
     for (const item of items) {
-      results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
+      try {
+        results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
+      } catch (err) {
+        if (!isSilencedError(err)) {
+          capture(err, { input: { handles: normalizedHandles } });
+        }
+      }
     }
   } catch (err) {
     if (!isSilencedError(err) && !isRoutineMiss(err)) {

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -4,7 +4,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import constants from '../../constants.json';
 import { isEvmAddress } from '../../helpers/address';
-import { isSilencedError } from '../../helpers/errors';
+import { isRoutineMiss, isSilencedError } from '../../helpers/errors';
 import { graphQlCall } from '../../helpers/graphql';
 import { getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
@@ -96,7 +96,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
       results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
     }
   } catch (err) {
-    if (!isSilencedError(err)) {
+    if (!isSilencedError(err) && !isRoutineMiss(err)) {
       capture(err, { input: { handles: normalizedHandles } });
     }
   }
@@ -117,7 +117,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
       }
     });
   } catch (err) {
-    if (!isSilencedError(err)) {
+    if (!isSilencedError(err) && !isRoutineMiss(err)) {
       capture(err, { input: { handles: normalizedHandles } });
     }
   }

--- a/src/resolvers/address/index.ts
+++ b/src/resolvers/address/index.ts
@@ -15,7 +15,7 @@ import {
   normalizeHandles,
   withoutEmptyAddress
 } from '../../helpers/address';
-import { isSilencedError } from '../../helpers/errors';
+import { isRoutineMiss, isSilencedError } from '../../helpers/errors';
 import { timeAddressResolverResponse as timeResponse } from '../../helpers/metrics';
 import { withoutEmptyValues } from '../../helpers/object';
 import { Address, Handle } from '../../helpers/types';
@@ -69,7 +69,7 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
               result = await r[fnName](_input);
               status = 1;
             } catch (err) {
-              if (!isSilencedError(err, r.MUTED_ERRORS)) {
+              if (!isSilencedError(err, r.MUTED_ERRORS) && !isRoutineMiss(err)) {
                 // A top-level `input` beside `tags` is dropped rather than wrapped.
                 capture(err, {
                   tags: { provider: r.NAME },

--- a/src/resolvers/address/unstoppableDomains.ts
+++ b/src/resolvers/address/unstoppableDomains.ts
@@ -2,7 +2,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import Resolution, { NamingServiceName } from '@unstoppabledomains/resolution';
 import { isEvmAddress } from '../../helpers/address';
-import { isSilencedError } from '../../helpers/errors';
+import { isRoutineMiss, isSilencedError } from '../../helpers/errors';
 import { withoutEmptyValues } from '../../helpers/object';
 import { batchContractCalls, getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
@@ -57,7 +57,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
           blockTag: 'latest'
         });
       } catch (err) {
-        if (!isSilencedError(err)) {
+        if (!isSilencedError(err) && !isRoutineMiss(err)) {
           capture(err, { input: { handles: normalizedHandles } });
         }
         return;

--- a/src/resolvers/image/index.ts
+++ b/src/resolvers/image/index.ts
@@ -17,7 +17,7 @@ import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from
 import starknet from './starknet';
 import trustwallet from './trustwallet';
 import { max } from '../../constants.json';
-import { isSilencedError } from '../../helpers/errors';
+import { isRoutineMiss, isSilencedError } from '../../helpers/errors';
 import { resize } from '../../helpers/image';
 
 type ResolverFn = (...args: any[]) => Promise<Buffer | false>;
@@ -29,34 +29,6 @@ type Resolver = {
   failureContract: boolean;
   mutedErrors?: string[];
 };
-
-const ROUTINE_NETWORK_ERROR_CODES = [
-  'ENOTFOUND',
-  'EAI_AGAIN',
-  'ECONNREFUSED',
-  'ERR_TLS_CERT_ALTNAME_INVALID',
-  'CERT_HAS_EXPIRED',
-  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
-  'DEPTH_ZERO_SELF_SIGNED_CERT'
-];
-
-// 401/402/403 are excluded from the routine band: withFailureContract wraps a
-// resolver's own authenticated API calls (Neynar, Snapshot Hub, CoinGecko Pro)
-// as well as its third-party avatar download, and those statuses are how a
-// dead/rotated credential shows up there — silencing them hides a real outage
-// instead of a missing avatar.
-const AUTH_STATUS_CODES = [401, 402, 403];
-
-function isRoutineMiss(error: any): boolean {
-  const status = Number(error?.status ?? error?.response?.status);
-  const code = error?.cause?.code ?? error?.code;
-
-  return (
-    (status >= 400 && status < 500 && !AUTH_STATUS_CODES.includes(status)) ||
-    ROUTINE_NETWORK_ERROR_CODES.includes(code) ||
-    error?.code === 'INVALID_ARGUMENT'
-  );
-}
 
 function withFailureContract(
   name: string,

--- a/src/resolvers/image/lens.ts
+++ b/src/resolvers/image/lens.ts
@@ -9,9 +9,9 @@ const LOCAL_NAME_MAX_BYTES = 254;
 
 // Lens is a public dependency, so its transient availability errors are not
 // actionable resolver defects. Read by resolvers/image/index.ts. A 429 is
-// already muted by isSilencedError's shared code list (helpers/errors.ts) and
-// isRoutineMiss's 4xx band (resolvers/image/index.ts), so only the 503 needs a
-// message-based mute.
+// already muted by isSilencedError's shared code list and isRoutineMiss's
+// 4xx band (both in helpers/errors.ts), so only the 503 needs a message-based
+// mute.
 export const MUTED_ERRORS = ['status code 503'];
 
 function normalizeImageUrl(url: string) {

--- a/src/resolvers/lookupDomains/index.ts
+++ b/src/resolvers/lookupDomains/index.ts
@@ -4,7 +4,7 @@ import * as ens from './ens';
 import * as ensV2 from './ensV2';
 import * as shibarium from './shibarium';
 import * as unstoppableDomains from './unstoppableDomains';
-import { isSilencedError } from '../../helpers/errors';
+import { isRoutineMiss, isSilencedError } from '../../helpers/errors';
 import { timeLookupDomainsResponse as timeResponse } from '../../helpers/metrics';
 import { Address, Handle } from '../../helpers/types';
 
@@ -43,7 +43,7 @@ export default async function lookupDomains(
               status = 1;
               return result;
             } catch (err) {
-              if (!isSilencedError(err)) {
+              if (!isSilencedError(err) && !isRoutineMiss(err)) {
                 capture(err, {
                   tags: { provider: NAME },
                   contexts: { input: { address, chainId } }

--- a/test/integration/resolvers/lookupDomains/shibarium.test.ts
+++ b/test/integration/resolvers/lookupDomains/shibarium.test.ts
@@ -189,6 +189,17 @@ describe('lookupDomains/shibarium through the shared handler', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it('does not report a host that no longer resolves', async () => {
+    mockedFetch.mockRejectedValue(
+      Object.assign(new Error('getaddrinfo ENOTFOUND api-public.interstellar.xyz'), {
+        code: 'ENOTFOUND'
+      })
+    );
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
   it('drops the pages already collected when a later page fails', async () => {
     mockedFetch
       .mockResolvedValueOnce(httpResponse(200, 'OK', page(PAGE_SIZE)))

--- a/test/unit/helpers/errors.test.ts
+++ b/test/unit/helpers/errors.test.ts
@@ -1,4 +1,4 @@
-import { isSilencedError } from '../../../src/helpers/errors';
+import { isRoutineMiss, isSilencedError } from '../../../src/helpers/errors';
 
 describe('isSilencedError', () => {
   it.each([500, 502, 503, 504, 521])('silences an RPC outage with status %s', status => {
@@ -35,5 +35,44 @@ describe('isSilencedError', () => {
 
   it('does not silence unrelated errors', () => {
     expect(isSilencedError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('isRoutineMiss', () => {
+  it.each(['ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED'])('treats a %s errno as routine', code => {
+    expect(isRoutineMiss(Object.assign(new TypeError('fetch failed'), { cause: { code } }))).toBe(
+      true
+    );
+  });
+
+  it.each([
+    'ERR_TLS_CERT_ALTNAME_INVALID',
+    'CERT_HAS_EXPIRED',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    'DEPTH_ZERO_SELF_SIGNED_CERT'
+  ])('treats a %s TLS failure as routine', code => {
+    expect(isRoutineMiss(Object.assign(new TypeError('fetch failed'), { cause: { code } }))).toBe(
+      true
+    );
+  });
+
+  it('treats a plain upstream 404 as routine', () => {
+    expect(isRoutineMiss({ status: 404 })).toBe(true);
+  });
+
+  it.each([401, 402, 403])('keeps an upstream %i out of the routine band', status => {
+    expect(isRoutineMiss({ status })).toBe(false);
+  });
+
+  it('does not treat an upstream 500 as routine', () => {
+    expect(isRoutineMiss({ status: 500 })).toBe(false);
+  });
+
+  it('treats an invalid-argument rejection as routine', () => {
+    expect(isRoutineMiss({ code: 'INVALID_ARGUMENT' })).toBe(true);
+  });
+
+  it('does not treat an unrelated error as routine', () => {
+    expect(isRoutineMiss(new Error('boom'))).toBe(false);
   });
 });

--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -93,6 +93,27 @@ describe('address resolvers - resolver failures', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      'a host that no longer resolves',
+      Object.assign(new TypeError('fetch failed'), {
+        cause: { code: 'ENOTFOUND' }
+      })
+    ],
+    ['a plain upstream 404', Object.assign(new Error('not found'), { status: 404 })],
+    [
+      'a TLS failure',
+      Object.assign(new TypeError('fetch failed'), {
+        cause: { code: 'CERT_HAS_EXPIRED' }
+      })
+    ]
+  ] as const)('does not capture a routine miss (%s)', async (_label, error) => {
+    jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
   it('applies MUTED_ERRORS only to the resolver exporting it', async () => {
     const error = new Error(LENS_503);
     jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -17,9 +17,7 @@ jest.mock('../../../../src/helpers/provider', () => ({
 
 const mockedFetch = mockGlobalFetch();
 
-// getProvider is called once, at module load, so this is the same instance
-// resolveNames holds onto: overriding its methods here reaches the module under test.
-const provider = (getProvider as jest.Mock).mock.results[0].value;
+const providerInstanceHeldByEns = (getProvider as jest.Mock).mock.results[0].value;
 
 const HANDLE = 'test.eth';
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
@@ -60,7 +58,7 @@ describe('resolvers/address/ens - resolveNames', () => {
 
   it('does not report the provider fallback resolving a malformed address', async () => {
     respondWith({ data: { domains: [] } });
-    provider.resolveName.mockResolvedValueOnce('not-a-valid-address');
+    providerInstanceHeldByEns.resolveName.mockResolvedValueOnce('not-a-valid-address');
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({});
     expect(capture).not.toHaveBeenCalled();

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -1,4 +1,5 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { getProvider } from '../../../../src/helpers/provider';
 import { resolveNames } from '../../../../src/resolvers/address/ens';
 import { jsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
 
@@ -15,6 +16,10 @@ jest.mock('../../../../src/helpers/provider', () => ({
 }));
 
 const mockedFetch = mockGlobalFetch();
+
+// getProvider is called once, at module load, so this is the same instance
+// resolveNames holds onto: overriding its methods here reaches the module under test.
+const provider = (getProvider as jest.Mock).mock.results[0].value;
 
 const HANDLE = 'test.eth';
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
@@ -41,6 +46,23 @@ describe('resolvers/address/ens - resolveNames', () => {
     });
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({ [HANDLE]: ADDRESS });
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not report a subgraph host that no longer resolves', async () => {
+    mockedFetch.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'ENOTFOUND' } })
+    );
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not report the provider fallback resolving a malformed address', async () => {
+    respondWith({ data: { domains: [] } });
+    provider.resolveName.mockResolvedValueOnce('not-a-valid-address');
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
     expect(capture).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -56,11 +56,22 @@ describe('resolvers/address/ens - resolveNames', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
-  it('does not report the provider fallback resolving a malformed address', async () => {
+  it('classifies a malformed provider-fallback result as routine, defensively', async () => {
     respondWith({ data: { domains: [] } });
     providerInstanceHeldByEns.resolveName.mockResolvedValueOnce('not-a-valid-address');
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({});
     expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('still reports a malformed address returned by the subgraph itself', async () => {
+    respondWith({
+      data: { domains: [{ name: HANDLE, resolvedAddress: { id: 'not-a-valid-address' } }] }
+    });
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_ARGUMENT' }), {
+      input: { handles: [HANDLE] }
+    });
   });
 });

--- a/test/unit/resolvers/address/unstoppableDomains.test.ts
+++ b/test/unit/resolvers/address/unstoppableDomains.test.ts
@@ -1,0 +1,44 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import snapshot from '@snapshot-labs/snapshot.js';
+import { resolveNames } from '../../../../src/resolvers/address/unstoppableDomains';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+const HANDLE = 'test.crypto';
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('resolvers/address/unstoppableDomains - resolveNames', () => {
+  it('reports a resolver failure', async () => {
+    const error = new Error('boom');
+    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(error, { input: { handles: [HANDLE] } });
+  });
+
+  it.each([
+    [
+      'a host that no longer resolves',
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'ENOTFOUND' } })
+    ],
+    ['a plain upstream 404', Object.assign(new Error('not found'), { status: 404 })]
+  ] as const)('does not report a routine miss (%s)', async (_label, error) => {
+    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('resolves successfully and reports nothing', async () => {
+    jest.spyOn(snapshot.utils, 'call').mockResolvedValue(ADDRESS);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({ [HANDLE]: ADDRESS });
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/resolvers/lookupDomains.test.ts
+++ b/test/unit/resolvers/lookupDomains.test.ts
@@ -154,6 +154,27 @@ describe('lookupDomains - error reporting', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      'a host that no longer resolves',
+      Object.assign(new TypeError('fetch failed'), {
+        cause: { code: 'ENOTFOUND' }
+      })
+    ],
+    ['a plain upstream 404', Object.assign(new Error('not found'), { status: 404 })],
+    [
+      'a TLS failure',
+      Object.assign(new TypeError('fetch failed'), {
+        cause: { code: 'CERT_HAS_EXPIRED' }
+      })
+    ]
+  ] as const)('does not capture a routine miss (%s)', async (_label, error) => {
+    (ens as jest.Mock).mockRejectedValue(error);
+
+    await expect(lookupDomains(VALID_ADDRESS, '1')).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
   it('names the failing provider, each with its own name', async () => {
     (ens as jest.Mock).mockRejectedValue(new Error('boom'));
     (shibarium as jest.Mock).mockRejectedValue(new Error('boom'));


### PR DESCRIPTION
Closes #617.

PR #595 added `isRoutineMiss` to the image resolver wrapper to stop reporting third-party avatar-URL failures (dead DNS, refused connections, plain 4xx, TLS certificate errors) as Sentry events, since those are no-data results rather than resolver defects. The other resolver families reach the same error shapes but still classify with `isSilencedError` alone, which has no equivalent for `ENOTFOUND`/`EAI_AGAIN`/`ECONNREFUSED`, TLS cert codes, or plain 4xx, so a routine DNS failure or host 4xx on `lookupDomains`, `address`, `address/ens`, or `address/unstoppableDomains` still gets reported as a defect.

Moves `isRoutineMiss` (and its network error code list) out of the image resolver into `src/helpers/errors.ts`, beside `isSilencedError`, and calls it alongside `isSilencedError` at the four other capture sites named in the issue. Also drives the existing shibarium `ENOTFOUND` regression test through the `lookupDomains` wrapper instead of the bare provider module, since the assertion never reached `capture` from there.

`address/ens.ts`'s subgraph-fetch catch keeps its own `getAddress` parsing on a separate catch from the network fetch, so a malformed address returned by the subgraph itself is still reported rather than swallowed by the same routine-miss check meant for the fetch's network errors.