### PR TITLE
chore: bump node engine requirement to >=24

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,5 +4,5 @@ jobs:
   lint:
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     with:
-      target: '22'
+      target: '24'
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Setup Redis

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "engines": {
-    "node": ">=22.6.0"
+    "node": ">=24"
   },
   "scripts": {
     "generate-chains": "node ./dist/src/scripts/generate-chains.js",
@@ -57,7 +57,7 @@
     "@types/express": "^4.17.11",
     "@types/jest": "^28.1.0",
     "@types/jest-image-snapshot": "^6.4.1",
-    "@types/node": "^14.14.21",
+    "@types/node": "^24",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.0.0",
     "jest": "^28.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,10 +2946,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^14.14.21":
-  version "14.18.63"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+"@types/node@^24":
+  version "24.13.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.3.tgz#49f18bd3c647866dcda51a0756c145e14590ce16"
+  integrity sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==
+  dependencies:
+    undici-types "~7.18.0"
 
 "@types/pixelmatch@*":
   version "5.2.6"
@@ -7133,6 +7135,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## What

Bump stamp's Node floor from 22 to 24: `engines.node` (`>=22.6.0` -> `>=24`), `@types/node` (`^14.14.21` -> `^24`), the resulting `yarn.lock` update, and the CI runner's `node-version`.

## Why

Node 22 left Active LTS in October 2025 and is now in Maintenance (EOL April 2027). Node 24 is Active LTS until October 2026, then Maintenance until April 2028. Same kind of sweep the org already did for Node 22 across several sibling services (see e.g. laser#76 and its table of prior PRs).

## Testing

Verified locally against a real Node 24.20.0 runtime (not just the version bump): `yarn install --frozen-lockfile` succeeds with the updated lockfile, `yarn typecheck` and `yarn lint` are clean against the new `@types/node`, and a full `yarn test:coverage` run's only red tests are the two live-API integration files that are already red here under Node 22 too (missing `D3_API_KEY_MAINNET` / `UNSTOPPABLE_DOMAINS_API_KEY` locally; both are injected in CI). So the runtime bump itself introduces nothing new.
