### PR TITLE
fix(ens): treat a data: avatar record as a fetchable URL

### DIFF
--- a/src/resolvers/image/ens.ts
+++ b/src/resolvers/image/ens.ts
@@ -26,7 +26,7 @@ export default async function resolve(nameOrAddress: string) {
 
   let url = await snapshot.utils.getEnsTextRecord(ensName, 'avatar', '1', getProviderOptions());
   url =
-    url?.startsWith('http') || url?.startsWith('data:')
+    url?.startsWith('http') || (url && /^data:[^,]*,/.test(url))
       ? url
       : `https://metadata.ens.domains/mainnet/avatar/${encodeURIComponent(ensName)}`;
 

--- a/src/resolvers/image/ens.ts
+++ b/src/resolvers/image/ens.ts
@@ -25,9 +25,10 @@ export default async function resolve(nameOrAddress: string) {
   if (!ensName) return false;
 
   let url = await snapshot.utils.getEnsTextRecord(ensName, 'avatar', '1', getProviderOptions());
-  url = url?.startsWith('http')
-    ? url
-    : `https://metadata.ens.domains/mainnet/avatar/${encodeURIComponent(ensName)}`;
+  url =
+    url?.startsWith('http') || url?.startsWith('data:')
+      ? url
+      : `https://metadata.ens.domains/mainnet/avatar/${encodeURIComponent(ensName)}`;
 
   return await fetchHttpImage(url);
 }

--- a/test/unit/resolvers/image/ens.test.ts
+++ b/test/unit/resolvers/image/ens.test.ts
@@ -109,7 +109,7 @@ describe('resolvers/image/ens', () => {
   it.each([
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4='
-  ])('uses a data: avatar record directly', async record => {
+  ])('uses a data: avatar record directly %s', async record => {
     const image = Buffer.from('avatar');
     jest.spyOn(snapshot.utils, 'getEnsTextRecord').mockResolvedValue(record);
     mockedFetchHttpImage.mockResolvedValue(image);
@@ -121,7 +121,9 @@ describe('resolvers/image/ens', () => {
 
   it.each([
     'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
-    'eip155:1/erc721:0xac5c7493036de60e63eb81c5e9a440b42f47ebf5/5413'
+    'eip155:1/erc721:0xac5c7493036de60e63eb81c5e9a440b42f47ebf5/5413',
+    'data:',
+    'data:image/png;base64'
   ])('falls back to the metadata service for a non-fetchable record %s', async record => {
     const image = Buffer.from('avatar');
     jest.spyOn(snapshot.utils, 'getEnsTextRecord').mockResolvedValue(record);

--- a/test/unit/resolvers/image/ens.test.ts
+++ b/test/unit/resolvers/image/ens.test.ts
@@ -106,6 +106,34 @@ describe('resolvers/image/ens', () => {
     expect(mockedFetchHttpImage).toHaveBeenCalledWith(url);
   });
 
+  it.each([
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4='
+  ])('uses a data: avatar record directly', async record => {
+    const image = Buffer.from('avatar');
+    jest.spyOn(snapshot.utils, 'getEnsTextRecord').mockResolvedValue(record);
+    mockedFetchHttpImage.mockResolvedValue(image);
+
+    await expect(resolve('vitalik.eth')).resolves.toBe(image);
+
+    expect(mockedFetchHttpImage).toHaveBeenCalledWith(record);
+  });
+
+  it.each([
+    'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+    'eip155:1/erc721:0xac5c7493036de60e63eb81c5e9a440b42f47ebf5/5413'
+  ])('falls back to the metadata service for a non-fetchable record %s', async record => {
+    const image = Buffer.from('avatar');
+    jest.spyOn(snapshot.utils, 'getEnsTextRecord').mockResolvedValue(record);
+    mockedFetchHttpImage.mockResolvedValue(image);
+
+    await expect(resolve('vitalik.eth')).resolves.toBe(image);
+
+    expect(mockedFetchHttpImage).toHaveBeenCalledWith(
+      'https://metadata.ens.domains/mainnet/avatar/vitalik.eth'
+    );
+  });
+
   it('keeps a normalized name in one fallback path segment', async () => {
     const image = Buffer.from('avatar');
     jest.spyOn(snapshot.utils, 'getEnsTextRecord').mockResolvedValue(null);


### PR DESCRIPTION
Closes #616.

`src/resolvers/image/ens.ts` decides whether an ENS `avatar` text record is a fetchable URL with `url?.startsWith('http')`. A `data:` URI avatar record fails that check even though it's already a usable image reference, so it was discarded and the resolver fell through to a `metadata.ens.domains` lookup, which cannot resolve a `data:` record either — the avatar was lost even though it was already in hand.

Accept a `data:` value in the same gate, requiring the RFC 2397 comma so a truncated or garbled value (e.g. bare `data:`) still falls through to the metadata-service fallback instead of reaching `fetch()` as if it were real. Records that are neither `http(s)` nor a well-formed `data:` URI (`ipfs://`, CAIP references, empty, malformed) keep going to the same fallback as before.

Filed #627 separately for a related but distinct finding from review: a large `data:` payload blocks Node's event loop synchronously inside `fetch()`, and the existing request deadline can't preempt that. It's pre-existing (lens, farcaster and coingecko already pass arbitrary `data:` URLs to the same `fetchHttpImage` unconditionally), not introduced by this change, and needs a fix that applies to all of those call sites rather than just this one.
