### PR TITLE
fix(errors): silence viem RPC timeouts and CCIP-Read aborts nested under ContractFunctionExecutionError

### DIFF
--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -25,6 +25,7 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
     // visible as they may signal a real problem (e.g. FORMERR 1 = malformed query);
     // NXDOMAIN (3) never reaches here (dns-connect returns it as an empty result).
     'Received error status from DNS server: 2.',
+    'The request took too long to respond.',
     ...(additionalMessages || [])
   ];
   const codes = [

--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -26,6 +26,7 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
     // NXDOMAIN (3) never reaches here (dns-connect returns it as an empty result).
     'Received error status from DNS server: 2.',
     'The request took too long to respond.',
+    'This operation was aborted',
     ...(additionalMessages || [])
   ];
   const codes = [

--- a/test/integration/helpers/errors.test.ts
+++ b/test/integration/helpers/errors.test.ts
@@ -125,19 +125,33 @@ describe('isSilencedError', () => {
   });
 
   it('silences a viem RPC timeout nested under ContractFunctionExecutionError', () => {
-    const timeoutError = Object.assign(
-      new Error('The request took too long to respond.\n\nDetails: The request timed out.'),
-      { name: 'TimeoutError' }
-    );
-    const callExecutionError = Object.assign(
-      new Error('The request took too long to respond.\n\nDetails: The request timed out.'),
-      { name: 'CallExecutionError', cause: timeoutError }
-    );
+    const timeoutMessage =
+      'The request took too long to respond.\n\nDetails: The request timed out.';
+    const timeoutError = Object.assign(new Error(timeoutMessage), { name: 'TimeoutError' });
+    const callExecutionError = Object.assign(new Error(timeoutMessage), {
+      name: 'CallExecutionError',
+      cause: timeoutError
+    });
     const contractFunctionExecutionError = Object.assign(
       new Error(
         'The request took too long to respond.\n\nContract Call:\n  function:  resolveWithGateways(bytes name, bytes data, string[] gateways)'
       ),
       { name: 'ContractFunctionExecutionError', cause: callExecutionError }
+    );
+
+    expect(isSilencedError(contractFunctionExecutionError)).toBe(true);
+  });
+
+  it('silences a viem CCIP-Read gateway abort wrapped without a shortMessage', () => {
+    const abortError = Object.assign(new Error('This operation was aborted'), {
+      name: 'AbortError',
+      code: 20
+    });
+    const contractFunctionExecutionError = Object.assign(
+      new Error(
+        'An unknown error occurred while executing the contract function "resolveWithGateways".\n\n\nDetails: This operation was aborted\nVersion: viem@2.55.13'
+      ),
+      { name: 'ContractFunctionExecutionError', cause: abortError }
     );
 
     expect(isSilencedError(contractFunctionExecutionError)).toBe(true);

--- a/test/integration/helpers/errors.test.ts
+++ b/test/integration/helpers/errors.test.ts
@@ -123,4 +123,23 @@ describe('isSilencedError', () => {
     // Status 1 (FORMERR) indicates a malformed query on our side — keep it visible.
     expect(isSilencedError(new Error('Received error status from DNS server: 1.'))).toBe(false);
   });
+
+  it('silences a viem RPC timeout nested under ContractFunctionExecutionError', () => {
+    const timeoutError = Object.assign(
+      new Error('The request took too long to respond.\n\nDetails: The request timed out.'),
+      { name: 'TimeoutError' }
+    );
+    const callExecutionError = Object.assign(
+      new Error('The request took too long to respond.\n\nDetails: The request timed out.'),
+      { name: 'CallExecutionError', cause: timeoutError }
+    );
+    const contractFunctionExecutionError = Object.assign(
+      new Error(
+        'The request took too long to respond.\n\nContract Call:\n  function:  resolveWithGateways(bytes name, bytes data, string[] gateways)'
+      ),
+      { name: 'ContractFunctionExecutionError', cause: callExecutionError }
+    );
+
+    expect(isSilencedError(contractFunctionExecutionError)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Problem

Stamp imposes its own 5s deadline on viem RPC calls (`DEFAULT_PROVIDER_TIMEOUT`). When that budget is hit on a contract read (e.g. `getEnsTextRecord`, used by the ENS avatar resolver), viem wraps the resulting error three levels deep: `ContractFunctionExecutionError` → `CallExecutionError` → `TimeoutError`. `isSilencedError` only ever looked one level down (`error.cause?.code`/`.message`), so it never recognized this shape and reported our own deadline as a resolver defect (Sentry STAMP-76, issue #606).

A second, related path goes through the same caller: when the CCIP-Read gateway deadline fires instead of the RPC transport one, viem wraps a raw `DOMException` that has no `shortMessage`, so `ContractFunctionExecutionError`'s own message falls back to a generic one rather than inheriting the abort's message directly.

## Fix

viem's `BaseError` hierarchy always folds a wrapped cause's message into its own composed message (via `shortMessage` when present, or a `Details:` line otherwise), so the deepest failure's text reaches the top of the chain regardless of nesting depth or which of those two paths fired. Both fixed strings are added to `isSilencedError`'s existing message list, the same mechanism this function already uses for other known-safe-to-silence shapes (ethers `status=504`, DNS SERVFAIL, etc).