### PR TITLE
fix(errors): split isRoutineMiss into a shared transport-failure check

### DIFF
--- a/src/helpers/errors.ts
+++ b/src/helpers/errors.ts
@@ -57,3 +57,17 @@ export function isSilencedError(error: any, additionalMessages?: string[]): bool
     )
   );
 }
+
+const TRANSPORT_FAILURE_CODES = [
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'CERT_HAS_EXPIRED',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'DEPTH_ZERO_SELF_SIGNED_CERT'
+];
+
+export function isTransportFailure(error: any): boolean {
+  return TRANSPORT_FAILURE_CODES.includes(error?.cause?.code ?? error?.code);
+}

--- a/src/resolvers/address/ens.ts
+++ b/src/resolvers/address/ens.ts
@@ -4,7 +4,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import constants from '../../constants.json';
 import { isEvmAddress } from '../../helpers/address';
-import { isSilencedError } from '../../helpers/errors';
+import { isSilencedError, isTransportFailure } from '../../helpers/errors';
 import { graphQlCall } from '../../helpers/graphql';
 import { getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
@@ -93,10 +93,16 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
     );
 
     for (const item of items) {
-      results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
+      try {
+        results[item.name] = item.resolvedAddress ? getAddress(item.resolvedAddress.id) : '';
+      } catch (err) {
+        if (!isSilencedError(err)) {
+          capture(err, { input: { handles: normalizedHandles } });
+        }
+      }
     }
   } catch (err) {
-    if (!isSilencedError(err)) {
+    if (!isSilencedError(err) && !isTransportFailure(err)) {
       capture(err, { input: { handles: normalizedHandles } });
     }
   }
@@ -117,7 +123,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
       }
     });
   } catch (err) {
-    if (!isSilencedError(err)) {
+    if (!isSilencedError(err) && !isTransportFailure(err)) {
       capture(err, { input: { handles: normalizedHandles } });
     }
   }

--- a/src/resolvers/address/index.ts
+++ b/src/resolvers/address/index.ts
@@ -15,7 +15,7 @@ import {
   normalizeHandles,
   withoutEmptyAddress
 } from '../../helpers/address';
-import { isSilencedError } from '../../helpers/errors';
+import { isSilencedError, isTransportFailure } from '../../helpers/errors';
 import { timeAddressResolverResponse as timeResponse } from '../../helpers/metrics';
 import { withoutEmptyValues } from '../../helpers/object';
 import { Address, Handle } from '../../helpers/types';
@@ -69,7 +69,7 @@ async function _call(fnName: string, input: string[], maxInputLength: number) {
               result = await r[fnName](_input);
               status = 1;
             } catch (err) {
-              if (!isSilencedError(err, r.MUTED_ERRORS)) {
+              if (!isSilencedError(err, r.MUTED_ERRORS) && !isTransportFailure(err)) {
                 // A top-level `input` beside `tags` is dropped rather than wrapped.
                 capture(err, {
                   tags: { provider: r.NAME },

--- a/src/resolvers/address/unstoppableDomains.ts
+++ b/src/resolvers/address/unstoppableDomains.ts
@@ -2,7 +2,7 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import snapshot from '@snapshot-labs/snapshot.js';
 import Resolution, { NamingServiceName } from '@unstoppabledomains/resolution';
 import { isEvmAddress } from '../../helpers/address';
-import { isSilencedError } from '../../helpers/errors';
+import { isSilencedError, isTransportFailure } from '../../helpers/errors';
 import { withoutEmptyValues } from '../../helpers/object';
 import { batchContractCalls, getProvider } from '../../helpers/provider';
 import { Address, Handle } from '../../helpers/types';
@@ -57,7 +57,7 @@ export async function resolveNames(handles: Handle[]): Promise<Record<Handle, Ad
           blockTag: 'latest'
         });
       } catch (err) {
-        if (!isSilencedError(err)) {
+        if (!isSilencedError(err) && !isTransportFailure(err)) {
           capture(err, { input: { handles: normalizedHandles } });
         }
         return;

--- a/src/resolvers/image/index.ts
+++ b/src/resolvers/image/index.ts
@@ -17,7 +17,7 @@ import { resolveAvatar as sxResolveAvatar, resolveCover as sxResolveCover } from
 import starknet from './starknet';
 import trustwallet from './trustwallet';
 import { max } from '../../constants.json';
-import { isSilencedError } from '../../helpers/errors';
+import { isSilencedError, isTransportFailure } from '../../helpers/errors';
 import { resize } from '../../helpers/image';
 
 type ResolverFn = (...args: any[]) => Promise<Buffer | false>;
@@ -30,16 +30,6 @@ type Resolver = {
   mutedErrors?: string[];
 };
 
-const ROUTINE_NETWORK_ERROR_CODES = [
-  'ENOTFOUND',
-  'EAI_AGAIN',
-  'ECONNREFUSED',
-  'ERR_TLS_CERT_ALTNAME_INVALID',
-  'CERT_HAS_EXPIRED',
-  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
-  'DEPTH_ZERO_SELF_SIGNED_CERT'
-];
-
 // 401/402/403 are excluded from the routine band: withFailureContract wraps a
 // resolver's own authenticated API calls (Neynar, Snapshot Hub, CoinGecko Pro)
 // as well as its third-party avatar download, and those statuses are how a
@@ -49,11 +39,10 @@ const AUTH_STATUS_CODES = [401, 402, 403];
 
 function isRoutineMiss(error: any): boolean {
   const status = Number(error?.status ?? error?.response?.status);
-  const code = error?.cause?.code ?? error?.code;
 
   return (
     (status >= 400 && status < 500 && !AUTH_STATUS_CODES.includes(status)) ||
-    ROUTINE_NETWORK_ERROR_CODES.includes(code) ||
+    isTransportFailure(error) ||
     error?.code === 'INVALID_ARGUMENT'
   );
 }

--- a/src/resolvers/lookupDomains/index.ts
+++ b/src/resolvers/lookupDomains/index.ts
@@ -4,7 +4,7 @@ import * as ens from './ens';
 import * as ensV2 from './ensV2';
 import * as shibarium from './shibarium';
 import * as unstoppableDomains from './unstoppableDomains';
-import { isSilencedError } from '../../helpers/errors';
+import { isSilencedError, isTransportFailure } from '../../helpers/errors';
 import { timeLookupDomainsResponse as timeResponse } from '../../helpers/metrics';
 import { Address, Handle } from '../../helpers/types';
 
@@ -43,7 +43,7 @@ export default async function lookupDomains(
               status = 1;
               return result;
             } catch (err) {
-              if (!isSilencedError(err)) {
+              if (!isSilencedError(err) && !isTransportFailure(err)) {
                 capture(err, {
                   tags: { provider: NAME },
                   contexts: { input: { address, chainId } }

--- a/test/integration/resolvers/lookupDomains/shibarium.test.ts
+++ b/test/integration/resolvers/lookupDomains/shibarium.test.ts
@@ -189,6 +189,17 @@ describe('lookupDomains/shibarium through the shared handler', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it('does not report a host that no longer resolves', async () => {
+    mockedFetch.mockRejectedValue(
+      Object.assign(new Error('getaddrinfo ENOTFOUND api-public.interstellar.xyz'), {
+        code: 'ENOTFOUND'
+      })
+    );
+
+    await expect(lookupDomainsThroughIndex(ADDRESS, CHAIN_ID)).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
   it('drops the pages already collected when a later page fails', async () => {
     mockedFetch
       .mockResolvedValueOnce(httpResponse(200, 'OK', page(PAGE_SIZE)))

--- a/test/unit/helpers/errors.test.ts
+++ b/test/unit/helpers/errors.test.ts
@@ -1,4 +1,4 @@
-import { isSilencedError } from '../../../src/helpers/errors';
+import { isSilencedError, isTransportFailure } from '../../../src/helpers/errors';
 
 describe('isSilencedError', () => {
   it.each([500, 502, 503, 504, 521])('silences an RPC outage with status %s', status => {
@@ -35,5 +35,36 @@ describe('isSilencedError', () => {
 
   it('does not silence unrelated errors', () => {
     expect(isSilencedError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('isTransportFailure', () => {
+  it.each(['ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED'])('treats a %s errno as one', code => {
+    expect(
+      isTransportFailure(Object.assign(new TypeError('fetch failed'), { cause: { code } }))
+    ).toBe(true);
+  });
+
+  it.each([
+    'ERR_TLS_CERT_ALTNAME_INVALID',
+    'CERT_HAS_EXPIRED',
+    'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    'DEPTH_ZERO_SELF_SIGNED_CERT'
+  ])('treats a %s TLS failure as one', code => {
+    expect(
+      isTransportFailure(Object.assign(new TypeError('fetch failed'), { cause: { code } }))
+    ).toBe(true);
+  });
+
+  it('does not treat a plain upstream 404 as one', () => {
+    expect(isTransportFailure({ status: 404 })).toBe(false);
+  });
+
+  it('does not treat an invalid-argument rejection as one', () => {
+    expect(isTransportFailure({ code: 'INVALID_ARGUMENT' })).toBe(false);
+  });
+
+  it('does not treat an unrelated error as one', () => {
+    expect(isTransportFailure(new Error('boom'))).toBe(false);
   });
 });

--- a/test/unit/resolvers/address.test.ts
+++ b/test/unit/resolvers/address.test.ts
@@ -93,6 +93,33 @@ describe('address resolvers - resolver failures', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      'a host that no longer resolves',
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'ENOTFOUND' } })
+    ],
+    [
+      'a TLS failure',
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'CERT_HAS_EXPIRED' } })
+    ]
+  ] as const)('does not capture a transport failure (%s)', async (_label, error) => {
+    jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('still reports a plain upstream 4xx from a fixed endpoint', async () => {
+    const error = Object.assign(new Error('not found'), { status: 404 });
+    jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);
+
+    await expect(lookupAddresses([ADDRESS])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Ens' },
+      contexts: { input: { lookupAddresses: [ADDRESS] } }
+    });
+  });
+
   it('applies MUTED_ERRORS only to the resolver exporting it', async () => {
     const error = new Error(LENS_503);
     jest.spyOn(ens, 'lookupAddresses').mockRejectedValue(error);

--- a/test/unit/resolvers/address/ens.test.ts
+++ b/test/unit/resolvers/address/ens.test.ts
@@ -1,4 +1,5 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
+import { getProvider } from '../../../../src/helpers/provider';
 import { resolveNames } from '../../../../src/resolvers/address/ens';
 import { jsonResponse, mockGlobalFetch } from '../../../helpers/fetch';
 
@@ -16,11 +17,13 @@ jest.mock('../../../../src/helpers/provider', () => ({
 
 const mockedFetch = mockGlobalFetch();
 
+const providerInstanceHeldByEns = (getProvider as jest.Mock).mock.results[0].value;
+
 const HANDLE = 'test.eth';
 const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
 
-function respondWith(body: any) {
-  mockedFetch.mockResolvedValue(jsonResponse(body));
+function respondWith(body: any, status = 200) {
+  mockedFetch.mockResolvedValue(jsonResponse(body, status));
 }
 
 describe('resolvers/address/ens - resolveNames', () => {
@@ -42,5 +45,44 @@ describe('resolvers/address/ens - resolveNames', () => {
 
     await expect(resolveNames([HANDLE])).resolves.toEqual({ [HANDLE]: ADDRESS });
     expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not report a subgraph host that no longer resolves', async () => {
+    mockedFetch.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'ENOTFOUND' } })
+    );
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('still reports a subgraph host answering with a 4xx', async () => {
+    respondWith({}, 404);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ status: 404 }), {
+      input: { handles: [HANDLE] }
+    });
+  });
+
+  it('still reports a malformed address returned by the subgraph itself', async () => {
+    respondWith({
+      data: { domains: [{ name: HANDLE, resolvedAddress: { id: 'not-a-valid-address' } }] }
+    });
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_ARGUMENT' }), {
+      input: { handles: [HANDLE] }
+    });
+  });
+
+  it('still reports a malformed address returned by the provider fallback', async () => {
+    respondWith({ data: { domains: [] } });
+    providerInstanceHeldByEns.resolveName.mockResolvedValueOnce('not-a-valid-address');
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_ARGUMENT' }), {
+      input: { handles: [HANDLE] }
+    });
   });
 });

--- a/test/unit/resolvers/address/unstoppableDomains.test.ts
+++ b/test/unit/resolvers/address/unstoppableDomains.test.ts
@@ -1,0 +1,55 @@
+import { capture } from '@snapshot-labs/snapshot-sentry';
+import snapshot from '@snapshot-labs/snapshot.js';
+import { resolveNames } from '../../../../src/resolvers/address/unstoppableDomains';
+
+jest.mock('@snapshot-labs/snapshot-sentry', () => ({
+  capture: jest.fn()
+}));
+
+const HANDLE = 'test.crypto';
+const ADDRESS = '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('resolvers/address/unstoppableDomains - resolveNames', () => {
+  it('reports a resolver failure', async () => {
+    const error = new Error('boom');
+    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(error, { input: { handles: [HANDLE] } });
+  });
+
+  it.each([
+    [
+      'a host that no longer resolves',
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'ENOTFOUND' } })
+    ],
+    [
+      'a TLS failure',
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'CERT_HAS_EXPIRED' } })
+    ]
+  ] as const)('does not capture a transport failure (%s)', async (_label, error) => {
+    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('still reports a plain upstream 4xx from the fixed contract endpoint', async () => {
+    const error = Object.assign(new Error('not found'), { status: 404 });
+    jest.spyOn(snapshot.utils, 'call').mockRejectedValue(error);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({});
+    expect(capture).toHaveBeenCalledWith(error, { input: { handles: [HANDLE] } });
+  });
+
+  it('resolves successfully and reports nothing', async () => {
+    jest.spyOn(snapshot.utils, 'call').mockResolvedValue(ADDRESS);
+
+    await expect(resolveNames([HANDLE])).resolves.toEqual({ [HANDLE]: ADDRESS });
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/resolvers/lookupDomains.test.ts
+++ b/test/unit/resolvers/lookupDomains.test.ts
@@ -154,6 +154,33 @@ describe('lookupDomains - error reporting', () => {
     expect(capture).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      'a host that no longer resolves',
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'ENOTFOUND' } })
+    ],
+    [
+      'a TLS failure',
+      Object.assign(new TypeError('fetch failed'), { cause: { code: 'CERT_HAS_EXPIRED' } })
+    ]
+  ] as const)('does not capture a transport failure (%s)', async (_label, error) => {
+    (ens as jest.Mock).mockRejectedValue(error);
+
+    await expect(lookupDomains(VALID_ADDRESS, '1')).resolves.toEqual([]);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('still reports a plain upstream 4xx from a fixed endpoint', async () => {
+    const error = Object.assign(new Error('not found'), { status: 404 });
+    (ens as jest.Mock).mockRejectedValue(error);
+
+    await expect(lookupDomains(VALID_ADDRESS, '1')).resolves.toEqual([]);
+    expect(capture).toHaveBeenCalledWith(error, {
+      tags: { provider: 'Ens' },
+      contexts: { input: { address: VALID_ADDRESS, chainId: '1' } }
+    });
+  });
+
   it('names the failing provider, each with its own name', async () => {
     (ens as jest.Mock).mockRejectedValue(new Error('boom'));
     (shibarium as jest.Mock).mockRejectedValue(new Error('boom'));


### PR DESCRIPTION
## Summary

wa0x6e's review on #626 pointed out that sharing the full `isRoutineMiss` predicate (DNS/TLS codes, the 4xx band, and `INVALID_ARGUMENT`) across the image and address/lookupDomains resolver families doesn't transfer cleanly: image resolvers fetch a per-input, often user-controlled URL where a 404 is an expected miss, while the address/lookupDomains resolvers all hit a fixed endpoint (ENS subgraph, api.unstoppabledomains.com, D3, an RPC provider) that answers a miss with an empty result rather than an HTTP error, so any 4xx those emit means our own endpoint is broken.

This splits the classifier along that line:
- `isTransportFailure` (`src/helpers/errors.ts`) carries only the DNS/TLS error codes and is shared at all five non-image capture sites (`address/index.ts`, `address/ens.ts` x2, `address/unstoppableDomains.ts`, `lookupDomains/index.ts`).
- The 4xx band and `INVALID_ARGUMENT` stay local to `resolvers/image/index.ts`'s own `isRoutineMiss`, where they were already family-specific policy.

As a side effect, `address/ens.ts`'s provider-fallback catch no longer mutes a malformed address returned by `provider.resolveName` under the old shared predicate's `INVALID_ARGUMENT` clause — that corruption now reports instead of being silently swallowed.

Addresses the review on #626. Closes #617.