### PR TITLE
fix(http): reject a reference getUrl cannot turn into a fetchable URL

### DIFF
--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -34,7 +34,14 @@ export function fetchHttpImage(url: string): Promise<Buffer> {
   return fetchWithDeadline(url, async response => Buffer.from(await response.arrayBuffer()));
 }
 
-export function getUrl(url) {
+export function getUrl(url: string): string | null {
   const gateway: string = process.env.IPFS_GATEWAY || 'cloudflare-ipfs.com';
-  return snapshot.utils.getUrl(url, gateway);
+  const candidate = snapshot.utils.getUrl(url, gateway);
+  if (!candidate) return null;
+
+  try {
+    return ['http:', 'https:'].includes(new URL(candidate).protocol) ? candidate : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/resolvers/image/selfid.ts
+++ b/src/resolvers/image/selfid.ts
@@ -12,5 +12,7 @@ export default async function resolve(address: string) {
   if (!src) return false;
 
   const url = getUrl(src);
+  if (!url) return false;
+
   return await fetchHttpImage(url);
 }

--- a/src/resolvers/image/snapshot.ts
+++ b/src/resolvers/image/snapshot.ts
@@ -139,6 +139,8 @@ function createPropertyResolver(entity: Entity, property: Property) {
     if (!value) return false;
 
     const url = getUrl(value);
+    if (!url) return false;
+
     return await fetchHttpImage(url);
   };
 }

--- a/src/resolvers/image/space-sx.ts
+++ b/src/resolvers/image/space-sx.ts
@@ -44,7 +44,10 @@ function createPropertyResolver(property: 'avatar' | 'cover') {
     const value = answers.find(Boolean);
     if (!value) return false;
 
-    return await fetchHttpImage(getUrl(value));
+    const url = getUrl(value);
+    if (!url) return false;
+
+    return await fetchHttpImage(url);
   };
 }
 

--- a/src/resolvers/image/starknet.ts
+++ b/src/resolvers/image/starknet.ts
@@ -123,16 +123,24 @@ function fetchImageOrMetadata(url: string): Promise<Buffer | { image?: string }>
   );
 }
 
+async function fetchMetadataImage(image: string): Promise<Buffer | null> {
+  const url = getUrl(image);
+  return url ? fetchHttpImage(url) : null;
+}
+
 export default async function resolve(domainOrAddress: string) {
   const img_url = await getImage(domainOrAddress);
 
   if (!img_url || img_url === DEFAULT_IMG_URL) return false;
 
-  const fetched = await fetchImageOrMetadata(getUrl(img_url));
+  const url = getUrl(img_url);
+  if (!url) return false;
+
+  const fetched = await fetchImageOrMetadata(url);
   const buffer = Buffer.isBuffer(fetched)
     ? fetched
     : fetched.image
-      ? await fetchHttpImage(getUrl(fetched.image))
+      ? await fetchMetadataImage(fetched.image)
       : null;
 
   return buffer ?? false;

--- a/test/unit/helpers/http.test.ts
+++ b/test/unit/helpers/http.test.ts
@@ -1,0 +1,34 @@
+import { getUrl } from '../../../src/helpers/http';
+
+const GATEWAY = process.env.IPFS_GATEWAY || 'cloudflare-ipfs.com';
+const CIDV0 = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG';
+const CIDV1 = 'bafkreifnrjhklxvfz3yigmc7c2y3z3p3k3ycidx2s2ecuwx4qw2m3myqi4';
+
+describe('getUrl', () => {
+  it('passes a valid absolute URL through unchanged', () => {
+    expect(getUrl('https://example.com/a.png')).toBe('https://example.com/a.png');
+    expect(getUrl('http://example.com/a.png')).toBe('http://example.com/a.png');
+  });
+
+  it('rewrites an ipfs:// URI onto the gateway', () => {
+    expect(getUrl(`ipfs://${CIDV0}`)).toBe(`https://${GATEWAY}/ipfs/${CIDV0}`);
+  });
+
+  it.each([
+    ['CIDv0', CIDV0],
+    ['CIDv1', CIDV1]
+  ])('rewrites a bare %s onto the gateway', (_label, cid) => {
+    expect(getUrl(cid)).toBe(`https://${GATEWAY}/ipfs/${cid}`);
+  });
+
+  it('returns null for an empty reference', () => {
+    expect(getUrl('')).toBeNull();
+  });
+
+  it.each([
+    ['a scheme with no host', 'http://'],
+    ['a URL with a port fetch cannot parse', 'https://example.com:abc/pic.png']
+  ])('returns null rather than a URL fetch would reject outright (%s)', (_label, input) => {
+    expect(getUrl(input)).toBeNull();
+  });
+});

--- a/test/unit/resolvers/image/noData.test.ts
+++ b/test/unit/resolvers/image/noData.test.ts
@@ -78,6 +78,12 @@ describe('resolvers answer false rather than throwing when there is no data', ()
 
       await expect(resolveSxAvatar(ADDRESS)).rejects.toThrow('everything is down');
     });
+
+    it('answers false for an avatar reference that cannot become a fetchable URL', async () => {
+      mockedFetch.mockResolvedValue(spaces([{ metadata: { avatar: 'http://' } }]));
+
+      await expect(resolveSxAvatar(ADDRESS)).resolves.toBe(false);
+    });
   });
 
   describe('snapshot', () => {
@@ -118,6 +124,12 @@ describe('resolvers answer false rather than throwing when there is no data', ()
     it('answers false for an onchain logo instead of asking for a field that is not there', async () => {
       await expect(resolveSpaceLogo(ADDRESS, 1, 'eth')).resolves.toBe(false);
       expect(mockedFetch).not.toHaveBeenCalled();
+    });
+
+    it('answers false for an avatar reference that cannot become a fetchable URL', async () => {
+      mockedFetch.mockResolvedValue(entry({ avatar: 'http://' }));
+
+      await expect(resolveUserAvatar(ADDRESS)).resolves.toBe(false);
     });
   });
 

--- a/test/unit/resolvers/image/selfid.test.ts
+++ b/test/unit/resolvers/image/selfid.test.ts
@@ -1,0 +1,51 @@
+const mockGetAccountDID = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock('@self.id/core', () => ({
+  Core: jest.fn().mockImplementation(() => ({
+    getAccountDID: mockGetAccountDID,
+    get: mockGet
+  }))
+}));
+
+jest.mock('../../../../src/helpers/http', () => ({
+  ...jest.requireActual('../../../../src/helpers/http'),
+  fetchHttpImage: jest.fn()
+}));
+
+import { fetchHttpImage } from '../../../../src/helpers/http';
+import resolve from '../../../../src/resolvers/image/selfid';
+
+const mockedFetchHttpImage = jest.mocked(fetchHttpImage);
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+
+beforeEach(() => {
+  mockGetAccountDID.mockReset().mockResolvedValue('did:pkh:eip155:1:0x0');
+  mockGet.mockReset();
+  mockedFetchHttpImage.mockReset();
+});
+
+describe('resolvers/image/selfid', () => {
+  it('answers false when the profile carries no avatar', async () => {
+    mockGet.mockResolvedValue({});
+
+    await expect(resolve(ADDRESS)).resolves.toBe(false);
+    expect(mockedFetchHttpImage).not.toHaveBeenCalled();
+  });
+
+  it('fetches a valid avatar url', async () => {
+    mockGet.mockResolvedValue({ image: { original: { src: 'https://example.com/a.png' } } });
+    const image = Buffer.from('avatar');
+    mockedFetchHttpImage.mockResolvedValue(image);
+
+    await expect(resolve(ADDRESS)).resolves.toBe(image);
+    expect(mockedFetchHttpImage).toHaveBeenCalledWith('https://example.com/a.png');
+  });
+
+  it('answers false for an avatar reference that cannot become a fetchable URL', async () => {
+    mockGet.mockResolvedValue({ image: { original: { src: 'http://' } } });
+
+    await expect(resolve(ADDRESS)).resolves.toBe(false);
+    expect(mockedFetchHttpImage).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/resolvers/image/starknet.test.ts
+++ b/test/unit/resolvers/image/starknet.test.ts
@@ -44,6 +44,25 @@ describe('Starknet image resolver', () => {
     expect(mockGetStarkProfile).toHaveBeenCalledWith(UNPADDED_ADDRESS);
   });
 
+  it('answers false for a profile picture that cannot become a fetchable URL', async () => {
+    mockGetStarkProfile.mockResolvedValue({ profilePicture: 'http://' });
+
+    await expect(starknet(ADDRESS)).resolves.toBe(false);
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it('answers false for on-chain metadata whose image cannot become a fetchable URL', async () => {
+    mockGetStarkProfile.mockResolvedValue({ profilePicture: 'https://example.com/metadata.json' });
+    mockedFetch.mockResolvedValue(
+      new Response(JSON.stringify({ image: 'http://' }), {
+        headers: { 'Content-Type': 'application/json' }
+      })
+    );
+
+    await expect(starknet(ADDRESS)).resolves.toBe(false);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects a non-2xx image response with its HTTP status', async () => {
     mockedFetch.mockResolvedValue(
       new Response('missing', { status: 404, statusText: 'Not Found' })


### PR DESCRIPTION
Closes #615.

`getUrl` (`src/helpers/http.ts`) delegates to `snapshot.utils.getUrl`, which rewrites `ipfs://`/`ipns://`/bare CIDs onto the configured gateway but never checks that the result is a URL `fetch()` can actually use. A bare scheme like `http://` or a URL with an unparseable port survives unchanged and reaches `fetch()`, which throws before any response exists. That throw carries no `.status`, so it isn't covered by `isRoutineMiss` or `isSilencedError`, and it gets captured/reported as an upstream failure instead of treated as the no-data case it is.

`getUrl` now validates the candidate URL and returns `null` when it can't produce a fetchable one. The four resolvers that call it directly (starknet, selfid, snapshot, space-sx) treat `null` the same way `basename.ts`'s avatar resolver already does: no-data rather than a failure.

A syntactically valid but meaningless gateway URL (e.g. a plain filename) still round-trips to the gateway and is already silenced once it 400s, by the existing routine-miss classification (`isRoutineMiss` now treats any 4xx except 401/402/403 as routine). This closes the other half, where the URL itself was never fetchable and `fetch()` never got a response to classify.

`data:` URI handling is out of scope here; it's a separate defect (#609) already being fixed in #598. This PR doesn't depend on #598 and doesn't touch the same lines as #625 (which bounds response body size, not URL validity), so either can land in any order relative to this one.